### PR TITLE
Adding GitHub PR template to the repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Motivation
+Add references to relevant tickets or a short description about what motivated you do it. (E.g Trello Card AND/OR GitHub ISSUE: https://github.com/integr8ly/tutorial-web-app/issues) 
+
+## What
+Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.)
+
+## Why
+Add an short answer for: Why it was done? (E.g The feature X was deprecated.)
+
+## How
+Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) 
+
+## Verification Steps
+Add detailed steps required to check this change. Following an example.
+ 
+1. Go to `XX >> YY >> SS`
+2. Create a new item `N` with the info `X`
+3. Try to edit this item 
+4. Check if in the left menu the feature X is not so long present.
+
+## Checklist:
+
+- [ ] Code has been tested locally by PR requester
+- [ ] Changes have been successfully verified by another team member 
+- [ ] Screen shots included (if applicable)
+
+## Progress
+
+- [x] Finished task
+- [ ] TODO
+
+## Additional Notes
+PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
+ 


### PR DESCRIPTION
## Motivation
No ticket - It can be very useful to have a PR template in GitHub to ensure all the details of the change are captured. This can be very useful when looking back at older issues and having all the context in the PR.

## What
Add GitHub PR template

## Why
Provide additional context on PRs

## How
Adding a PULL_REQUEST_TEMPLATE.md to a .github folder at the root of the project

## Verification Steps
None

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
