### PR TITLE
Fix spacing issue around time value in walkthrough intro

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -112,12 +112,19 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
           >
             <Icon
               name="clock"
+              style={
+                Object {
+                  "marginRight": 5,
+                }
+              }
               type="fa"
             />
-            <span
-              className="integr8ly-task-dashboard-time-to-completion_minutes"
-            >
-              tutorial.minutes
+            <span>
+              <span
+                className="integr8ly-task-dashboard-time-to-completion_minutes"
+              >
+                tutorial.minutes
+              </span>
             </span>
           </div>
         </h1>

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -96,10 +96,12 @@ class TutorialPage extends React.Component {
                 <h1 className="pf-c-title pf-m-2xl">
                   {t('tutorial.tasksToComplete')}
                   <div className="pull-right integr8ly-task-dashboard-time-to-completion">
-                    <Icon type="fa" name="clock" />
-                    <span className="integr8ly-task-dashboard-time-to-completion_minutes">
+                    <Icon type="fa" name="clock" style={{ marginRight: 5 }} />
+                    <span>
                       {thread.data.estimatedTime}
-                      {t('tutorial.minutes')}
+                      <span className="integr8ly-task-dashboard-time-to-completion_minutes">
+                        {t('tutorial.minutes')}
+                      </span>
                     </span>
                   </div>
                 </h1>


### PR DESCRIPTION
## Description

Fix the spacing between the time and word 'minutes' in the 'Tasks to complete this walkthrough' heading.

<img width="206" alt="screen shot 2018-11-08 at 4 47 45 pm" src="https://user-images.githubusercontent.com/4032718/48229555-6bdb9980-e376-11e8-9917-a251d50b6f12.png">

## Related Items

Fixes issue https://github.com/integr8ly/tutorial-web-app/issues/218
