### PR TITLE
Reset Font Family for Step Indicator Text

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -465,15 +465,15 @@ class TaskPage extends React.Component {
                             step.infoVerifications.map(
                               (verification, v) =>
                                 verifications[step.infoVerifications[0]] === undefined ? (
-                                  <span className="far integr8ly-module-column--footer_status" key={v}>
+                                  <span className="integr8ly-module-column--footer_status" key={v}>
                                     {task + 1}.{l + 1}
                                   </span>
                                 ) : (
                                   <span
                                     className={
                                       verifications[step.infoVerifications[0]]
-                                        ? 'far integr8ly-module-column--footer_status-checked'
-                                        : 'far integr8ly-module-column--footer_status-unchecked'
+                                        ? 'integr8ly-module-column--footer_status-checked'
+                                        : 'integr8ly-module-column--footer_status-unchecked'
                                     }
                                     key={v}
                                   >


### PR DESCRIPTION
Remove `far` from the `<span>` that wrapper the step indicator text. This returns the text to use Open Sans as the font-family.
<img width="380" alt="screen shot 2018-11-08 at 11 58 01 am" src="https://user-images.githubusercontent.com/4032718/48214388-d4fae700-e34d-11e8-8934-1751c886384c.png">

<img width="345" alt="screen shot 2018-11-08 at 11 58 12 am" src="https://user-images.githubusercontent.com/4032718/48214383-d2988d00-e34d-11e8-91b5-89558a9b25fe.png">


Fixes issue https://github.com/integr8ly/tutorial-web-app/issues/226