### PR TITLE
fix breadcrumb not going to intro bug

### DIFF
--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -23,7 +23,7 @@ class Breadcrumb extends React.Component {
         {threadName &&
           taskPosition && (
             <React.Fragment>
-              <PfBreadcrumb.Item href={`#/tutorial/${threadId}`}>{threadName}</PfBreadcrumb.Item>
+              <PfBreadcrumb.Item href={`/tutorial/${threadId}`}>{threadName}</PfBreadcrumb.Item>
               <PfBreadcrumb.Item active>{t('breadcrumb.task', { taskPosition, totalTasks })}</PfBreadcrumb.Item>
             </React.Fragment>
           )}

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -282,7 +282,7 @@ class TaskPage extends React.Component {
         <React.Fragment>
           <Breadcrumb
             threadName={thread.data.title}
-            threadId={thread.data.id.parseInt}
+            threadId={thread.data.id}
             taskPosition={task + 1}
             totalTasks={totalTasks}
             homeClickedCallback={() => {


### PR DESCRIPTION
Fixed issue in which the walkthrough name in the breadcrumb was not bringing the user back to the intro page of that walkthrough. Issue was two-fold - the URL to the breadcrumb needed to be changed, and needed to revert a change that was made to parseInt the threadId (can cause a null if it's already a number).