### PR TITLE
convert code snippets to copy paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "start": "node server.js",
     "start:dev": "FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" run-p -l watch:css start:local start:server",
     "start:local": "react-scripts start",
-    "start:server": "nodemon server.js",
+    "start:server": "nodemon --watch server.js --exec 'node server.js'",
     "commit:hash": "echo REACT_APP_UI_COMMIT_HASH=$(git rev-list -1 --all) > .env",
     "build": "yarn commit:hash && yarn build:css && yarn build:js && yarn postbuild",
     "test": "yarn lint && react-scripts test --env=jsdom --coverage",

--- a/server.js
+++ b/server.js
@@ -1,7 +1,8 @@
-const express = require('express')
-const path = require('path')
-const app = express()
-const port = process.env.PORT || 5001
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 5001;
 
 // Dynamic configuration for openshift API calls
 app.get('/config.js', (req, res) => {
@@ -70,9 +71,9 @@ app.get('/config.js', (req, res) => {
   } else {
     let redirectHost;
     if (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-host']) {
-      redirectHost = `${req.headers['x-forwarded-proto']}://${req.headers['x-forwarded-host']}`
+      redirectHost = `${req.headers['x-forwarded-proto']}://${req.headers['x-forwarded-host']}`;
     } else {
-      redirectHost = `https://${req.headers.host}`
+      redirectHost = `https://${req.headers.host}`;
     }
     res.send(`window.OPENSHIFT_CONFIG = {
       clientId: '${process.env.OPENSHIFT_OAUTHCLIENT_ID}',
@@ -82,17 +83,17 @@ app.get('/config.js', (req, res) => {
       scopes: ['user:full'],
       masterUri: 'https://${process.env.OPENSHIFT_HOST}',
       wssMasterUri: 'wss://${process.env.OPENSHIFT_HOST}'
-    };`)
+    };`);
   }
-})
+});
 
 if (process.env.NODE_ENV === 'production') {
   // Serve any static files
-  app.use(express.static(path.join(__dirname, 'build')))
+  app.use(express.static(path.join(__dirname, 'build')));
   // Handle React routing, return all requests to React app
-  app.get('*', function (req, res) {
-    res.sendFile(path.join(__dirname, 'build', 'index.html'))
-  })
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(__dirname, 'build', 'index.html'));
+  });
 }
 
-app.listen(port, () => console.log(`Listening on port ${port}`))
+app.listen(port, () => console.log(`Listening on port ${port}`));

--- a/src/components/asciiDocTemplate/asciiDocTemplate.js
+++ b/src/components/asciiDocTemplate/asciiDocTemplate.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Asciidoctor from 'asciidoctor.js';
 import { translate } from 'react-i18next';
+import CopyField from '../copyField/copyField';
 
 class AsciiDocTemplate extends React.Component {
   state = { loaded: false, html: null };
@@ -9,6 +11,7 @@ class AsciiDocTemplate extends React.Component {
   constructor(props) {
     super(props);
     this.isUnmounted = false;
+    this.rootDiv = React.createRef();
   }
 
   componentDidMount() {
@@ -30,6 +33,15 @@ class AsciiDocTemplate extends React.Component {
     }
   }
 
+  componentDidUpdate() {
+    if (this.rootDiv.current) {
+      const codeBlocks = this.rootDiv.current.querySelectorAll('pre');
+      codeBlocks.forEach(block => {
+        ReactDOM.render(<CopyField value={block.innerText} multiline={block.clientHeight > 40} />, block.parentNode);
+      });
+    }
+  }
+
   componentWillUnmount() {
     this.isUnmounted = true;
   }
@@ -37,7 +49,7 @@ class AsciiDocTemplate extends React.Component {
   render() {
     const { loaded, html } = this.state;
     if (loaded) {
-      return <div dangerouslySetInnerHTML={{ __html: html }} />;
+      return <div ref={this.rootDiv} dangerouslySetInnerHTML={{ __html: html }} />;
     }
     return null;
   }

--- a/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
+++ b/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CopyField Component should default expanded on multiline and collapse on blur: expanded 1`] = `null`;
+
+exports[`CopyField Component should render a multi-line copy component: multi-line 1`] = `
+<div
+  aria-live="polite"
+  class="integr8ly-copy form-group"
+>
+  <span
+    class="input-group"
+  >
+    <span
+      class="input-group-btn"
+    >
+      <button
+        aria-hidden="true"
+        class="integr8ly-copy-display-button btn btn-default"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="fa fa-angle-down"
+        />
+      </button>
+    </span>
+    <input
+      class="integr8ly-copy-input expanded form-control"
+      id="test"
+      readonly=""
+      type="text"
+      value="{\\"hello\\":\\"world\\"}"
+    />
+    <span
+      class="input-group-btn"
+    >
+      <button
+        aria-label="Copy to Clipboard"
+        class="btn btn-default"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="fa fa-paste"
+        />
+      </button>
+    </span>
+  </span>
+  <textarea
+    aria-hidden="true"
+    class="integr8ly-copy-display"
+    disabled=""
+    rows="5"
+    style="width: 100%;"
+  >
+    {"hello":"world"}
+  </textarea>
+</div>
+`;
+
+exports[`CopyField Component should render a single-line copy component: single-line 1`] = `
+<div
+  aria-live="polite"
+  class="integr8ly-copy form-group"
+>
+  <span
+    class="input-group"
+  >
+    <input
+      class="integr8ly-copy-input false form-control"
+      id="test"
+      readonly=""
+      type="text"
+      value="{\\"hello\\":\\"world\\"}"
+    />
+    <span
+      class="input-group-btn"
+    >
+      <button
+        aria-label="Copy to Clipboard"
+        class="btn btn-default"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="fa fa-paste"
+        />
+      </button>
+    </span>
+  </span>
+</div>
+`;

--- a/src/components/copyField/__tests__/copyField.test.js
+++ b/src/components/copyField/__tests__/copyField.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { CopyField } from '../copyField';
+
+describe('CopyField Component', () => {
+  it('should render a single-line copy component', () => {
+    const props = {
+      id: 'test',
+      value: JSON.stringify({ hello: 'world' })
+    };
+    const component = mount(<CopyField {...props} />);
+
+    expect(component.render()).toMatchSnapshot('single-line');
+  });
+
+  it('should render a multi-line copy component', () => {
+    const props = {
+      id: 'test',
+      multiline: true,
+      value: JSON.stringify({ hello: 'world' })
+    };
+    const component = mount(<CopyField {...props} />);
+
+    expect(component.render()).toMatchSnapshot('multi-line');
+  });
+
+  it('should default expanded on multiline and collapse on blur', () => {
+    const props = {
+      id: 'test',
+      multiline: true,
+      value: JSON.stringify({ hello: 'world' })
+    };
+    const component = mount(<CopyField {...props} />);
+    const componentInstance = component.instance();
+    const mockEvent = { target: { blur: () => {} } };
+
+    componentInstance.onExpand(mockEvent);
+    expect(component.state().expanded).toEqual(false);
+    expect(component.render().find('textarea.integr8ly-copy-display')).toMatchSnapshot('expanded');
+  });
+});

--- a/src/components/copyField/copyField.js
+++ b/src/components/copyField/copyField.js
@@ -1,0 +1,213 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form, Icon, InputGroup, Button, OverlayTrigger, Tooltip as PFTooltip } from 'patternfly-react';
+import { generateId } from '../../common/helpers';
+
+class CopyField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      copied: false,
+      expanded: !!props.multiline,
+      timer: null
+    };
+  }
+
+  onCopy = event => {
+    const { timer } = this.state;
+    const { value } = this.props;
+    const success = this.copyClipboard(value);
+
+    event.target.blur();
+    clearTimeout(timer);
+
+    this.setState(
+      {
+        copied: success
+      },
+      () => this.resetStateTimer()
+    );
+  };
+
+  copyClipboard = text => {
+    let successful;
+
+    try {
+      window.getSelection().removeAllRanges();
+
+      const newTextarea = document.createElement('pre');
+      newTextarea.appendChild(document.createTextNode(text));
+
+      newTextarea.style.position = 'absolute';
+      newTextarea.style.top = '-9999px';
+      newTextarea.style.left = '-9999px';
+
+      const range = document.createRange();
+      window.document.body.appendChild(newTextarea);
+
+      range.selectNode(newTextarea);
+
+      window.getSelection().addRange(range);
+
+      successful = window.document.execCommand('copy');
+
+      window.document.body.removeChild(newTextarea);
+      window.getSelection().removeAllRanges();
+    } catch (e) {
+      successful = false;
+      console.warn('Copy to clipboard failed.', e.message);
+    }
+
+    return successful;
+  };
+
+  onExpand = event => {
+    const { expanded } = this.state;
+    event.target.blur();
+
+    this.setState({
+      expanded: !expanded
+    });
+  };
+
+  onSelect = event => {
+    event.target.select();
+  };
+
+  resetStateTimer() {
+    const { resetTimer } = this.props;
+
+    const timer = setTimeout(
+      () =>
+        this.setState({
+          copied: false
+        }),
+      resetTimer
+    );
+
+    this.setState({ timer });
+  }
+
+  renderButton() {
+    const { copied } = this.state;
+    const { label, labelClicked, labelDescription, labelClickedDescription, tooltipPlacement } = this.props;
+
+    if (labelDescription && labelClickedDescription && label && labelClicked) {
+      const setToolTipId = generateId();
+
+      return (
+        <React.Fragment>
+          {copied && (
+            <OverlayTrigger
+              overlay={<PFTooltip id={setToolTipId}>{labelClickedDescription}</PFTooltip>}
+              placement={tooltipPlacement}
+            >
+              <Button onClick={this.onCopy} aria-label={labelClickedDescription}>
+                {labelClicked}
+              </Button>
+            </OverlayTrigger>
+          )}
+          {!copied && (
+            <OverlayTrigger
+              overlay={<PFTooltip id={setToolTipId}>{labelDescription}</PFTooltip>}
+              placement={tooltipPlacement}
+            >
+              <Button onClick={this.onCopy} aria-label={labelDescription}>
+                {label}
+              </Button>
+            </OverlayTrigger>
+          )}
+        </React.Fragment>
+      );
+    }
+
+    if (label && labelClicked) {
+      return (
+        <Button onClick={this.onCopy} aria-label={labelDescription}>
+          {copied && label}
+          {!copied && labelClicked}
+        </Button>
+      );
+    }
+
+    return (
+      <Button onClick={this.onCopy} aria-label={labelDescription}>
+        {copied && (
+          <React.Fragment>
+            <Icon type="fa" name="check" /> Copied
+          </React.Fragment>
+        )}
+        {!copied && 'Copy'}
+      </Button>
+    );
+  }
+
+  render() {
+    const { expanded } = this.state;
+    const { id, multiline, expandDescription, value } = this.props;
+
+    const setId = id || generateId();
+
+    return (
+      <Form.FormGroup className="integr8ly-copy" controlId={setId} aria-live="polite">
+        <InputGroup>
+          {multiline && (
+            <InputGroup.Button>
+              <Button onClick={this.onExpand} className="integr8ly-copy-display-button" aria-hidden tabIndex={-1}>
+                {!expanded && <Icon type="fa" name="angle-right" />}
+                {expanded && <Icon type="fa" name="angle-down" />}
+              </Button>
+            </InputGroup.Button>
+          )}
+          <Form.FormControl
+            type="text"
+            value={value}
+            className={`integr8ly-copy-input ${expanded && 'expanded'}`}
+            readOnly
+            aria-label={expandDescription}
+            onClick={this.onSelect}
+          />
+          <InputGroup.Button>{this.renderButton()}</InputGroup.Button>
+        </InputGroup>
+        {expanded && (
+          <textarea
+            className="integr8ly-copy-display"
+            rows={5}
+            aria-label={expandDescription}
+            disabled
+            value={value}
+            aria-hidden
+            style={{ width: '100%' }}
+          />
+        )}
+      </Form.FormGroup>
+    );
+  }
+}
+
+CopyField.propTypes = {
+  id: PropTypes.string,
+  expandDescription: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  labelClicked: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  labelDescription: PropTypes.string,
+  labelClickedDescription: PropTypes.string,
+  multiline: PropTypes.bool,
+  resetTimer: PropTypes.number,
+  tooltipPlacement: PropTypes.string,
+  value: PropTypes.string.isRequired
+};
+
+CopyField.defaultProps = {
+  id: null,
+  expandDescription: null,
+  label: <Icon type="fa" name="paste" />,
+  labelClicked: <Icon type="fa" name="check" />,
+  labelDescription: 'Copy to Clipboard',
+  labelClickedDescription: 'Copied',
+  multiline: false,
+  resetTimer: 8000,
+  tooltipPlacement: 'top'
+};
+
+export { CopyField as default, CopyField };

--- a/src/styles/application/_copyField.scss
+++ b/src/styles/application/_copyField.scss
@@ -1,0 +1,29 @@
+.integr8ly-copy {
+  &-input {
+    &.false {
+      width: 200px;
+      @media (min-width: 768px) {
+        width: 400px;
+      }
+      text-overflow: ellipsis;
+    }
+    &.expanded {
+      background-color: $color-pf-black-200;
+    }
+  }
+  &-display {
+    width: 100%;
+    padding: 15px;
+    border: 1px solid $color-pf-black-400;
+    border-top-width: 0;
+    word-wrap: break-word;
+    resize: none;
+  }
+  & > .input-group {
+    display: flex;
+    .input-group-addon,
+    .input-group-btn {
+      width: auto;
+    }
+  }
+}

--- a/src/styles/application/_layout.scss
+++ b/src/styles/application/_layout.scss
@@ -34,6 +34,7 @@
         bottom: 0;
         left: 0;
         width: 75%;
+        z-index: 10;
         @media (max-width: 768px) {
           width: 100%;
         }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -32,3 +32,4 @@ $icon-font-path: '~patternfly/dist/fonts/';
 @import 'application/modules';
 @import 'application/appLauncher';
 @import 'application/installedAppsView';
+@import 'application/copyField';


### PR DESCRIPTION
* add copy/paste component and convert all `pre` code snippet blocks to patternfly [copy to clipboard components](https://www.patternfly.org/pattern-library/forms-and-controls/copy-to-clipboard/) 
* format `server.js` (prettier)
* run nodemon server with `--watch` so it does not reload locally after UI changes

Todo:
- [ ] review styling and multiline aspects w/ design