### PR TITLE
Increase build memory to allow react build to finish

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -76,7 +76,7 @@ objects:
     postCommit: {}
     resources:
       limits:
-        memory: 1Gi
+        memory: 1.5Gi
     source:
       git:
         uri: ${SOURCE_REPOSITORY_URL}


### PR DESCRIPTION
1Gi of memory request doesn't seem to be enough for the react build to pass

```
$ react-scripts build
Creating an optimized production build...
The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
error Command failed with exit code 1.
```

1.5Gi seems to work