### PR TITLE
Fix bottom numbering

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -84,7 +84,7 @@ class TaskPage extends React.Component {
         }
         this.setState({
           verifications,
-          verificationsChecked: !hasVerifications
+          verificationsChecked: Object.values(verifications).every(v => v === true)
         });
       });
     }

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -456,7 +456,7 @@ class TaskPage extends React.Component {
                                     : 'integr8ly-module-column--footer_status-step'
                                 }
                               >
-                                {task + 1}.{l}
+                                {task + 1}.{l + 1}
                               </span>
                             ))}
                           {step.successVerifications &&
@@ -469,7 +469,7 @@ class TaskPage extends React.Component {
                                     : 'integr8ly-module-column--footer_status-step'
                                 }
                               >
-                                {task + 1}.{l}
+                                {task + 1}.{l + 1}
                               </span>
                             ))}
                         </React.Fragment>


### PR DESCRIPTION
Quick fix to accommodate the decision to start the bottom step numbering scheme (currently x.0, x.1, x.2) at .1 instead of .0, so that it matches the asciidoc headings, which will start at x.1.