### PR TITLE
fix github link

### DIFF
--- a/docs/modules/ROOT/pages/_partials/task-configuring-github-oauth-app.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-configuring-github-oauth-app.adoc
@@ -21,7 +21,9 @@ Some walkthroughs require access to your GitHub account. A GitHub OAuth app enab
 // end::intro[]
 endif::location[]
 
-. Navigate to https://github.com/settings/developers
+:github-devel-settings-url: https://github.com/settings/developers
+
+. Navigate to link:{github-devel-settings-url}[window="_blank"]
 . Click *New OAuth App*
 . Enter `integration` as the name for the app.
 . Enter the URL you received as part of your onboarding as the  *Homepage URL* and *Authorization callback URL*.

--- a/public/steelthreads/asciidocs/en/task-configuring-github-oauth-app.adoc
+++ b/public/steelthreads/asciidocs/en/task-configuring-github-oauth-app.adoc
@@ -16,7 +16,9 @@
 = Configuring a GitHub OAuth App
 
 
-. Navigate to https://github.com/settings/developers
+:github-devel-settings-url: https://github.com/settings/developers
+
+. Navigate to link:{github-devel-settings-url}[window="_blank"]
 . Click *New OAuth App*
 . Enter `integration` as the name for the app.
 . Enter the URL you received as part of your onboarding as the  *Homepage URL* and *Authorization callback URL*.


### PR DESCRIPTION
Card: https://trello.com/c/bxd7qPVS/251-walkthrough-0-github-link-in-the-tutorial-should-use-targetblank


@jasonmadigan @aidenkeating 