### PR TITLE
fix next button nav

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -84,7 +84,7 @@ class TaskPage extends React.Component {
         }
         this.setState({
           verifications,
-          verificationsChecked: !hasVerifications
+          verificationsChecked: Object.values(verifications).every(v => v === true)
         });
       });
     }


### PR DESCRIPTION
Fix so the Next button is active when navigating to a panel in which all Yes/No verifications had previously already been checked as Yes. 