### PR TITLE
Dashboard url fallback

### DIFF
--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -1,5 +1,5 @@
 import { WALKTHROUGH_IDS } from '../services/walkthroughServices';
-import { DEFAULT_SERVICES } from '../common/serviceInstanceHelpers';
+import { DEFAULT_SERVICES, getDashboardUrl } from '../common/serviceInstanceHelpers';
 
 const getDocsForWalkthrough = (walkthrough, middlewareServices, walkthroughServices) => {
   if (!walkthrough) {
@@ -60,7 +60,7 @@ const getUrlFromMiddlewareServices = (middlewareServices, serviceName) => {
     return null;
   }
   const service = middlewareServices.data[serviceName];
-  return service.status.dashboardURL || service.metadata.annotations['integreatly/dashboard-url'];
+  return getDashboardUrl(service);
 };
 
 const getUrlFromWalkthroughServices = (walkthroughServices, serviceName) => {

--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -147,6 +147,24 @@ const handleWalkthroughOneRoutes = (namespacePrefix, dispatch, event) => {
   }
 };
 
+/**
+ * Try to get the service's dashboard URL preferably from the status properties and
+ * as a fallback the integreatly/dashboard-url annotation. Returns an empty string
+ * if neither is applicable.
+ * @param si Service Instance Object
+ * @returns {string} Dashboard URL
+ */
+const getDashboardUrl = si => {
+  const { status, metadata } = si;
+  if (status.dashboardURL) {
+    return status.dashboardURL;
+  } else if (metadata.annotations && metadata.annotations['integreatly/dashboard-url']) {
+    return metadata.annotations['integreatly/dashboard-url'];
+  } else {
+    return '';
+  }
+};
+
 export {
   buildServiceInstanceCompareFn,
   buildServiceInstanceResourceObj,
@@ -155,5 +173,6 @@ export {
   DefaultServiceInstanceTransform,
   EnMasseServiceInstanceTransform,
   handleWalkthroughOneRoutes,
-  MessagingAppServiceInstanceTransform
+  MessagingAppServiceInstanceTransform,
+  getDashboardUrl
 };

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -93,7 +93,7 @@ class InstalledAppsView extends React.Component {
         >
           <div className="integr8ly-installed-apps-view-title">
             <p>{prettyName}</p>
-            <span className={`gastatus integr8ly-label-${gaStatus}`}>{gaStatus}</span>
+            <span className={`integr8ly-label-${gaStatus}`}>{gaStatus}</span>
           </div>
           {InstalledAppsView.getStatusForApp(app)}
           <small />

--- a/src/components/loadingScreen/loadingScreen.js
+++ b/src/components/loadingScreen/loadingScreen.js
@@ -21,13 +21,13 @@ class LoadingScreen extends React.Component {
       opacity: this.props.backdropOpacity
     };
     if (this.props.backdropImage !== null) {
-      backdropStyle['background-image'] = `url("${this.props.backdropImage}")`;
+      backdropStyle.backgroundImage = `url("${this.props.backdropImage}")`;
     } else {
-      backdropStyle['background-color'] = this.props.backdropColor;
+      backdropStyle.backgroundColor = this.props.backdropColor;
     }
 
     const logoStyle = {
-      'background-image': `url(" ${this.props.logo}")`
+      backgroundImage: `url(" ${this.props.logo}")`
     };
 
     return (
@@ -52,7 +52,7 @@ LoadingScreen.propTypes = {
   showBackdrop: PropTypes.bool,
   backdropImage: PropTypes.string,
   backdropColor: PropTypes.string,
-  backdropOpacity: PropTypes.number,
+  backdropOpacity: PropTypes.string,
   progress: PropTypes.number,
   throbberImage: PropTypes.string,
   logo: PropTypes.string,

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -15,7 +15,7 @@ const TutorialDashboard = props => {
     else startedText = 'Resume';
 
     return cards.push(
-      <Col xs={12} sm={4}>
+      <Col xs={12} sm={4} key={walkthrough.id}>
         <TutorialCard
           title={walkthrough.title}
           getStartedLink={
@@ -35,7 +35,7 @@ const TutorialDashboard = props => {
               className="fa-lg"
             />
           }
-          minsIcon={<Icon type="fa" name="clock-o" className="fa-lg" arrow-alt-circle-right />}
+          minsIcon={<Icon type="fa" name="clock-o" className="fa-lg" arrow-alt-circle-right="true" />}
           progress={currentProgress === undefined ? 0 : currentProgress.progress}
           mins={walkthrough.estimatedTime}
         >

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -344,8 +344,9 @@ class TaskPage extends React.Component {
                       {threadTask.steps.map((step, l) => (
                         <React.Fragment key={l}>
                           {step.infoVerifications &&
-                            step.infoVerifications.map(() => (
+                            step.infoVerifications.map(v => (
                               <Icon
+                                key={v}
                                 className={
                                   step.infoVerifications && verifications[step.infoVerifications[0]]
                                     ? 'integr8ly-module-column--footer_status-checked'
@@ -356,8 +357,9 @@ class TaskPage extends React.Component {
                               />
                             ))}
                           {step.successVerifications &&
-                            step.successVerifications.map(() => (
+                            step.successVerifications.map(v => (
                               <Icon
+                                key={v}
                                 className={
                                   step.successVerifications && verifications[step.successVerifications[0]]
                                     ? 'integr8ly-module-column--footer_status-checked'
@@ -368,8 +370,9 @@ class TaskPage extends React.Component {
                               />
                             ))}
                           {step.infoVerifications &&
-                            step.infoVerifications.map(() => (
+                            step.infoVerifications.map(v => (
                               <span
+                                key={v}
                                 className={
                                   verifications[step.infoVerifications[0]]
                                     ? 'integr8ly-module-column--footer_status-checked'
@@ -380,8 +383,9 @@ class TaskPage extends React.Component {
                               </span>
                             ))}
                           {step.successVerifications &&
-                            step.successVerifications.map(() => (
+                            step.successVerifications.map(v => (
                               <span
+                                key={v}
                                 className={
                                   verifications[step.successVerifications[0]]
                                     ? 'integr8ly-module-column--footer_status-checked'

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -140,14 +140,6 @@ class TaskPage extends React.Component {
     return middlewareServices.amqCredentials[name];
   };
 
-  getUrlFromMiddlewareServices = (middlewareServices, serviceName) => {
-    if (!middlewareServices || !middlewareServices.data || !middlewareServices.data[serviceName]) {
-      return null;
-    }
-    const service = middlewareServices.data[serviceName];
-    return service.status.dashboardURL || service.metadata.annotations['integreatly/dashboard-url'];
-  };
-
   getUrlFromWalkthroughServices = (walkthroughServices, serviceName) => {
     if (
       !walkthroughServices ||


### PR DESCRIPTION
When `status.dashboardUrl` does not exist on a service instance we use `annotations['integreatly/dashboard']` as a fallback. But the annotations object might not exist when, for example, a service failed to provision. This change provides a fallback to the fallback by checking for existence first.

Also fixes some react warnings in the browser console.