### PR TITLE
Adjust alignment of Walkthrough and Resources titles

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -32,7 +32,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
     >
       <Col
         bsClass="col"
-        className="integr8ly-task-container"
+        className="integr8ly-task-container pf-u-mt-lg"
         componentClass="div"
         sm={9}
         xs={12}
@@ -164,7 +164,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
           />
         </ListView>
         <div
-          className="pull-right integr8ly-task-dashboard-time-to-completion"
+          className="pull-right integr8ly-task-dashboard-time-to-completion pf-u-mb-lg"
         >
           <Button
             active={false}

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -72,7 +72,7 @@ class TutorialPage extends React.Component {
               <PfMasthead />
             </Grid.Row>
             <Grid.Row>
-              <Grid.Col xs={12} sm={9} className="integr8ly-task-container">
+              <Grid.Col xs={12} sm={9} className="integr8ly-task-container pf-u-mt-lg">
                 <div className="integr8ly-task-dashboard-header">
                   <h1 className="pf-c-title pf-m-2xl">{thread.data.title}</h1>
                   <Button bsStyle="primary" onClick={e => this.getStarted(e, thread.data.id)}>
@@ -124,7 +124,7 @@ class TutorialPage extends React.Component {
                     />
                   ))}
                 </ListView>
-                <div className="pull-right integr8ly-task-dashboard-time-to-completion">
+                <div className="pull-right integr8ly-task-dashboard-time-to-completion pf-u-mb-lg">
                   <Button bsStyle="primary" onClick={e => this.getStarted(e, thread.data.id)}>
                     {t('tutorial.getStarted')}
                   </Button>

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -125,7 +125,7 @@
       top: 0;
       right: 0;
       bottom: 0;
-      padding-top: 40px;
+      padding-top: 60px;
       overflow-y: auto;
       background-color: $pf-color-black-150;
       border-left: var(--pf-global--BorderWidth--sm) solid;


### PR DESCRIPTION
Add a margin to the top of the Walkthrough tutorial title and increase padding of the Resources title to provide proper spacing from the navbar. Also increase the margin at the bottom of the page to keep the button from sitting on the edge of the viewport.

<img width="1920" alt="screen shot 2018-11-08 at 12 12 59 pm" src="https://user-images.githubusercontent.com/4032718/48215297-f4930f00-e34f-11e8-80bc-01b90ce731f2.png">

Fixes issue https://github.com/integr8ly/tutorial-web-app/issues/206
Fixes issue https://github.com/integr8ly/tutorial-web-app/issues/222