### PR TITLE
fix state issue of the next button in each walkthrough tasks

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -82,9 +82,11 @@ class TaskPage extends React.Component {
             }
           }
         }
+
+        const verificationsChecked = Object.values(verifications).every(v => v === true);
         this.setState({
           verifications,
-          verificationsChecked: !hasVerifications
+          verificationsChecked
         });
       });
     }


### PR DESCRIPTION
Add verification progress from the store to the initial state when the task loads to fix the state issue with the `Next` button being disabled when the steps are already verified.

Resolves https://github.com/integr8ly/tutorial-web-app/issues/145