### PR TITLE
navigation alignment and spacing adjustments

### DIFF
--- a/src/pages/congratulations/congratulations.js
+++ b/src/pages/congratulations/congratulations.js
@@ -20,7 +20,7 @@ class CongratulationsPage extends React.Component {
           <Masthead />
         </Grid.Row>
         <Grid.Row>
-          <Grid.Col xs={12} sm={9} className="integr8ly-module mb-0">
+          <Grid.Col xs={12} sm={9} className="integr8ly-module integr8ly-module-congratulations mb-0">
             <div className="integr8ly-module-column">
               <div className="integr8ly-module-column--status">
                 <span>Walkthrough</span>

--- a/src/styles/application/_overrides.scss
+++ b/src/styles/application/_overrides.scss
@@ -6,3 +6,6 @@
 .navbar-pf-vertical .navbar-brand {
   padding: 15px 20px;
 }
+.navbar-pf-vertical .nav .nav-item-iconic > .dropdown-title {
+  line-height: 1;
+}

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -2,6 +2,9 @@
   &-module {
     margin-top: 40px;
     margin-bottom: 80px;
+    &-congratulations {
+      margin-top: 0;
+    }
     &-column {
       &--status {
         background-color: $color-pf-black-100;


### PR DESCRIPTION
- fix the alignment of the 'developer' text in the navigation bar
- remove the extra `40px` margin at the top of the Congratulations screen