### PR TITLE
Add ga and service status to walkthru resources

### DIFF
--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon } from 'patternfly-react';
 import { connect } from '../../redux';
 import { getDashboardUrl } from '../../common/serviceInstanceHelpers';
 
@@ -20,11 +21,28 @@ class WalkthroughResources extends React.Component {
     if (resources.length !== 0) {
       return resources.map(resource => {
         let url = '';
+        let gaStatus = '';
+        let serviceStatus = '';
+
         if (resource.serviceName === 'openshift') {
           url = `${window.OPENSHIFT_CONFIG.masterUri}/console`;
+          serviceStatus = true;
+          gaStatus = '';
         } else {
+          const serviceStatusApi = middlewareServices.data[resource.serviceName].status.conditions[0].status;
+          const gaStatusApi = middlewareServices.data[resource.serviceName].productDetails.gaStatus;
           url = getDashboardUrl(middlewareServices.data[resource.serviceName]);
+
+          if (serviceStatusApi) {
+            serviceStatus = serviceStatusApi;
+          }
+          if (gaStatusApi) {
+            gaStatus = gaStatusApi;
+          }
         }
+
+        resource.serviceStatus = serviceStatus;
+        resource.gaStatus = gaStatus;
 
         resource.links.forEach(link => {
           if (link.type === 'console') {
@@ -51,7 +69,26 @@ class WalkthroughResources extends React.Component {
         ));
         return (
           <div key={resource.title}>
-            <h4 className="integr8ly-helpful-links-product-title">{resource.title}</h4>
+            <h4 className="integr8ly-helpful-links-product-title">
+              <Icon
+                className={resource.serviceStatus ? 'integr8ly-state-ready' : 'integr8ly-state-unavailable'}
+                type="pf"
+                name={resource.serviceStatus ? 'on-running' : 'error-circle-o'}
+              />
+              &nbsp;
+              {resource.title}
+              &nbsp;
+              {resource.gaStatus === 'community' ? (
+                <span className="integr8ly-label-community integr8ly-walkthrough-labels-tag">community</span>
+              ) : (
+                <span />
+              )}
+              {resource.gaStatus === 'preview' ? (
+                <span className="integr8ly-label-preview integr8ly-walkthrough-labels-tag">preview</span>
+              ) : (
+                <span />
+              )}
+            </h4>
             <ul className="list-unstyled">{resourceLinks}</ul>
           </div>
         );


### PR DESCRIPTION
Adds GA and service status labels to the walkthrough resources panel (links) on the right while within a walkthrough.

![labels-to-walkthru](https://user-images.githubusercontent.com/39063664/47945729-55e35a00-deda-11e8-856a-f3cfe2ce986e.png)

Full disclosure - for service status, I could only get running/not running working, I could not figure out how to get 'provisioning' working correctly. 

My thoughts were to get these changes in, and file a bug re provisioning status. Alternatively, I can keep this PR open and merge up once that is figured out, if that is preferred.