### PR TITLE
update icons in task and footer

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -310,11 +310,14 @@ class TaskPage extends React.Component {
                             this.getDocsAttributes()
                           )}
                         />
+
+                        {/* for Yes/No implementation */}
                         {step.infoVerifications &&
                           step.infoVerifications.map(
                             (verification, j) =>
                               verifications[step.infoVerifications[0]] === undefined ? (
-                                <Alert type="info" className="integr8ly-module-column--steps_alert-blue" key={j}>
+                                <div className="alert integr8ly-module-column--steps_alert-blue" key={j}>
+                                  <i className="pficon fa fa-circle-o" />
                                   <strong>{t('task.verificationTitle')}</strong>
                                   <AsciiDocTemplate
                                     adoc={verification}
@@ -343,7 +346,7 @@ class TaskPage extends React.Component {
                                       No
                                     </Radio>
                                   </ButtonGroup>
-                                </Alert>
+                                </div>
                               ) : (
                                 <Alert
                                   type={
@@ -412,79 +415,67 @@ class TaskPage extends React.Component {
                                 </Alert>
                               )
                           )}
-                        {step.successVerifications &&
-                          step.successVerifications.map((verification, c) => (
-                            <Alert type="success" key={c}>
-                              <strong>{t('task.verificationTitle')}</strong>
-                              <AsciiDocTemplate
-                                adoc={verification}
-                                attributes={Object.assign({}, thread.data.attributes, step.attributes, attrs)}
-                              />
-                            </Alert>
-                          ))}
                       </React.Fragment>
                     ))}
                   </div>
+
+                  {/* Bottom footer */}
                   <div className="integr8ly-module-column--footer">
                     <h6>{t('task.CompleteAndCheck')}</h6>
                     <div className="integr8ly-module-column--footer_status">
                       {threadTask.steps.map((step, l) => (
                         <React.Fragment key={l}>
+                          {/* Bottom footer icon */}
                           {step.infoVerifications &&
-                            step.infoVerifications.map(v => (
-                              <Icon
-                                key={v}
-                                className={
-                                  step.infoVerifications && verifications[step.infoVerifications[0]]
-                                    ? 'integr8ly-module-column--footer_status-checked'
-                                    : 'integr8ly-module-column--footer_status'
-                                }
-                                type="fa"
-                                name={verifications[step.infoVerifications[0]] ? 'check-circle-o' : 'circle-o'}
-                              />
-                            ))}
-                          {step.successVerifications &&
-                            step.successVerifications.map(v => (
-                              <Icon
-                                key={v}
-                                className={
-                                  step.successVerifications && verifications[step.successVerifications[0]]
-                                    ? 'integr8ly-module-column--footer_status-checked'
-                                    : 'integr8ly-module-column--footer_status'
-                                }
-                                type="fa"
-                                name={verifications[step.successVerifications[0]] ? 'check-circle-o' : 'circle-o'}
-                              />
-                            ))}
+                            step.infoVerifications.map(
+                              (verification, v) =>
+                                verifications[step.infoVerifications[0]] === undefined ? (
+                                  <Icon
+                                    type="fa"
+                                    className="integr8ly-module-column--footer_status"
+                                    key={v}
+                                    name="circle-o"
+                                  />
+                                ) : (
+                                  <Icon
+                                    type="fa"
+                                    className={
+                                      step.infoVerifications && verifications[step.infoVerifications[0]]
+                                        ? 'integr8ly-module-column--footer_status-checked'
+                                        : 'integr8ly-module-column--footer_status-unchecked'
+                                    }
+                                    key={v}
+                                    name={
+                                      verifications[step.infoVerifications[0]] ? 'check-circle-o' : 'times-circle-o'
+                                    }
+                                  />
+                                )
+                            )}
+                          {/* Bottom footer number to the right of icon  */}
                           {step.infoVerifications &&
-                            step.infoVerifications.map(v => (
-                              <span
-                                key={v}
-                                className={
-                                  verifications[step.infoVerifications[0]]
-                                    ? 'integr8ly-module-column--footer_status-checked'
-                                    : 'integr8ly-module-column--footer_status-step'
-                                }
-                              >
-                                {task + 1}.{l + 1}
-                              </span>
-                            ))}
-                          {step.successVerifications &&
-                            step.successVerifications.map(v => (
-                              <span
-                                key={v}
-                                className={
-                                  verifications[step.successVerifications[0]]
-                                    ? 'integr8ly-module-column--footer_status-checked'
-                                    : 'integr8ly-module-column--footer_status-step'
-                                }
-                              >
-                                {task + 1}.{l + 1}
-                              </span>
-                            ))}
+                            step.infoVerifications.map(
+                              (verification, v) =>
+                                verifications[step.infoVerifications[0]] === undefined ? (
+                                  <span className="integr8ly-module-column--footer_status" key={v}>
+                                    {task + 1}.{l + 1}
+                                  </span>
+                                ) : (
+                                  <span
+                                    className={
+                                      verifications[step.infoVerifications[0]]
+                                        ? 'integr8ly-module-column--footer_status-checked'
+                                        : 'integr8ly-module-column--footer_status-unchecked'
+                                    }
+                                    key={v}
+                                  >
+                                    {task + 1}.{l + 1}
+                                  </span>
+                                )
+                            )}
                         </React.Fragment>
                       ))}
                     </div>
+
                     <div
                       className="btn-group btn-group-justified"
                       role="group"

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -51,6 +51,10 @@
           background-color: $pf-color-blue-50;
           border-color: $pf-color-blue-200;
           color: $pf-color-black-1000;
+
+          i {
+            color: $pf-color-blue-400;
+          }
         }
       }
 
@@ -71,6 +75,7 @@
 
         &_status {
           margin-bottom: 10px;
+          padding-right: 15px;
           color: $pf-color-blue-400;
 
           .fa {
@@ -81,6 +86,12 @@
             margin-bottom: 10px;
             padding-right: 15px;
             color: $pf-color-green-400;
+          }
+
+          &-unchecked {
+            margin-bottom: 10px;
+            padding-right: 15px;
+            color: $pf-color-red-100;
           }
 
           &-step {


### PR DESCRIPTION
Updated UI with icon/behavior to more closely match the UX specifications:

- Instead of the info alert/icon, use an empty blue 'O' on the default alert box, before user has selected a yes/no option
- Instead of toggling blue O (default/no) and green check (yes) in bottom footer, add a third case (red circle x) in which user has selected No
- Simplified/cleaned up the task.js jsx quite a bit because we are no longer using successVerifications in the asciidoc source... everything is infoVerification


Screen caps:

**Default:**
![default](https://user-images.githubusercontent.com/39063664/47541225-873ea300-d8a6-11e8-8be9-f4c805e8b907.png)

**Yes:**
![yes](https://user-images.githubusercontent.com/39063664/47541254-9e7d9080-d8a6-11e8-8c48-a9ec9e14ac7f.png)

**No:**
![no](https://user-images.githubusercontent.com/39063664/47541264-a6d5cb80-d8a6-11e8-8a6d-50e2dd1f5ebe.png)

