### PR TITLE
add workaround for numbered step heading style

### DIFF
--- a/docs/bin/listAll.txt
+++ b/docs/bin/listAll.txt
@@ -21,8 +21,8 @@ running-spring-app.adoc
 setting-up-enmasse.adoc
 task-calling-fuse-aggregation-app-endpoint.adoc
 task-creating-addresses.adoc
-task-creating-connections.adoc
 task-creating-connections-enmasse.adoc
+task-creating-connections.adoc
 task-creating-fuse-integration-1A.adoc
 task-creating-fuse-integration.adoc
 task-deploying-fuse-aggregation-app.adoc

--- a/docs/bin/taskAll.txt
+++ b/docs/bin/taskAll.txt
@@ -1,7 +1,7 @@
 ../modules/ROOT/pages/_partials/task-calling-fuse-aggregation-app-endpoint.adoc
 ../modules/ROOT/pages/_partials/task-creating-addresses.adoc
-../modules/ROOT/pages/_partials/task-creating-connections.adoc
 ../modules/ROOT/pages/_partials/task-creating-connections-enmasse.adoc
+../modules/ROOT/pages/_partials/task-creating-connections.adoc
 ../modules/ROOT/pages/_partials/task-creating-fuse-integration-1A.adoc
 ../modules/ROOT/pages/_partials/task-creating-fuse-integration.adoc
 ../modules/ROOT/pages/_partials/task-deploying-fuse-aggregation-app.adoc

--- a/docs/modules/ROOT/pages/_partials/add-fuse-aggregation-app-endpoint.adoc
+++ b/docs/modules/ROOT/pages/_partials/add-fuse-aggregation-app-endpoint.adoc
@@ -4,6 +4,7 @@
 
 
 [id='add-fuse-aggregation-app-endpoint_{context}']
+[.integr8ly-docs-header]
 ===== 3.2 Adding the Fuse Aggregation App Endpoint to {3Scale-ProductName}
 
 . Select the *API* menu item from the top of the screen.

--- a/docs/modules/ROOT/pages/_partials/api-management-login.adoc
+++ b/docs/modules/ROOT/pages/_partials/api-management-login.adoc
@@ -4,6 +4,7 @@
 
 
 [id='api-management-login_{context}']
+[.integr8ly-docs-header]
 ===== 3.1 API Management Login 
 
 // TODO service & url placeholders

--- a/docs/modules/ROOT/pages/_partials/calling-fuse-aggregation-app-endpoint-fail-limits.adoc
+++ b/docs/modules/ROOT/pages/_partials/calling-fuse-aggregation-app-endpoint-fail-limits.adoc
@@ -4,6 +4,7 @@
 
 
 [id='calling-fuse-aggregation-app-endpoint-fail-limits_{context}']
+[.integr8ly-docs-header]
 ===== 4.3 Verifying access to the API Service is limited 
 
 . In the *user_key* field, enter `{fuse-aggregator-app-name}`.

--- a/docs/modules/ROOT/pages/_partials/calling-fuse-aggregation-app-endpoint-fail-user-key.adoc
+++ b/docs/modules/ROOT/pages/_partials/calling-fuse-aggregation-app-endpoint-fail-user-key.adoc
@@ -4,6 +4,7 @@
 
 
 [id='calling-fuse-aggregation-app-endpoint-fail-user-key_{context}']
+[.integr8ly-docs-header]
 ===== 4.1 Checking the API Service is protected 
 
 . From the *ActiveDocs* page for the `{fuse-aggregator-app-name}` Application, expand the *GET /flights* endpoint.

--- a/docs/modules/ROOT/pages/_partials/calling-fuse-aggregation-app-endpoint-success.adoc
+++ b/docs/modules/ROOT/pages/_partials/calling-fuse-aggregation-app-endpoint-success.adoc
@@ -4,6 +4,7 @@
 
 
 [id='calling-fuse-aggregation-app-endpoint-success_{context}']
+[.integr8ly-docs-header]
 ===== 4.2 Validating access to the API Service 
 
 . In the *user_key* field, enter `{fuse-aggregator-app-name}`.

--- a/docs/modules/ROOT/pages/_partials/creating-amq-connection-in-fuse.adoc
+++ b/docs/modules/ROOT/pages/_partials/creating-amq-connection-in-fuse.adoc
@@ -1,6 +1,6 @@
 
 [id='creating-amqp-connection-in-fuse_{context}']
-
+[.integr8ly-docs-header]
 ===== 1.2 Creating an AMQ connection
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/creating-amqp-connection-in-fuse.adoc
+++ b/docs/modules/ROOT/pages/_partials/creating-amqp-connection-in-fuse.adoc
@@ -5,7 +5,7 @@
 :enmasse: Red Hat AMQ Online
 
 [id='creating-amqp-connection-in-fuse_{context}']
-
+[.integr8ly-docs-header]
 ===== 2.3 Creating AMQP connection in Red Hat Fuse Online
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/creating-api-connector-1A.adoc
+++ b/docs/modules/ROOT/pages/_partials/creating-api-connector-1A.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-api-connector_{context}']
+[.integr8ly-docs-header]
 ===== 2.1 Creating an API Connector 
 
 . Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.

--- a/docs/modules/ROOT/pages/_partials/creating-api-connector.adoc
+++ b/docs/modules/ROOT/pages/_partials/creating-api-connector.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-api-connector_{context}']
+[.integr8ly-docs-header]
 ===== 1.1 Creating an API Connector 
 
 . Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.

--- a/docs/modules/ROOT/pages/_partials/creating-fuse-integration.adoc
+++ b/docs/modules/ROOT/pages/_partials/creating-fuse-integration.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-fuse-integration_{context}']
+[.integr8ly-docs-header]
 ===== 2.1 Creating an integration
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/creating-http-connection-1A.adoc
+++ b/docs/modules/ROOT/pages/_partials/creating-http-connection-1A.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-http-connection-in-fuse_{context}']
+[.integr8ly-docs-header]
 ===== 2.2 Creating HTTP connection to CRUD App
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/creating-http-connection.adoc
+++ b/docs/modules/ROOT/pages/_partials/creating-http-connection.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-http-connection-in-fuse_{context}']
+[.integr8ly-docs-header]
 ===== 1.3 Creating HTTP connection to CRUD App
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/fuse-aggregation-app-endpoint-activedocs.adoc
+++ b/docs/modules/ROOT/pages/_partials/fuse-aggregation-app-endpoint-activedocs.adoc
@@ -4,6 +4,7 @@
 
 
 [id='fuse-aggregation-app-endpoint-activedocs_{context}']
+[.integr8ly-docs-header]
 ===== 3.4 Create a new ActiveDocs Service
 
 . Select the *APIs* menu item at the top to return to the *APIs* Overview page.

--- a/docs/modules/ROOT/pages/_partials/fuse-aggregation-app-endpoint-activity-monitoring.adoc
+++ b/docs/modules/ROOT/pages/_partials/fuse-aggregation-app-endpoint-activity-monitoring.adoc
@@ -4,6 +4,7 @@
 
 
 [id='fuse-aggregation-app-endpoint-activity-monitoring_{context}']
+[.integr8ly-docs-header]
 ===== 4.4 Monitoring the API Service 
 
 . Select the *Analytics* tab from the top menu.

--- a/docs/modules/ROOT/pages/_partials/fuse-aggregation-app-endpoint-limits.adoc
+++ b/docs/modules/ROOT/pages/_partials/fuse-aggregation-app-endpoint-limits.adoc
@@ -4,6 +4,7 @@
 
 
 [id='fuse-aggregation-app-endpoint-limits_{context}']
+[.integr8ly-docs-header]
 ===== 3.3 Setting Fuse Aggregation App Endpoint Limits 
 
 . Create a new *Application Plan*:

--- a/docs/modules/ROOT/pages/_partials/task-creating-addresses.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-creating-addresses.adoc
@@ -15,7 +15,7 @@
 :enmasse-url: https://console-enmasse.apps.city.openshiftworkshop.com/console/my-example-space
 // https://console-enmasse-my-example-space.apps.city.openshiftworkshop.com/#/dashboard
 
-
+[.integr8ly-docs-header]
 ===== 1.1 Creating an address in EnMasse space
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/task-creating-fuse-integration-1A.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-creating-fuse-integration-1A.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-fuse-integration_{context}']
+[.integr8ly-docs-header]
 ===== 3.1 Creating an integration
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/task-creating-fuse-integration.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-creating-fuse-integration.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-fuse-integration_{context}']
+[.integr8ly-docs-header]
 ===== 2.1 Creating an integration
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/task-deploying-fuse-aggregation-app.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-deploying-fuse-aggregation-app.adoc
@@ -7,13 +7,9 @@
 // * ID: [id='doing-procedure-a']
 // * Title: = Doing procedure A
 
-
 [id='deploying-fuse-aggregation-app_{context}']
-
-
-
-
-===== 1 Deploying the Fuse Aggregation App
+[.integr8ly-docs-header]
+===== 1.1 Deploying the Fuse Aggregation App
 
 ifdef::location[]
 // tag::intro[]

--- a/docs/modules/ROOT/pages/_partials/task-modifying-fuse-aggregation-app.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-modifying-fuse-aggregation-app.adoc
@@ -7,13 +7,9 @@
 // * ID: [id='doing-procedure-a']
 // * Title: = Doing procedure A
 
-
 [id='modifying-fuse-aggregation-app_{context}']
-
-
-
-
-===== 2 Modifying the Fuse Aggregation App
+[.integr8ly-docs-header]
+===== 2.1 Modifying the Fuse Aggregation App
 
 ifdef::location[]
 // tag::intro[]

--- a/docs/modules/ROOT/pages/_partials/task-using-integration-1A.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-using-integration-1A.adoc
@@ -2,10 +2,8 @@
 //
 // <List assemblies here, each on a new line>
 
-
 [id='using-integration_{context}']
-
-
+[.integr8ly-docs-header]
 ===== 4.1 Using the application integration
 
 ifdef::location[]

--- a/docs/modules/ROOT/pages/_partials/task-using-integration.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-using-integration.adoc
@@ -2,10 +2,8 @@
 //
 // <List assemblies here, each on a new line>
 
-
 [id='using-integration_{context}']
-
-
+[.integr8ly-docs-header]
 ===== 3.1 Using the application integration
 
 ifdef::location[]

--- a/public/steelthreads/asciidocs/en/add-fuse-aggregation-app-endpoint.adoc
+++ b/public/steelthreads/asciidocs/en/add-fuse-aggregation-app-endpoint.adoc
@@ -4,6 +4,7 @@
 
 
 [id='add-fuse-aggregation-app-endpoint_{context}']
+[.integr8ly-docs-header]
 ===== 3.2 Adding the Fuse Aggregation App Endpoint to {3Scale-ProductName}
 
 . Select the *API* menu item from the top of the screen.

--- a/public/steelthreads/asciidocs/en/api-management-login.adoc
+++ b/public/steelthreads/asciidocs/en/api-management-login.adoc
@@ -4,6 +4,7 @@
 
 
 [id='api-management-login_{context}']
+[.integr8ly-docs-header]
 ===== 3.1 API Management Login
 
 // TODO service & url placeholders

--- a/public/steelthreads/asciidocs/en/calling-fuse-aggregation-app-endpoint-fail-limits.adoc
+++ b/public/steelthreads/asciidocs/en/calling-fuse-aggregation-app-endpoint-fail-limits.adoc
@@ -4,6 +4,7 @@
 
 
 [id='calling-fuse-aggregation-app-endpoint-fail-limits_{context}']
+[.integr8ly-docs-header]
 ===== 4.3 Verifying access to the API Service is limited
 
 . In the *user_key* field, enter `{fuse-aggregator-app-name}`.

--- a/public/steelthreads/asciidocs/en/calling-fuse-aggregation-app-endpoint-fail-user-key.adoc
+++ b/public/steelthreads/asciidocs/en/calling-fuse-aggregation-app-endpoint-fail-user-key.adoc
@@ -4,6 +4,7 @@
 
 
 [id='calling-fuse-aggregation-app-endpoint-fail-user-key_{context}']
+[.integr8ly-docs-header]
 ===== 4.1 Checking the API Service is protected
 
 . From the *ActiveDocs* page for the `{fuse-aggregator-app-name}` Application, expand the *GET /flights* endpoint.

--- a/public/steelthreads/asciidocs/en/calling-fuse-aggregation-app-endpoint-success.adoc
+++ b/public/steelthreads/asciidocs/en/calling-fuse-aggregation-app-endpoint-success.adoc
@@ -4,6 +4,7 @@
 
 
 [id='calling-fuse-aggregation-app-endpoint-success_{context}']
+[.integr8ly-docs-header]
 ===== 4.2 Validating access to the API Service
 
 . In the *user_key* field, enter `{fuse-aggregator-app-name}`.

--- a/public/steelthreads/asciidocs/en/creating-amq-connection-in-fuse.adoc
+++ b/public/steelthreads/asciidocs/en/creating-amq-connection-in-fuse.adoc
@@ -1,5 +1,5 @@
 [id='creating-amqp-connection-in-fuse_{context}']
-
+[.integr8ly-docs-header]
 ===== 1.2 Creating an AMQ connection
 
 

--- a/public/steelthreads/asciidocs/en/creating-amqp-connection-in-fuse.adoc
+++ b/public/steelthreads/asciidocs/en/creating-amqp-connection-in-fuse.adoc
@@ -5,7 +5,7 @@
 :enmasse: Red Hat AMQ Online
 
 [id='creating-amqp-connection-in-fuse_{context}']
-
+[.integr8ly-docs-header]
 ===== 2.3 Creating AMQP connection in Red Hat Fuse Online
 
 

--- a/public/steelthreads/asciidocs/en/creating-api-connector-1A.adoc
+++ b/public/steelthreads/asciidocs/en/creating-api-connector-1A.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-api-connector_{context}']
+[.integr8ly-docs-header]
 ===== 2.1 Creating an API Connector
 
 . Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.

--- a/public/steelthreads/asciidocs/en/creating-api-connector.adoc
+++ b/public/steelthreads/asciidocs/en/creating-api-connector.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-api-connector_{context}']
+[.integr8ly-docs-header]
 ===== 1.1 Creating an API Connector
 
 . Log in to the link:{fuse-url}[Red Hat Fuse Online, window="_blank"] console.

--- a/public/steelthreads/asciidocs/en/creating-fuse-integration.adoc
+++ b/public/steelthreads/asciidocs/en/creating-fuse-integration.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-fuse-integration_{context}']
+[.integr8ly-docs-header]
 ===== 2.1 Creating an integration
 
 

--- a/public/steelthreads/asciidocs/en/creating-http-connection-1A.adoc
+++ b/public/steelthreads/asciidocs/en/creating-http-connection-1A.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-http-connection-in-fuse_{context}']
+[.integr8ly-docs-header]
 ===== 2.2 Creating HTTP connection to CRUD App
 
 

--- a/public/steelthreads/asciidocs/en/creating-http-connection.adoc
+++ b/public/steelthreads/asciidocs/en/creating-http-connection.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-http-connection-in-fuse_{context}']
+[.integr8ly-docs-header]
 ===== 1.3 Creating HTTP connection to CRUD App
 
 

--- a/public/steelthreads/asciidocs/en/fuse-aggregation-app-endpoint-activedocs.adoc
+++ b/public/steelthreads/asciidocs/en/fuse-aggregation-app-endpoint-activedocs.adoc
@@ -4,6 +4,7 @@
 
 
 [id='fuse-aggregation-app-endpoint-activedocs_{context}']
+[.integr8ly-docs-header]
 ===== 3.4 Create a new ActiveDocs Service
 
 . Select the *APIs* menu item at the top to return to the *APIs* Overview page.

--- a/public/steelthreads/asciidocs/en/fuse-aggregation-app-endpoint-activity-monitoring.adoc
+++ b/public/steelthreads/asciidocs/en/fuse-aggregation-app-endpoint-activity-monitoring.adoc
@@ -4,6 +4,7 @@
 
 
 [id='fuse-aggregation-app-endpoint-activity-monitoring_{context}']
+[.integr8ly-docs-header]
 ===== 4.4 Monitoring the API Service
 
 . Select the *Analytics* tab from the top menu.

--- a/public/steelthreads/asciidocs/en/fuse-aggregation-app-endpoint-limits.adoc
+++ b/public/steelthreads/asciidocs/en/fuse-aggregation-app-endpoint-limits.adoc
@@ -4,6 +4,7 @@
 
 
 [id='fuse-aggregation-app-endpoint-limits_{context}']
+[.integr8ly-docs-header]
 ===== 3.3 Setting Fuse Aggregation App Endpoint Limits
 
 . Create a new *Application Plan*:

--- a/public/steelthreads/asciidocs/en/task-creating-addresses.adoc
+++ b/public/steelthreads/asciidocs/en/task-creating-addresses.adoc
@@ -15,7 +15,7 @@
 :enmasse-url: https://console-enmasse.apps.city.openshiftworkshop.com/console/my-example-space
 // https://console-enmasse-my-example-space.apps.city.openshiftworkshop.com/#/dashboard
 
-
+[.integr8ly-docs-header]
 ===== 1.1 Creating an address in EnMasse space
 
 

--- a/public/steelthreads/asciidocs/en/task-creating-fuse-integration-1A.adoc
+++ b/public/steelthreads/asciidocs/en/task-creating-fuse-integration-1A.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-fuse-integration_{context}']
+[.integr8ly-docs-header]
 ===== 3.1 Creating an integration
 
 

--- a/public/steelthreads/asciidocs/en/task-creating-fuse-integration.adoc
+++ b/public/steelthreads/asciidocs/en/task-creating-fuse-integration.adoc
@@ -4,6 +4,7 @@
 
 
 [id='creating-fuse-integration_{context}']
+[.integr8ly-docs-header]
 ===== 2.1 Creating an integration
 
 

--- a/public/steelthreads/asciidocs/en/task-deploying-fuse-aggregation-app.adoc
+++ b/public/steelthreads/asciidocs/en/task-deploying-fuse-aggregation-app.adoc
@@ -7,13 +7,9 @@
 // * ID: [id='doing-procedure-a']
 // * Title: = Doing procedure A
 
-
 [id='deploying-fuse-aggregation-app_{context}']
-
-
-
-
-===== 1 Deploying the Fuse Aggregation App
+[.integr8ly-docs-header]
+===== 1.1 Deploying the Fuse Aggregation App
 
 
 // TODO placeholders for product names

--- a/public/steelthreads/asciidocs/en/task-modifying-fuse-aggregation-app.adoc
+++ b/public/steelthreads/asciidocs/en/task-modifying-fuse-aggregation-app.adoc
@@ -7,13 +7,9 @@
 // * ID: [id='doing-procedure-a']
 // * Title: = Doing procedure A
 
-
 [id='modifying-fuse-aggregation-app_{context}']
-
-
-
-
-===== 2 Modifying the Fuse Aggregation App
+[.integr8ly-docs-header]
+===== 2.1 Modifying the Fuse Aggregation App
 
 
 // TODO placeholders for product names

--- a/public/steelthreads/asciidocs/en/task-using-integration-1A.adoc
+++ b/public/steelthreads/asciidocs/en/task-using-integration-1A.adoc
@@ -2,10 +2,8 @@
 //
 // <List assemblies here, each on a new line>
 
-
 [id='using-integration_{context}']
-
-
+[.integr8ly-docs-header]
 ===== 4.1 Using the application integration
 
 

--- a/public/steelthreads/asciidocs/en/task-using-integration.adoc
+++ b/public/steelthreads/asciidocs/en/task-using-integration.adoc
@@ -2,10 +2,8 @@
 //
 // <List assemblies here, each on a new line>
 
-
 [id='using-integration_{context}']
-
-
+[.integr8ly-docs-header]
 ===== 3.1 Using the application integration
 
 

--- a/src/styles/application/_patternfly4.scss
+++ b/src/styles/application/_patternfly4.scss
@@ -197,3 +197,16 @@ ol {
   height: 32px; // accounts for increase in base font size from 12px to 16px
 }
 /* stylelint-enable */
+
+.integr8ly-docs-header {
+  h5 {
+    font-size: $h3-font-size;
+    font-weight: $pf-global--FontWeight--semi-bold;
+    margin-top: 20px;
+    margin-bottom: 10px;
+  }
+  .olist {
+    font-size: $pf-global--FontSize--md;
+    font-weight: $pf-global--FontWeight--normal;
+  }
+}


### PR DESCRIPTION
Added a new style as a workaround to the issue in which task headings weren't rendering with the forced number AND the patternfly heading style. Sample output:

![numbered-heading-steps](https://user-images.githubusercontent.com/39063664/47311803-b20bcb80-d608-11e8-971c-b87f7a974b8c.png)


