### PR TITLE
Include the TCP and AMQP credentials in the middlwareReducer

### DIFF
--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -16,11 +16,11 @@ const getWalkthroughSpecificAttrs = (walkthrough, middlewareServices, walkthroug
   if (walkthrough.id === WALKTHROUGH_IDS.ONE) {
     const crudAppName = `${walkthrough.namespaceSuffix}-${DEFAULT_SERVICES.CRUD_APP}`;
     const msgAppName = `${walkthrough.namespaceSuffix}-${DEFAULT_SERVICES.MESSAGING_APP}`;
-    const { url, username, password } = middlewareServices.amqCredentials;
+    const { tcpUrl, username, password } = middlewareServices.amqCredentials;
     return {
       'spring-boot-url': getUrlFromWalkthroughServices(walkthroughServices, crudAppName),
       'node-js-url': getUrlFromWalkthroughServices(walkthroughServices, msgAppName),
-      'messaging-broker-url': url,
+      'messaging-broker-url': tcpUrl,
       'messaging-username': username,
       'messaging-password': password
     };

--- a/src/redux/reducers/middlewareReducers.js
+++ b/src/redux/reducers/middlewareReducers.js
@@ -39,11 +39,7 @@ const middlewareReducers = (state = initialState, action) => {
     return Object.assign({}, state, {
       middlewareServices: {
         ...state.middlewareServices,
-        amqCredentials: {
-          username: action.payload.username,
-          password: action.payload.password,
-          url: action.payload.url
-        }
+        amqCredentials: action.payload
       }
     });
   }

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -143,7 +143,12 @@ const handleAMQStatefulSetWatchEvents = (dispatch, namespace, event) => {
 
   dispatch({
     type: FULFILLED_ACTION(middlewareTypes.GET_AMQ_CREDENTIALS),
-    payload: { username: usernameEnv.value, password: passwordEnv.value, url: `broker-amq-tcp.${namespace}.svc` }
+    payload: {
+      username: usernameEnv.value,
+      password: passwordEnv.value,
+      tcpUrl: `broker-amq-tcp.${namespace}.svc`,
+      url: `broker-amq-amqp.${namespace}.svc`
+    }
   });
 };
 


### PR DESCRIPTION
Currently we only store the TCP AMQ broker, however we require the
AMQP broker service url also. This change includes the AMQP and TCP
broker URLs.