### PR TITLE
Allow to only provision select services

### DIFF
--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -154,16 +154,16 @@ const handleServiceInstancesProvision = (namespacePrefix, dispatch, event) => {
 
   if (serviceInstance && serviceInstance.status && serviceInstance.status.conditions) {
     const lastCondition = serviceInstance.status.conditions.pop();
-
-    if (lastCondition.type === 'Failed') {
-      dispatch({
-        type: REJECTED_ACTION(GET_THREAD),
-        error: true,
-        payload: {
-          errorMessage: lastCondition.message
-        }
-      });
+    if (!lastCondition || lastCondition.type !== 'Failed') {
+      return;
     }
+    dispatch({
+      type: REJECTED_ACTION(GET_THREAD),
+      error: true,
+      payload: {
+        errorMessage: lastCondition.message
+      }
+    });
   }
 };
 /**


### PR DESCRIPTION
@david-martin Would you mind taking a look? I tested using the following file

/tmp/meh.json
```
{
  "servicesToProvision": ["3scale", "fuse"]
}
```

and the following command

```
OPENSHIFT_HOST=master.akeating.openshiftworkshop.com SERVER_EXTRA_CONFIG_FILE=/tmp/meh.json yarn start:dev
```