### PR TITLE
Adding GitHub issue template to the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+Add a brief and meaningful description.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Steps to Reproduce
+1.
+2.
+
+## Specifications
+  - Browser:
+  - Browser version:
+  - OS: 
+
+## Additional Notes
+PS.: Add images and/or .gifs to illustrate the issue


### PR DESCRIPTION
It can be very useful to have an issue template in GitHub to ensure all the details of the issue are captured when it is created.

Please let me know if you think there should be additional information captured under specifications.