### PR TITLE
[WIP] Add oauth flow to the webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,30 @@
 
 This web application provides the front door into the Inetgreatly initiative. It houses the various Tutorials (aka Steel Threads) as well as a dashboard of installed products/services.
 
-# deployment
+# local development
+
+```
+yarn install;yarn start:dev
+```
+
+This will install dependencies & start the server.
+Mock data will be used for any calls to OpenShift.
+
+To configure local development with a running OpenShift cluster, do the following.
+
+Create an OAuthClient:
+
+```
+yarn run oauthclient
+```
+
+Start the server, specifying the OpenShift host (This will disable mock data).
+
+```
+OPENSHIFT_HOST=localhost:8443 yarn start:dev
+```
+
+# remote development
 
 ```
 oc new-project integreatly-web-app

--- a/oauthclient.yml
+++ b/oauthclient.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+grantMethod: auto
+kind: OAuthClient
+metadata:
+  name: tutorial-web-app
+redirectURIs:
+- http://localhost:3006

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "watch:css": "yarn build:css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/styles/index.scss -o src/styles/.css --watch --recursive",
     "build:js": "react-scripts build",
     "start": "node server.js",
-    "start:dev": "OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" REDIRECT_HOST=http://localhost:3006/oauth/callback OPENSHIFT_HOST=localhost:8443 run-p -l watch:css start:local api:dev start:server",
+    "start:dev": "OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" REDIRECT_HOST=http://localhost:3006/oauth/callback run-p -l watch:css start:local api:dev start:server",
     "start:local": "react-scripts start",
     "start:server": "nodemon server.js",
     "commit:hash": "echo REACT_APP_UI_COMMIT_HASH=$(git rev-list -1 --all) > .env",
@@ -72,7 +72,8 @@
     "lint:locales": "node scripts/syncLocales --check",
     "docker:build": "docker build -t integreatly-web-app .",
     "preinstall": "node -v; npm -v;",
-    "postbuild": "[ \"$BUILD_ENV\" != OCP ] && exit 0; yarn install --production --ignore-scripts --prefer-offline;"
+    "postbuild": "[ \"$BUILD_ENV\" != OCP ] && exit 0; yarn install --production --ignore-scripts --prefer-offline;",
+    "oauthclient": "oc --server https://localhost:8443 get oauthclient/tutorial-web-app || oc --server https://localhost:8443 create -f ./oauthclient.yml"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/server.js
+++ b/server.js
@@ -5,14 +5,21 @@ const port = process.env.PORT || 5001
 
 // Dynamic configuration for openshift API calls
 app.get('/config.js', (req, res) => {
-  res.send(`window.OPENSHIFT_CONFIG = {
-    clientId: '${process.env.OPENSHIFT_OAUTHCLIENT_ID}',
-    accessTokenUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/token',
-    authorizationUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/authorize',
-    redirectUri: '${process.env.REDIRECT_HOST}',
-    scopes: ['user:full'],
-    masterUri: 'https://${process.env.OPENSHIFT_HOST}'
-  };`)
+  if (!process.env.OPENSHIFT_HOST) {
+    console.warn('OPENSHIFT_HOST not set. Using mock data');
+    res.send(`window.OPENSHIFT_CONFIG = {
+      mockData: true
+    };`);
+  } else {
+    res.send(`window.OPENSHIFT_CONFIG = {
+      clientId: '${process.env.OPENSHIFT_OAUTHCLIENT_ID}',
+      accessTokenUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/token',
+      authorizationUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/authorize',
+      redirectUri: '${process.env.REDIRECT_HOST}',
+      scopes: ['user:full'],
+      masterUri: 'https://${process.env.OPENSHIFT_HOST}'
+    };`)
+  }
 })
 
 if (process.env.NODE_ENV === 'production') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { HashRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import 'patternfly/dist/css/rcue.css';
 import 'patternfly/dist/css/rcue-additions.css';
 import './styles/.css/index.css';

--- a/src/pages/oauth/oauth.js
+++ b/src/pages/oauth/oauth.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import OpenShiftResourceParser from "openshift-resource-parser";
+
+class OAuthPage extends React.Component {
+  componentDidMount() {
+    const resourceParser = new OpenShiftResourceParser(window.OPENSHIFT_CONFIG);
+
+    resourceParser.finishOAuth().then(function (data) {
+      const url = new URL(data.then);
+      this.props.history.push(url.pathname);
+    }.bind(this));
+  }
+
+  render() {
+    return <div>Authenticating...</div>;
+  }
+}
+
+export { OAuthPage as default };

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -6,9 +6,20 @@ import { noop, Button, Grid, Icon, ListView } from 'patternfly-react';
 import { connect, reduxActions } from '../../redux';
 import Breadcrumb from '../../components/breadcrumb/breadcrumb';
 import AsciiDocTemplate from '../../components/asciiDocTemplate/asciiDocTemplate';
+import OpenShiftResourceParser from "openshift-resource-parser";
 
 class TutorialPage extends React.Component {
   componentDidMount() {
+    const resourceParser = new OpenShiftResourceParser(window.OPENSHIFT_CONFIG);
+
+    resourceParser.listProvisionedMWServices("evals")
+      .then(provisionedServiceList => resourceParser.getProvisionedMWService("evals", provisionedServiceList[0].name))
+      .then(provisionedService => {
+        console.log(provisionedService);
+      })
+      .catch(err => console.error(err));
+
+
     this.loadThread();
   }
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import LandingPage from './pages/landing/landingPage';
 // import StaticLandingPage from './pages/staticLanding/staticLandingPage';
 import TutorialPage from './pages/tutorial/tutorial';
 import TaskPage from './pages/tutorial/task/task';
+import OAuthPage from './pages/oauth/oauth';
 
 /**
  * Return the application base directory.
@@ -43,6 +44,13 @@ const routes = () => [
     to: '/tutorial/:id/task/:task/:step?',
     component: TaskPage,
     exact: false
+  },
+  {
+    iconClass: 'pficon pficon-orders',
+    title: 'Auth',
+    to: '/oauth/callback',
+    component: OAuthPage,
+    exact: true
   }
 ];
 


### PR DESCRIPTION
This adds a new route `/oauth/callback` to handle the oauth flow
redirect.
A simple openshift API call is included in the tutorial page to
retrieve service instance details.
This call will trigger an OAuth flow if the user isn't logged in.

TODO

* [x] Rebase after https://github.com/integr8ly/tutorial-web-app/pull/6 is merged
* [ ] Update the version of the openshift-resource-parser lib after https://github.com/integr8ly/openshift-resource-parser/pull/1 is merged & published
* [x] Update README steps for local dev for setting up OAuthClient in OpenShift
* [x] Verify the default config.js content works for local development (using mock data)
* [x] Verify local development can be configured to work with an openshift cluster (using real data for integration testing)