### PR TITLE
PF4 Branch: Convert Labels to PF4 styling

### DIFF
--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -87,7 +87,7 @@ class InstalledAppsView extends React.Component {
       <li onClick={() => window.open(`${customApp.url}`, '_blank')} key={`openshift_console_${i}`} value={i}>
         <div className="integr8ly-installed-apps-view-title">
           <p>{customApp.name}</p>
-          <span className="integr8ly-label-community">custom</span>
+          <span className="pf-c-label integr8ly-label-community">custom</span>
         </div>
         <div className="integr8ly-state-ready">
           <Icon type="fa" name="bolt" /> &nbsp;Ready for use
@@ -107,7 +107,7 @@ class InstalledAppsView extends React.Component {
         >
           <div className="integr8ly-installed-apps-view-title">
             <p>{prettyName}</p>
-            <span className={`integr8ly-label-${gaStatus}`}>{gaStatus}</span>
+            <span className={`pf-c-label integr8ly-label-${gaStatus}`}>{gaStatus}</span>
           </div>
           {InstalledAppsView.getStatusForApp(app)}
           <small />

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -43,12 +43,12 @@ const TutorialDashboard = props => {
 
           <div className="integr8ly-walkthrough-labels">
             {walkthrough.community === true ? (
-              <span className="integr8ly-label-community integr8ly-walkthrough-labels-tag">community</span>
+              <span className="pf-c-label integr8ly-label-community integr8ly-walkthrough-labels-tag">community</span>
             ) : (
               <span />
             )}
             {walkthrough.preview === true ? (
-              <span className="integr8ly-label-preview integr8ly-walkthrough-labels-tag">preview</span>
+              <span className="pf-c-label integr8ly-label-preview integr8ly-walkthrough-labels-tag">preview</span>
             ) : (
               <span />
             )}

--- a/src/styles/application/_labels.scss
+++ b/src/styles/application/_labels.scss
@@ -5,6 +5,7 @@
     padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
     border: var(--pf-global--BorderWidth--sm) solid;
     border-color: $pf-color-black-300;
+    border-radius: var(--pf-global--BorderRadius--sm);
     background-color: $pf-color-black-300;
     color: $pf-color-black-900;
     font-size: var(--pf-global--FontSize--xs) !important; /* stylelint-disable-line declaration-no-important */
@@ -17,6 +18,7 @@
     padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
     border: var(--pf-global--BorderWidth--sm) solid;
     border-color: $pf-color-blue-200;
+    border-radius: var(--pf-global--BorderRadius--sm);
     background-color: $pf-color-blue-200;
     color: $pf-color-black-900;
     font-size: var(--pf-global--FontSize--xs) !important; /* stylelint-disable-line declaration-no-important */


### PR DESCRIPTION
Convert the existing PF3 labels to the PF4 labels. Once PF3 is removed, then the `labels.scss` file can be simplified.