### PR TITLE
OAuth login flow

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,11 +35,17 @@ app.get('/config.js', (req, res) => {
       }
     };`);
   } else {
+    let redirectHost;
+    if (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-host']) {
+      redirectHost = `${req.headers['x-forwarded-proto']}://${req.headers['x-forwarded-host']}`
+    } else {
+      redirectHost = `https://${req.headers.host}`
+    }
     res.send(`window.OPENSHIFT_CONFIG = {
       clientId: '${process.env.OPENSHIFT_OAUTHCLIENT_ID}',
       accessTokenUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/token',
       authorizationUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/authorize',
-      redirectUri: 'https://${req.headers.host}/oauth/callback',
+      redirectUri: '${redirectHost}/oauth/callback',
       scopes: ['user:full'],
       masterUri: 'https://${process.env.OPENSHIFT_HOST}'
     };`)

--- a/src/components/openshiftResourceParser/clients/provisioned-service-client.js
+++ b/src/components/openshiftResourceParser/clients/provisioned-service-client.js
@@ -52,14 +52,21 @@ export default class ProvisionedServiceClient {
       this.listClusterServiceClasses(this.openshiftURL, authToken),
       this.listServiceInstances(this.openshiftURL, authToken, namespace)
     ]).then(([clusterServiceClasses, serviceInstances]) => {
+      // TODO: filter service instances by a whitelist
+      //       so only services involved in walkthroughs
+      //       are shown
       if (!serviceInstances || serviceInstances.length === 0) {
         return [];
       }
       return serviceInstances.map(serviceInstance => {
-        const displayName = clusterServiceClasses.find(
+        const clusterServiceClass = clusterServiceClasses.find(
           serviceClass => serviceClass.name === serviceInstance.clusterServiceClassId
         );
-        return new ProvisionedService(serviceInstance.name, serviceInstance.consoleURL, displayName);
+        return new ProvisionedService(
+          serviceInstance.clusterServiceClassExternalName,
+          serviceInstance.consoleURL,
+          clusterServiceClass
+        );
       });
     });
   }

--- a/src/components/openshiftResourceParser/index.js
+++ b/src/components/openshiftResourceParser/index.js
@@ -21,7 +21,7 @@ export default class OpenShiftResourceParser {
   constructor(config) {
     this.config = config;
     if (!this.config.mockData) {
-      this.provisionedServiceClient = new ProvisionedServiceClient(this.config, this.startOAuth);
+      this.provisionedServiceClient = new ProvisionedServiceClient(this.config.masterUri, this.startOAuth.bind(this));
     }
   }
 

--- a/src/components/openshiftResourceParser/types/cluster-service-class.js
+++ b/src/components/openshiftResourceParser/types/cluster-service-class.js
@@ -3,10 +3,12 @@ export default class ClusterServiceClass {
    * Construct a new {@link ClusterServiceClass}
    * @param {string} name The identifying name of the cluster service class
    * @param {string} displayName The human-friendly name of the cluster service class
+   * @param {string} description The class description
    */
-  constructor(name, displayName) {
+  constructor(name, displayName, description) {
     this.name = name;
     this.displayName = displayName;
+    this.description = description;
   }
 
   /**
@@ -22,7 +24,8 @@ export default class ClusterServiceClass {
       jsonData.metadata.name &&
       jsonData.spec &&
       jsonData.spec.externalMetadata &&
-      jsonData.spec.externalMetadata.displayName
+      jsonData.spec.externalMetadata.displayName &&
+      jsonData.spec.description
     );
   }
 
@@ -32,6 +35,10 @@ export default class ClusterServiceClass {
    * @returns {ClusterServiceClass}
    */
   static fromJSON(jsonData) {
-    return new ClusterServiceClass(jsonData.metadata.name, jsonData.spec.externalMetadata.displayName);
+    return new ClusterServiceClass(
+      jsonData.metadata.name,
+      jsonData.spec.externalMetadata.displayName,
+      jsonData.spec.description
+    );
   }
 }

--- a/src/components/openshiftResourceParser/types/provisioned-service.js
+++ b/src/components/openshiftResourceParser/types/provisioned-service.js
@@ -2,13 +2,17 @@ export default class ProvisionedService {
   /**
    * Construct a new {@link ProvisionedService}.
    * @constructor
-   * @param {string} name The name of the service
-   * @param {string} consoleURL The dashboard URL of the service
+   * @param {string} name The unique name of the service
+   * @param {string} appLink The dashboard URL of the service
    * @param {ClusterServiceClass} service The cluster service class
    */
-  constructor(name, consoleURL, service) {
+  constructor(name, appLink, service) {
     this.name = name;
-    this.consoleURL = consoleURL;
+    this.appLink = appLink;
     this.service = service;
+
+    // TODO: Lookup these details based on the unique service class name
+    this.appName = name;
+    this.appDescription = name;
   }
 }

--- a/src/components/openshiftResourceParser/types/service-instance.js
+++ b/src/components/openshiftResourceParser/types/service-instance.js
@@ -1,15 +1,17 @@
 export default class ServiceInstance {
-  constructor(name, consoleURL, clusterServiceClassId) {
+  constructor(name, consoleURL, clusterServiceClassId, clusterServiceClassExternalName) {
     this.name = name;
     this.consoleURL = consoleURL;
     this.clusterServiceClassId = clusterServiceClassId;
+    this.clusterServiceClassExternalName = clusterServiceClassExternalName;
   }
 
   static fromJSON(jsonData) {
     const { name } = jsonData.metadata;
     const consoleURL = jsonData.status.dashboardURL;
+    const { clusterServiceClassExternalName } = jsonData.spec;
     const clusterServiceClassId = jsonData.spec.clusterServiceClassRef.name;
 
-    return new ServiceInstance(name, consoleURL, clusterServiceClassId);
+    return new ServiceInstance(name, consoleURL, clusterServiceClassId, clusterServiceClassExternalName);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { HashRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import 'patternfly/dist/css/patternfly.css';
 import 'patternfly/dist/css/patternfly-additions.css';
 import './styles/.css/index.css';

--- a/src/pages/oauth/oauth.js
+++ b/src/pages/oauth/oauth.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import OpenShiftResourceParser from '../../components/openshiftResourceParser';
+
+class OAuthPage extends React.Component {
+  componentDidMount() {
+    const resourceParser = new OpenShiftResourceParser(window.OPENSHIFT_CONFIG);
+
+    resourceParser.finishOAuth().then(data => {
+      const url = new URL(data.then);
+      this.props.history.push(url.pathname);
+    });
+  }
+
+  render() {
+    return <div>Authenticating...</div>;
+  }
+}
+
+OAuthPage.propTypes = {
+  history: PropTypes.object.isRequired
+};
+
+export { OAuthPage as default };

--- a/src/router/__tests__/__snapshots__/router.test.js.snap
+++ b/src/router/__tests__/__snapshots__/router.test.js.snap
@@ -29,6 +29,12 @@ exports[`Router Component should render a basic component 1`] = `
       key="/tutorial/:id/task/:task/:step?"
       path="/tutorial/:id/task/:task/:step?"
     />
+    <Route
+      component={[Function]}
+      exact={true}
+      key="/oauth/callback"
+      path="/oauth/callback"
+    />
     <Redirect
       from="/"
       push={false}

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import LandingPage from './pages/landing/landingPage';
 // import StaticLandingPage from './pages/staticLanding/staticLandingPage';
 import TutorialPage from './pages/tutorial/tutorial';
 import TaskPage from './pages/tutorial/task/task';
+import OAuthPage from './pages/oauth/oauth';
 
 /**
  * Return the application base directory.
@@ -43,6 +44,13 @@ const routes = () => [
     to: '/tutorial/:id/task/:task/:step?',
     component: TaskPage,
     exact: false
+  },
+  {
+    iconClass: 'pficon pficon-orders',
+    title: 'Auth',
+    to: '/oauth/callback',
+    component: OAuthPage,
+    exact: true
   }
 ];
 


### PR DESCRIPTION
Add an OAuth callback route for after the OAuth login flow finishes.

The OAuth flow is triggered automatically as soon as the
openshiftResourceParser component is used, and there isn't an access
token yet.
If a token already exists, the login flow is skipped and the requested
OpenShift API call is made.

After the login flow completes, the browser is redirected to the
original page they were on when the login flow was started.