### PR TITLE
ga labels and pretty names

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ app.get('/config.js', (req, res) => {
         serviceInstances: [
           {
             spec: {
-              clusterServiceClassExternalName: 'Red Hat OpenShift'
+              clusterServiceClassExternalName: 'enmasse-standard'
             },
             status: {
               dashboardURL:'${process.env.OPENSHIFT_URL}',
@@ -23,7 +23,7 @@ app.get('/config.js', (req, res) => {
           },
           {
             spec: {
-              clusterServiceClassExternalName: 'Red Hat 3scale API Management Platform'
+              clusterServiceClassExternalName: '3scale'
             },
             status: {
               dashboardURL:'${process.env.OPENSHIFT_URL}',
@@ -32,7 +32,7 @@ app.get('/config.js', (req, res) => {
           },
           {
             spec: {
-              clusterServiceClassExternalName: 'Red Hat AMQ'
+              clusterServiceClassExternalName: 'amq-broker-71-persistence'
             },
             status: {
               dashboardURL:'${process.env.OPENSHIFT_URL}',
@@ -41,7 +41,7 @@ app.get('/config.js', (req, res) => {
           },
           {
             spec: {
-              clusterServiceClassExternalName: 'Red Hat Fuse'
+              clusterServiceClassExternalName: 'fuse'
             },
             status: {
               dashboardURL:'${process.env.OPENSHIFT_URL}',
@@ -50,7 +50,7 @@ app.get('/config.js', (req, res) => {
           },
           {
             spec: {
-              clusterServiceClassExternalName: 'Red Hat OpenShift Application Runtimes'
+              clusterServiceClassExternalName: 'launcher'
             },
             status: {
               dashboardURL:'${process.env.OPENSHIFT_URL}',
@@ -59,7 +59,7 @@ app.get('/config.js', (req, res) => {
           },
           {
             spec: {
-              clusterServiceClassExternalName: 'Eclipse Che'
+              clusterServiceClassExternalName: 'che'
             },
             status: {
               dashboardURL:'${process.env.OPENSHIFT_URL}',

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -17,6 +17,16 @@ class InstalledAppsView extends React.Component {
     this.setState({ currentApp: e.target.value });
   }
 
+  static getAppProductDetails(app) {
+    const { serviceDetails, spec } = app;
+    if (serviceDetails) {
+      return serviceDetails;
+    }
+    return {
+      prettyName: spec.clusterServiceClassExternalName
+    };
+  }
+
   static getStatusForApp(app) {
     const provisioningStatus = (
       <div className="state-provisioining">
@@ -70,17 +80,23 @@ class InstalledAppsView extends React.Component {
   }
 
   static createMasterList(apps) {
-    const masterList = apps.map((app, index) => (
-      <li
-        onClick={() => window.open(InstalledAppsView.getRouteForApp(app), '_blank')}
-        key={`${app.spec.clusterServiceClassExternalName}_${index}`}
-        value={index}
-      >
-        <p>{app.spec.clusterServiceClassExternalName}</p>
-        {InstalledAppsView.getStatusForApp(app)}
-        <small />
-      </li>
-    ));
+    const masterList = apps.map((app, index) => {
+      const { prettyName, gaStatus } = InstalledAppsView.getAppProductDetails(app);
+      return (
+        <li
+          onClick={() => window.open(InstalledAppsView.getRouteForApp(app), '_blank')}
+          key={`${app.spec.clusterServiceClassExternalName}_${index}`}
+          value={index}
+        >
+          <div className="integr8ly-installed-apps-view-title">
+            <p>{prettyName}</p>
+            <p className={`gastatus ${gaStatus}`}>{gaStatus}</p>
+          </div>
+          {InstalledAppsView.getStatusForApp(app)}
+          <small />
+        </li>
+      );
+    });
     masterList.push(this.getOpenshiftConsole(masterList.length));
     return <ul className="integr8ly-installed-apps-view-list">{masterList}</ul>;
   }

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -90,7 +90,7 @@ class InstalledAppsView extends React.Component {
         >
           <div className="integr8ly-installed-apps-view-title">
             <p>{prettyName}</p>
-            <p className={`gastatus ${gaStatus}`}>{gaStatus}</p>
+            <span className={`gastatus integr8ly-label-${gaStatus}`}>{gaStatus}</span>
           </div>
           {InstalledAppsView.getStatusForApp(app)}
           <small />

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -17,10 +17,10 @@ class InstalledAppsView extends React.Component {
     this.setState({ currentApp: e.target.value });
   }
 
-  static getAppProductDetails(app) {
-    const { serviceDetails, spec } = app;
-    if (serviceDetails) {
-      return serviceDetails;
+  static getProductDetails(app) {
+    const { productDetails, spec } = app;
+    if (productDetails) {
+      return productDetails;
     }
     return {
       prettyName: spec.clusterServiceClassExternalName
@@ -81,7 +81,7 @@ class InstalledAppsView extends React.Component {
 
   static createMasterList(apps) {
     const masterList = apps.map((app, index) => {
-      const { prettyName, gaStatus } = InstalledAppsView.getAppProductDetails(app);
+      const { prettyName, gaStatus } = InstalledAppsView.getProductDetails(app);
       return (
         <li
           onClick={() => window.open(InstalledAppsView.getRouteForApp(app), '_blank')}

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -1,0 +1,27 @@
+// This file needs to live inside src to be importable
+export default {
+  'enmasse-standard': {
+    prettyName: 'EnMasse',
+    gaStatus: null
+  },
+  'amq-broker-71-persistence': {
+    prettyName: 'Red Hat AMQ',
+    gaStatus: 'preview'
+  },
+  fuse: {
+    prettyName: 'Red Hat Fuse',
+    gaStatus: 'preview'
+  },
+  che: {
+    prettyName: 'Eclipse Che',
+    gaStatus: 'community'
+  },
+  launcher: {
+    prettyName: 'Red Hat Developer Launcher',
+    gaStatus: null
+  },
+  '3scale': {
+    prettyName: 'Red Hat 3scale API Management Platform',
+    gaStatus: null
+  }
+};

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -18,7 +18,7 @@ export default {
   },
   launcher: {
     prettyName: 'Red Hat Developer Launcher',
-    gaStatus: null
+    gaStatus: 'community'
   },
   '3scale': {
     prettyName: 'Red Hat 3scale API Management Platform',

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -31,6 +31,31 @@ const WALKTHROUGH_SERVICES = [
   DEFAULT_SERVICES.THREESCALE
 ];
 
+const WALKTHROUGH_SERVICE_DETAILS = {
+  [DEFAULT_SERVICES.ENMASSE]: {
+    prettyName: 'EnMasse',
+    gaStatus: 'preview'
+  },
+  [DEFAULT_SERVICES.FUSE]: {
+    prettyName: 'Red Hat Fuse'
+  },
+  [DEFAULT_SERVICES.AMQ]: {
+    prettyName: 'Red Hat AMQ'
+  },
+  [DEFAULT_SERVICES.CHE]: {
+    prettyName: 'Eclipse Che'
+  },
+  [DEFAULT_SERVICES.LAUNCHER]: {
+    prettyName: 'Red Hat Developer Launcher'
+  },
+  [DEFAULT_SERVICES.THREESCALE]: {
+    prettyName: 'Red Hat 3scale API Management Platform',
+    gaStatus: 'community'
+  }
+};
+
+console.log(WALKTHROUGH_SERVICE_DETAILS);
+
 /**
  * Dispatch a mock set of user services.
  * @param {Object} dispatch Redux dispatch.
@@ -41,12 +66,13 @@ const mockMiddlewareServices = (dispatch, mockData) => {
     return;
   }
   window.localStorage.setItem('currentUserName', 'mockUser@mockUser.com');
-  mockData.serviceInstances.forEach(si =>
+  mockData.serviceInstances.forEach(si => {
+    si.serviceDetails = WALKTHROUGH_SERVICE_DETAILS[si.spec.clusterServiceClassExternalName];
     dispatch({
       type: FULFILLED_ACTION(middlewareTypes.CREATE_WALKTHROUGH),
       payload: si
-    })
-  );
+    });
+  });
 };
 
 /**
@@ -73,6 +99,7 @@ const manageMiddlewareServices = dispatch => {
     const namespaceObj = namespaceResource(userNamespace);
     const namespaceRequestObj = namespaceRequestResource(userNamespace);
 
+    // Namespace
     findOrCreateOpenshiftResource(
       namespaceDef,
       namespaceObj,
@@ -86,6 +113,7 @@ const manageMiddlewareServices = dispatch => {
         );
         return Promise.all(
           siObjs.map(siObj =>
+            // Service Instance
             findOrCreateOpenshiftResource(
               serviceInstanceDef(userNamespace),
               siObj,

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -223,6 +223,7 @@ const handleServiceInstanceWatchEvents = (dispatch, event) => {
     return;
   }
   if (event.type === OpenShiftWatchEvents.ADDED || event.type === OpenShiftWatchEvents.MODIFIED) {
+    event.payload.serviceDetails = WALKTHROUGH_SERVICE_DETAILS[si.spec.clusterServiceClassExternalName];
     dispatch({
       type: FULFILLED_ACTION(middlewareTypes.CREATE_WALKTHROUGH),
       payload: event.payload

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -22,6 +22,8 @@ import {
   routeDef
 } from '../common/openshiftResourceDefinitions';
 
+import productDetails from '../product-info';
+
 const WALKTHROUGH_SERVICES = [
   DEFAULT_SERVICES.ENMASSE,
   DEFAULT_SERVICES.CHE,
@@ -31,30 +33,17 @@ const WALKTHROUGH_SERVICES = [
   DEFAULT_SERVICES.THREESCALE
 ];
 
-const WALKTHROUGH_SERVICE_DETAILS = {
-  [DEFAULT_SERVICES.ENMASSE]: {
-    prettyName: 'EnMasse',
-    gaStatus: 'preview'
-  },
-  [DEFAULT_SERVICES.FUSE]: {
-    prettyName: 'Red Hat Fuse'
-  },
-  [DEFAULT_SERVICES.AMQ]: {
-    prettyName: 'Red Hat AMQ'
-  },
-  [DEFAULT_SERVICES.CHE]: {
-    prettyName: 'Eclipse Che'
-  },
-  [DEFAULT_SERVICES.LAUNCHER]: {
-    prettyName: 'Red Hat Developer Launcher'
-  },
-  [DEFAULT_SERVICES.THREESCALE]: {
-    prettyName: 'Red Hat 3scale API Management Platform',
-    gaStatus: 'community'
+/**
+ * Lookup product details (name and GA status) and add them to the
+ * service instance object
+ * @param serviceInstance Service instance retrieved from Openshift
+ */
+const setProductDetails = serviceInstance => {
+  const { spec } = serviceInstance;
+  if (spec) {
+    serviceInstance.productDetails = productDetails[spec.clusterServiceClassExternalName];
   }
 };
-
-console.log(WALKTHROUGH_SERVICE_DETAILS);
 
 /**
  * Dispatch a mock set of user services.
@@ -67,7 +56,7 @@ const mockMiddlewareServices = (dispatch, mockData) => {
   }
   window.localStorage.setItem('currentUserName', 'mockUser@mockUser.com');
   mockData.serviceInstances.forEach(si => {
-    si.serviceDetails = WALKTHROUGH_SERVICE_DETAILS[si.spec.clusterServiceClassExternalName];
+    setProductDetails(si);
     dispatch({
       type: FULFILLED_ACTION(middlewareTypes.CREATE_WALKTHROUGH),
       payload: si
@@ -223,7 +212,7 @@ const handleServiceInstanceWatchEvents = (dispatch, event) => {
     return;
   }
   if (event.type === OpenShiftWatchEvents.ADDED || event.type === OpenShiftWatchEvents.MODIFIED) {
-    event.payload.serviceDetails = WALKTHROUGH_SERVICE_DETAILS[si.spec.clusterServiceClassExternalName];
+    setProductDetails(event.payload);
     dispatch({
       type: FULFILLED_ACTION(middlewareTypes.CREATE_WALKTHROUGH),
       payload: event.payload

--- a/src/styles/application/_installedAppsView.scss
+++ b/src/styles/application/_installedAppsView.scss
@@ -55,4 +55,24 @@
       cursor: pointer;
     }
   }
+  &-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .gastatus {
+      text-transform: capitalize;
+      font-size: 12px;
+      font-weight: bold;
+      padding: 5px;
+    }
+
+    .preview {
+      background-color: $pf-color-black-200;
+    }
+
+    .community {
+      background-color: $pf-color-purple-200;
+    }
+  }
 }

--- a/src/styles/application/_installedAppsView.scss
+++ b/src/styles/application/_installedAppsView.scss
@@ -56,23 +56,10 @@
     }
   }
   &-title {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-
     .gastatus {
       text-transform: capitalize;
-      font-size: 12px;
-      font-weight: bold;
-      padding: 5px;
-    }
-
-    .preview {
-      background-color: $pf-color-black-200;
-    }
-
-    .community {
-      background-color: $pf-color-purple-200;
+      float: right;
+      position: relative;
     }
   }
 }


### PR DESCRIPTION
Display pretty names and GA labels in the installed applications list. Currently this metadata is hardcoded in `src/product-info.js` and i'm looking for ways to get the info from the Asciidoc.

![bildschirmfoto 2018-10-12 um 16 18 03](https://user-images.githubusercontent.com/1851198/46874860-7c155d00-ce3a-11e8-8bed-0004a55b8c2d.png)
