### PR TITLE
Cleanup loading screen for variable viewport sizes

### DIFF
--- a/src/components/loadingScreen/loadingScreen.js
+++ b/src/components/loadingScreen/loadingScreen.js
@@ -20,11 +20,7 @@ class LoadingScreen extends React.Component {
     return (
       <React.Fragment>
         <div className="integr8ly-loadingscreen">
-          {this.props.showBackdrop === true && (
-            <div className="integr8ly-loadingscreen-backdrop">
-              <div className="integr8ly-loadingscreen-logo" />
-            </div>
-          )}
+          <div className="integr8ly-loadingscreen-logo" />
           <div className="integr8ly-loadingscreen-spacer">
             <object className="integr8ly-loadingscreen-throbber" data={this.props.throbberImage} type="image/svg+xml">
               <img
@@ -50,7 +46,6 @@ class LoadingScreen extends React.Component {
 }
 
 LoadingScreen.propTypes = {
-  showBackdrop: PropTypes.bool,
   progress: PropTypes.number,
   staticThrobberImage: PropTypes.string,
   throbberImage: PropTypes.string,
@@ -61,7 +56,6 @@ LoadingScreen.propTypes = {
 
 LoadingScreen.defaultProps = {
   hideDelay: 2500,
-  showBackdrop: true,
   progress: 0,
   staticThrobberImage: require('./resources/StartingServices_Final.png'),
   throbberImage: require('./resources/StartingServices_Final.svg'),

--- a/src/styles/application/_loading.scss
+++ b/src/styles/application/_loading.scss
@@ -2,31 +2,32 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 0;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background-size: cover;
+  background-color: var(--pf-global--info-color--200);
+  background-image: url("../../img/provisioning-bg.png");
+  z-index: 5;
 
   &-spacer {
-    align-self: center;
-    min-height: 465px;
-    min-width: 380px;
-    margin-top: 75px;
-    z-index: 5;
+    @media (max-width: $pf-global--breakpoint--sm), (max-height: 550px) { // set height at max-width of 576px OR max-height of 550px
+      min-height: auto;
+    }
+  }
+
+  &-throbber {
+    @media (max-width: $pf-global--breakpoint--sm), (max-height: 550px) { // set display: none at max-width of 576px OR max-height of 550px
+      display: none;
+    }
   }
 
   &-throbber-static {
     height: 380px;
     width: 465px;
-  }
-
-  &-backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    background-size: cover;
-    background-color: var(--pf-global--info-color--200);
-    background-image: url("../../img/provisioning-bg.png");
-    z-index: 5;
   }
 
   &-logo {
@@ -42,15 +43,11 @@
   &-text {
     color: $pf-color-white;
     text-align: center;
-    z-index: 5;
   }
 
   &-progress {
     display: flex;
-    justify-content: center;
     width: 65%;
-    margin: 0 auto;
-    z-index: 5;
   }
 
   &-progressbar {


### PR DESCRIPTION
## Description
Adjust the loading screen to render properly on variable viewport sizes.
- Hide the animated SVG on devices with either a width smaller than `576px` or height smaller than `500px`
- Auto-center text vertically when the SVG is not rendered

- Tested on viewports from `<500px x <500px` up to `3800px x 2000px`

## Related Items
- issue #238 