### PR TITLE
Tutorial heading

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -37,19 +37,50 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
         sm={8}
         xs={12}
       >
+        <div
+          className="integr8ly-task-dashboard-header"
+        >
+          <h3 />
+          <Button
+            active={false}
+            block={false}
+            bsClass="btn"
+            bsStyle="primary"
+            disabled={false}
+            onClick={[Function]}
+          >
+            tutorial.getStarted
+          </Button>
+        </div>
+        <div
+          className="alert alert-primary"
+          style={
+            Object {
+              "marginTop": 10,
+            }
+          }
+        >
+          <h3
+            className="integr8ly-tutorial-prereqs"
+          >
+            tutorial.prereq
+          </h3>
+          <ul
+            className="fa-ul"
+          >
+            <li
+              key="0"
+            >
+              <i
+                className="fa-li fa fa-check-square-o"
+              />
+              Github account
+            </li>
+          </ul>
+        </div>
         <Component
           attributes={Object {}}
         />
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="primary"
-          disabled={false}
-          onClick={[Function]}
-        >
-          tutorial.getStarted
-        </Button>
       </Col>
       <Col
         bsClass="col"
@@ -182,54 +213,6 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
         <ListView
           className="integr8ly-list-view-pf"
         >
-          <ListViewItem
-            actions={
-              <div
-                className="integr8ly-task-dashboard-estimated-time"
-              >
-                <Icon
-                  name="clock-o"
-                  style={
-                    Object {
-                      "marginRight": 5,
-                    }
-                  }
-                  type="fa"
-                />
-                 
-                <span>
-                  10 
-                  tutorial.minutes
-                </span>
-              </div>
-            }
-            additionalInfo={null}
-            checkboxInput={null}
-            compoundExpand={false}
-            compoundExpanded={false}
-            description={
-              <div>
-                <ul
-                  style={
-                    Object {
-                      "paddingLeft": 20,
-                    }
-                  }
-                >
-                  <li>
-                    Github account
-                  </li>
-                </ul>
-              </div>
-            }
-            heading="0. Completing prerequisites"
-            hideCloseIcon={false}
-            leftContent={null}
-            onCloseCompoundExpand={[Function]}
-            onExpand={[Function]}
-            onExpandClose={[Function]}
-            stacked={true}
-          />
           <ListViewItem
             actions={
               <div

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -50,24 +50,26 @@ class TutorialPage extends React.Component {
             </Grid.Row>
             <Grid.Row>
               <Grid.Col xs={12} sm={8} className="integr8ly-task-container">
-                <div className="alert alert-primary" style={{ marginTop: 10 }}>
-                  <h3 className="integr8ly-tutorial-header">{t('tutorial.prereq')}</h3>
-                  <ul className="fa-ul">
+                <div className="integr8ly-task-dashboard-prereqs">
+                  <h4>{thread.data.title}</h4>
+                  <Button bsStyle="primary" onClick={e => this.getStarted(e, thread.data.id)}>
+                    {t('tutorial.getStarted')}
+                  </Button>
+                  <div className="alert alert-primary" style={{ marginTop: 10 }}>
+                    <h3 className="integr8ly-tutorial-header">{t('tutorial.prereq')}</h3>
+                    <ul className="fa-ul">
                     {thread.data.prerequisites.map((req, i) => (
                       <li key={i}>
                         <i className="fa-li fa fa-check-square-o" />
                         {req}
                       </li>
                     ))}
-                  </ul>
-                </div>
+                    </ul>
+                  </div>
                 <AsciiDocTemplate
                   adoc={thread.data.descriptionDoc}
                   attributes={Object.assign({}, thread.data.attributes)}
                 />
-                <Button bsStyle="primary" onClick={e => this.getStarted(e, thread.data.id)}>
-                  {t('tutorial.getStarted')}
-                </Button>
               </Grid.Col>
               <Grid.Col sm={4} className="integr8ly-task-container">
                 <h4 className="integr8ly-helpful-links-heading">Helpful Links</h4>

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -50,22 +50,23 @@ class TutorialPage extends React.Component {
             </Grid.Row>
             <Grid.Row>
               <Grid.Col xs={12} sm={8} className="integr8ly-task-container">
-                <div className="integr8ly-task-dashboard-prereqs">
-                  <h4>{thread.data.title}</h4>
+                <div className="integr8ly-task-dashboard-header">
+                  <h3>{thread.data.title}</h3>
                   <Button bsStyle="primary" onClick={e => this.getStarted(e, thread.data.id)}>
                     {t('tutorial.getStarted')}
                   </Button>
-                  <div className="alert alert-primary" style={{ marginTop: 10 }}>
-                    <h3 className="integr8ly-tutorial-header">{t('tutorial.prereq')}</h3>
-                    <ul className="fa-ul">
+                </div>
+                <div className="alert alert-primary" style={{ marginTop: 10 }}>
+                  <h3 className="integr8ly-tutorial-prereqs">{t('tutorial.prereq')}</h3>
+                  <ul className="fa-ul">
                     {thread.data.prerequisites.map((req, i) => (
                       <li key={i}>
                         <i className="fa-li fa fa-check-square-o" />
                         {req}
                       </li>
                     ))}
-                    </ul>
-                  </div>
+                  </ul>
+                </div>
                 <AsciiDocTemplate
                   adoc={thread.data.descriptionDoc}
                   attributes={Object.assign({}, thread.data.attributes)}
@@ -125,26 +126,6 @@ class TutorialPage extends React.Component {
                 </h3>
 
                 <ListView className="integr8ly-list-view-pf">
-                  {/* for UX testing only right now */}
-                  <ListView.Item
-                    heading="0. Completing prerequisites"
-                    description={
-                      <div>
-                        <ul style={{ paddingLeft: 20 }}>
-                          {thread.data.prerequisites.map((req, i) => (
-                            <li key={i}>{req}</li>
-                          ))}
-                        </ul>
-                      </div>
-                    }
-                    actions={
-                      <div className="integr8ly-task-dashboard-estimated-time">
-                        <Icon type="fa" name="clock-o" style={{ marginRight: 5 }} />{' '}
-                        <span>10 {t('tutorial.minutes')}</span>
-                      </div>
-                    }
-                    stacked
-                  />
                   {thread.data.tasks.map((task, i) => (
                     <ListView.Item
                       key={i}

--- a/src/styles/application/_taskDashboard.scss
+++ b/src/styles/application/_taskDashboard.scss
@@ -12,14 +12,14 @@
     font-weight: $pf-global--FontWeight--normal;
   }
 
-  &-prereqs {
+  &-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
   }
 }
 
-.integr8ly-tutorial-header {
+.integr8ly-tutorial-prereqs {
   margin-top: 5px;
   font-size: $pf-global--FontSize--xl;
 }

--- a/src/styles/application/_taskDashboard.scss
+++ b/src/styles/application/_taskDashboard.scss
@@ -11,6 +11,12 @@
     color: $pf-color-black-600;
     font-weight: $pf-global--FontWeight--normal;
   }
+
+  &-prereqs {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 }
 
 .integr8ly-tutorial-header {


### PR DESCRIPTION
On the tutorial page:

- show the tutorial title as headline
- move the 'Get Started' button next to the headline
- remove the prereqs from the tasks to complete

Screenshot:

![bildschirmfoto 2018-10-10 um 10 06 04](https://user-images.githubusercontent.com/1851198/46721829-5179a780-cc74-11e8-9326-aac80a56d24f.png)
