### PR TITLE
add walkthrough manifest and init action

### DIFF
--- a/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
+++ b/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
@@ -4,6 +4,7 @@ A custom walkthrough that shows users how to do something.
 
 This walkthrough is so super awesome, wow! Everyone will learn so much from it.
 
+
 == First task
 
 This is the first task, super duper

--- a/public/walkthroughs/my-custom-walkthrough/walkthrough.json
+++ b/public/walkthroughs/my-custom-walkthrough/walkthrough.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "repos": [],
+    "services": []
+  }
+}

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -36,7 +36,7 @@ Breadcrumb.propTypes = {
   history: PropTypes.object,
   t: PropTypes.func.isRequired,
   threadName: PropTypes.string,
-  threadId: PropTypes.number,
+  threadId: PropTypes.string,
   taskPosition: PropTypes.number,
   totalTasks: PropTypes.number,
   homeClickedCallback: PropTypes.func

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -9,8 +9,7 @@ import { connect, reduxActions } from '../../redux';
 
 class LandingPage extends React.Component {
   componentDidMount() {
-    const { getProgress, getWalkthroughs, getCustomWalkthroughs } = this.props;
-    // getWalkthroughs('en');
+    const { getProgress, getCustomWalkthroughs } = this.props;
     getCustomWalkthroughs();
     getProgress();
   }
@@ -40,7 +39,7 @@ class LandingPage extends React.Component {
 
 LandingPage.propTypes = {
   getProgress: PropTypes.func,
-  getWalkthroughs: PropTypes.func,
+  getCustomWalkthroughs: PropTypes.func,
   middlewareServices: PropTypes.object,
   walkthroughServices: PropTypes.object,
   user: PropTypes.object
@@ -48,7 +47,7 @@ LandingPage.propTypes = {
 
 LandingPage.defaultProps = {
   getProgress: noop,
-  getWalkthroughs: noop,
+  getCustomWalkthroughs: noop,
   middlewareServices: { data: {} },
   walkthroughServices: { data: {} },
   user: { userProgress: {} }

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -12,7 +12,11 @@ import WalkthroughResources from '../../../components/walkthroughResources/walkt
 import { prepareWalkthroughNamespace, walkthroughs, WALKTHROUGH_IDS } from '../../../services/walkthroughServices';
 import { buildNamespacedServiceInstanceName } from '../../../common/openshiftHelpers';
 import { getDocsForWalkthrough } from '../../../common/docsHelpers';
-import { parseWalkthroughAdoc, WalkthroughVerificationBlock, WalkthroughTextBlock } from '../../../common/walkthroughHelpers';
+import {
+  parseWalkthroughAdoc,
+  WalkthroughVerificationBlock,
+  WalkthroughTextBlock
+} from '../../../common/walkthroughHelpers';
 
 class TaskPage extends React.Component {
   state = { task: 0, verifications: {} };
@@ -20,11 +24,13 @@ class TaskPage extends React.Component {
   componentDidMount() {
     const {
       getWalkthrough,
+      initWalkthrough,
       match: {
         params: { id }
       }
     } = this.props;
     getWalkthrough(id);
+    initWalkthrough(id);
     const { prepareWalkthroughOne, prepareWalkthroughOneA, prepareWalkthroughTwo } = this.props;
     if (this.props.match.params.id === WALKTHROUGH_IDS.ONE) {
       prepareWalkthroughOne(this.props.middlewareServices.amqCredentials);
@@ -89,7 +95,7 @@ class TaskPage extends React.Component {
       }
     });
     return verificationIds;
-  }
+  };
 
   getTotalSteps = tasks => {
     let totalSteps = 0;
@@ -200,8 +206,8 @@ class TaskPage extends React.Component {
 
   renderVerificationBlock(id, block) {
     const { t } = this.props;
-    let isNoChecked = this.state.verifications[id] !== undefined && !this.state.verifications[id];
-    let isYesChecked = this.state.verifications[id] !== undefined && !!this.state.verifications[id];
+    const isNoChecked = this.state.verifications[id] !== undefined && !this.state.verifications[id];
+    const isYesChecked = this.state.verifications[id] !== undefined && !!this.state.verifications[id];
     return (
       <Alert type="info" className="integr8ly-module-column--steps_alert-blue" key={id}>
         <strong>{t('task.verificationTitle')}</strong>
@@ -226,12 +232,9 @@ class TaskPage extends React.Component {
             >
               No
             </Radio>
-            {isNoChecked &&
-              block.hasFailBlock &&
-              <div dangerouslySetInnerHTML={{ __html: block.failBlock.html }}/>}
+            {isNoChecked && block.hasFailBlock && <div dangerouslySetInnerHTML={{ __html: block.failBlock.html }} />}
             {isYesChecked &&
-              block.hasSuccessBlock &&
-              <div dangerouslySetInnerHTML={{ __html: block.successBlock.html }}/>}
+              block.hasSuccessBlock && <div dangerouslySetInnerHTML={{ __html: block.successBlock.html }} />}
           </React.Fragment>
         }
       </Alert>
@@ -240,15 +243,15 @@ class TaskPage extends React.Component {
 
   render() {
     const attrs = this.getDocsAttributes();
-    const { t, thread } = this.props;
+    const { t, thread, manifest } = this.props;
     const { verifications } = this.state;
-    
-    if (thread.pending) {
+
+    if (thread.pending || manifest.pending) {
       // todo: loading state
       return null;
     }
 
-    if (thread.error) {
+    if (thread.error || manifest.error) {
       return (
         <div>
           <PfMasthead />
@@ -297,8 +300,11 @@ class TaskPage extends React.Component {
                         <h3>{step.title}</h3>
                         {step.blocks.map((block, j) => (
                           <React.Fragment key={`${i}-${j}`}>
-                            {block instanceof WalkthroughTextBlock && <div dangerouslySetInnerHTML={{ __html: block.html }} />}
-                            {block instanceof WalkthroughVerificationBlock && this.renderVerificationBlock(`${i}-${j}`, block)}
+                            {block instanceof WalkthroughTextBlock && (
+                              <div dangerouslySetInnerHTML={{ __html: block.html }} />
+                            )}
+                            {block instanceof WalkthroughVerificationBlock &&
+                              this.renderVerificationBlock(`${i}-${j}`, block)}
                           </React.Fragment>
                         ))}
                       </React.Fragment>
@@ -436,8 +442,10 @@ TaskPage.propTypes = {
   prepareWalkthroughOneA: PropTypes.func,
   prepareWalkthroughTwo: PropTypes.func,
   thread: PropTypes.object,
-  //user: PropTypes.object,
-  getWalkthrough: PropTypes.func
+  manifest: PropTypes.object,
+  // user: PropTypes.object,
+  getWalkthrough: PropTypes.func,
+  initWalkthrough: PropTypes.func
 };
 
 TaskPage.defaultProps = {
@@ -462,8 +470,10 @@ TaskPage.defaultProps = {
   prepareWalkthroughOneA: noop,
   prepareWalkthroughTwo: noop,
   thread: null,
-  //user: null,
-  getWalkthrough: noop
+  manifest: null,
+  // user: null,
+  getWalkthrough: noop,
+  initWalkthrough: noop
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -474,7 +484,8 @@ const mapDispatchToProps = dispatch => ({
   getProgress: progress => dispatch(reduxActions.userActions.getProgress()),
   prepareWalkthroughTwo: () => prepareWalkthroughNamespace(dispatch, walkthroughs.two, null),
   setProgress: progress => dispatch(reduxActions.userActions.setProgress(progress)),
-  getWalkthrough: id => dispatch(reduxActions.threadActions.getCustomThread(id))
+  getWalkthrough: id => dispatch(reduxActions.threadActions.getCustomThread(id)),
+  initWalkthrough: id => dispatch(reduxActions.threadActions.initCustomThread(id))
 });
 
 const mapStateToProps = state => ({

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -4,7 +4,6 @@ import { withRouter } from 'react-router-dom';
 import { translate } from 'react-i18next';
 import { noop, Button, Grid, Icon, ListView } from 'patternfly-react';
 import { connect, reduxActions } from '../../redux';
-import AsciiDocTemplate from '../../components/asciiDocTemplate/asciiDocTemplate';
 import PfMasthead from '../../components/masthead/masthead';
 import WalkthroughResources from '../../components/walkthroughResources/walkthroughResources';
 import { parseWalkthroughAdoc } from '../../common/walkthroughHelpers';
@@ -163,7 +162,8 @@ TutorialPage.propTypes = {
     params: PropTypes.object
   }),
   getThread: PropTypes.func,
-  thread: PropTypes.object
+  thread: PropTypes.object,
+  getWalkthrough: PropTypes.func
 };
 
 TutorialPage.defaultProps = {
@@ -177,7 +177,8 @@ TutorialPage.defaultProps = {
     params: {}
   },
   getThread: noop,
-  thread: null
+  thread: null,
+  getWalkthrough: noop
 };
 
 const mapDispatchToProps = dispatch => ({

--- a/src/redux/actions/threadActions.js
+++ b/src/redux/actions/threadActions.js
@@ -11,4 +11,9 @@ const getCustomThread = id => ({
   payload: threadServices.getCustomThread(id)
 });
 
-export { getThread, getCustomThread };
+const initCustomThread = id => ({
+  type: threadTypes.INIT_THREAD,
+  payload: threadServices.initCustomThread(id)
+});
+
+export { getThread, getCustomThread, initCustomThread };

--- a/src/redux/constants/threadConstants.js
+++ b/src/redux/constants/threadConstants.js
@@ -1,3 +1,4 @@
 const GET_THREAD = 'GET_THREAD';
+const INIT_THREAD = 'INIT_THREAD';
 
-export { GET_THREAD };
+export { GET_THREAD, INIT_THREAD };

--- a/src/redux/reducers/threadReducers.js
+++ b/src/redux/reducers/threadReducers.js
@@ -9,6 +9,14 @@ const initialState = {
     pending: false,
     fulfilled: false,
     data: {}
+  },
+  manifest: {
+    error: false,
+    errorStatus: null,
+    errorMessage: null,
+    pending: false,
+    fulfilled: false,
+    data: {}
   }
 };
 
@@ -55,7 +63,46 @@ const threadReducers = (state = initialState, action) => {
           initialState
         }
       );
+    case REJECTED_ACTION(threadTypes.INIT_THREAD):
+      return setStateProp(
+        'manifest',
+        {
+          error: action.error,
+          errorMessage: action.payload.message
+        },
+        {
+          state,
+          initialState
+        }
+      );
 
+    // Error/rejected
+    case PENDING_ACTION(threadTypes.INIT_THREAD):
+      return setStateProp(
+        'manifest',
+        {
+          pending: true
+        },
+        {
+          state,
+          initialState
+        }
+      );
+
+    // Success/Fulfilled
+    case FULFILLED_ACTION(threadTypes.INIT_THREAD):
+      return setStateProp(
+        'manifest',
+        {
+          pending: false,
+          fulfilled: true,
+          data: action.payload.data
+        },
+        {
+          state,
+          initialState
+        }
+      );
     default:
       return state;
   }

--- a/src/services/threadServices.js
+++ b/src/services/threadServices.js
@@ -15,4 +15,11 @@ const getCustomThread = id =>
     })
   );
 
-export { getThread, getCustomThread };
+const initCustomThread = id =>
+  axios(
+    serviceConfig({
+      url: `/walkthroughs/${id}/walkthrough.json`
+    })
+  );
+
+export { getThread, getCustomThread, initCustomThread };


### PR DESCRIPTION
@aidenkeating since you also need the walkthrough manifest json file to work on the service dependencies i thought i'd send a PR already.

This requests the json file in `task.js` and assigns it to `props.manifest`. I will continue to add the server call to init the repos.

Also fixes most of the linting issues. Build will still fail though because there are still two linter issues left (code you're currently working on so i'd rather not change).