### PR TITLE
fix total number of applications shown on installed apps view

### DIFF
--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -91,7 +91,7 @@ class InstalledAppsView extends React.Component {
       <div className="panel panel-default integr8ly-installed-apps-view">
         <div className="panel-heading panel-title integr8ly-installed-apps-view-panel-title">
           <h3>Applications</h3>
-          <div>{this.props.apps.length} applications</div>
+          <div>{appList.props.children.length} applications</div>
         </div>
         <div className="panel-content">{appList}</div>
       </div>


### PR DESCRIPTION
The `Openshift Console` is not counted in the total number of applications listed in the installed apps view on the landing page. Update this to use the created appList instead of using the apps length in props which doesn't contain the `Openshift Console`

![image](https://user-images.githubusercontent.com/9078522/46865952-57f45480-ce17-11e8-991c-0f6fa4acb53c.png)
