### PR TITLE
fix final task next button

### DIFF
--- a/public/steelthreads/json/en/thread-1.json
+++ b/public/steelthreads/json/en/thread-1.json
@@ -66,11 +66,11 @@
       "steps": [
         {
           "stepDoc": "task-using-integration.adoc",
-          "successVerifications": [
+          "infoVerifications": [
             "task-using-integration-verification.adoc"
           ],
           "infoVerificationsNo": [
-            "task-sing-integration-verification-no.adoc"
+            "task-using-integration-verification-no.adoc"
           ]
         }
       ]

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -274,7 +274,7 @@ class TaskPage extends React.Component {
         <React.Fragment>
           <Breadcrumb
             threadName={thread.data.title}
-            threadId={thread.data.id}
+            threadId={thread.data.id.parseInt}
             taskPosition={task + 1}
             totalTasks={totalTasks}
             homeClickedCallback={() => {
@@ -511,7 +511,11 @@ class TaskPage extends React.Component {
                       )}
                       {task + 1 === totalTasks && (
                         <ButtonGroup>
-                          <Button onClick={e => this.exitTutorial(e)}>
+                          <Button
+                            bsStyle={verificationsChecked ? 'primary' : 'default'}
+                            onClick={e => this.exitTutorial(e)}
+                            disabled={!verificationsChecked}
+                          >
                             {t('task.exitTutorial')} <Icon type="fa" name="angle-right" style={{ paddingLeft: 5 }} />
                           </Button>
                         </ButtonGroup>


### PR DESCRIPTION
Fixes 3 issues:

* Next button behavior (disabled by default, enabled on all Yes, etc) not working on the final task of each walkthrough
* Walkthrough 1A not showing yes/no verification info in final task
* Type mismatch error in console for threadId