### PR TITLE
Fix status buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,10 @@ src/**/*.css
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode/settings.json
+.vscode/tasks.json
+.vscode/launch.json
+.vscode/extensions.json
 
 # dependencies
 /node_modules

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -184,10 +184,16 @@ class TaskPage extends React.Component {
                   </div>
                   <div className="integr8ly-module-column--footer">
                     <h6>{t('task.CompleteAndCheck')}</h6>
-                    <div className="integr8ly-module-column--footer_status">
+                    <div
+                      className={
+                        verificationsChecked
+                          ? 'integr8ly-module-column--footer_status-checked'
+                          : 'integr8ly-module-column--footer_status'
+                      }
+                    >
                       {threadTask.steps.map((step, l) => (
                         <React.Fragment key={l}>
-                          <Icon type="fa" name="circle-o" />
+                          <Icon type="fa" name={verificationsChecked ? 'check' : 'circle-o'} />
                           <span className="integr8ly-module-column--footer_status-step">
                             {task}.{l}
                           </span>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -189,8 +189,7 @@ class TaskPage extends React.Component {
                         <React.Fragment key={l}>
                           <Icon type="fa" name="circle-o" />
                           <span className="integr8ly-module-column--footer_status-step">
-                            1.
-                            {l}
+                            {task}.{l}
                           </span>
                         </React.Fragment>
                       ))}

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -52,10 +52,17 @@ class TaskPage extends React.Component {
             step.infoVerifications.forEach(verification => {
               verifications[verification] = false;
             });
+          } else if (step.successVerifications) {
+            step.successVerifications.forEach(verification => {
+              verifications[verification] = false;
+            });
           }
         });
         const hasVerifications = Object.keys(verifications).length > 0;
-        this.setState({ verifications, verificationsChecked: !hasVerifications });
+        this.setState({
+          verifications,
+          verificationsChecked: !hasVerifications
+        });
       });
     }
   }
@@ -132,6 +139,7 @@ class TaskPage extends React.Component {
       // todo: error state
       return null;
     }
+
     if (thread.fulfilled && thread.data) {
       const threadTask = thread.data.tasks[task];
       const totalTasks = thread.data.tasks.length;
@@ -184,19 +192,57 @@ class TaskPage extends React.Component {
                   </div>
                   <div className="integr8ly-module-column--footer">
                     <h6>{t('task.CompleteAndCheck')}</h6>
-                    <div
-                      className={
-                        verificationsChecked
-                          ? 'integr8ly-module-column--footer_status-checked'
-                          : 'integr8ly-module-column--footer_status'
-                      }
-                    >
+                    <div className="integr8ly-module-column--footer_status">
                       {threadTask.steps.map((step, l) => (
                         <React.Fragment key={l}>
-                          <Icon type="fa" name={verificationsChecked ? 'check' : 'circle-o'} />
-                          <span className="integr8ly-module-column--footer_status-step">
-                            {task}.{l}
-                          </span>
+                          {step.infoVerifications &&
+                            step.infoVerifications.map(() => (
+                              <Icon
+                                className={
+                                  step.infoVerifications && verifications[step.infoVerifications[0]]
+                                    ? 'integr8ly-module-column--footer_status-checked'
+                                    : 'integr8ly-module-column--footer_status'
+                                }
+                                type="fa"
+                                name={verifications[step.infoVerifications[0]] ? 'check' : 'circle-o'}
+                              />
+                            ))}
+                          {step.successVerifications &&
+                            step.successVerifications.map(() => (
+                              <Icon
+                                className={
+                                  step.successVerifications && verifications[step.successVerifications[0]]
+                                    ? 'integr8ly-module-column--footer_status-checked'
+                                    : 'integr8ly-module-column--footer_status'
+                                }
+                                type="fa"
+                                name={verifications[step.successVerifications[0]] ? 'check' : 'circle-o'}
+                              />
+                            ))}
+                          {step.infoVerifications &&
+                            step.infoVerifications.map(() => (
+                              <span
+                                className={
+                                  verifications[step.infoVerifications[0]]
+                                    ? 'integr8ly-module-column--footer_status-checked'
+                                    : 'integr8ly-module-column--footer_status-step'
+                                }
+                              >
+                                {task}.{l}
+                              </span>
+                            ))}
+                          {step.successVerifications &&
+                            step.successVerifications.map(() => (
+                              <span
+                                className={
+                                  verifications[step.successVerifications[0]]
+                                    ? 'integr8ly-module-column--footer_status-checked'
+                                    : 'integr8ly-module-column--footer_status-step'
+                                }
+                              >
+                                {task}.{l}
+                              </span>
+                            ))}
                         </React.Fragment>
                       ))}
                     </div>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -220,6 +220,7 @@ class TaskPage extends React.Component {
                           <Button
                             bsStyle={verificationsChecked ? 'primary' : 'default'}
                             onClick={e => this.goToTask(e, task + 1)}
+                            disabled={!verificationsChecked}
                           >
                             {t('task.nextTask')} <Icon type="fa" name="angle-right" style={{ paddingLeft: 5 }} />
                           </Button>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -185,12 +185,15 @@ class TaskPage extends React.Component {
                   <div className="integr8ly-module-column--footer">
                     <h6>{t('task.CompleteAndCheck')}</h6>
                     <div className="integr8ly-module-column--footer_status">
-                      <Icon type="fa" name="circle-o" />
-                      <span className="integr8ly-module-column--footer_status-step">1.1</span>
-                      <Icon type="fa" name="circle-o" />
-                      <span className="integr8ly-module-column--footer_status-step">1.2</span>
-                      <Icon type="fa" name="circle-o" />
-                      <span className="integr8ly-module-column--footer_status-step">1.3</span>
+                      {threadTask.steps.map((step, l) => (
+                        <React.Fragment key={l}>
+                          <Icon type="fa" name="circle-o" />
+                          <span className="integr8ly-module-column--footer_status-step">
+                            1.
+                            {l}
+                          </span>
+                        </React.Fragment>
+                      ))}
                     </div>
                     <div
                       className="btn-group btn-group-justified"

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -66,6 +66,7 @@
 
           &-checked {
             margin-bottom: 10px;
+            padding-right: 15px;
             color: $color-pf-green;
           }
 

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -64,6 +64,11 @@
             padding-right: 5px;
           }
 
+          &-checked {
+            margin-bottom: 10px;
+            color: $color-pf-green;
+          }
+
           &-step {
             margin-right: 15px;
           }


### PR DESCRIPTION
Changes/fixes:

Removed hard-coded radio buttons on bottom of panel, they're now auto-generated and named according to the actual steps.

Next button inactive until all checkboxes are enabled (aka completed), then enabled/color change

Handles info steps as well as success steps (fixed exception err)

Footer 'success' buttons now toggle and are coordinated with checkboxes, so when you enable/disable a checkbox, the icon changes to a checkmark and is colored green/circle icon and is colored blue 

