### PR TITLE
Adjust margin of Installed Applications title

### DIFF
--- a/src/styles/application/_installedAppsView.scss
+++ b/src/styles/application/_installedAppsView.scss
@@ -14,7 +14,7 @@
 
     & h1 {
       flex-basis: 70%;
-      margin-top: 5px;
+      margin-top: 9px;
       color: $pf-color-black-800;
     }
 


### PR DESCRIPTION
The top margin of the Installed Applications title was not enough to align the title with that of "Start a Walkthrough". This caused the alignment of the list items to not match with that of the cards.

<img width="269" alt="screen shot 2018-11-08 at 12 02 31 pm" src="https://user-images.githubusercontent.com/4032718/48214661-6f5b2a80-e34e-11e8-805d-0f3d13380f8a.png">

Fixes issue https://github.com/integr8ly/tutorial-web-app/issues/224