### PR TITLE
Add attributes to asciidoc and allow task resources to be specified

### DIFF
--- a/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
+++ b/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
@@ -1,5 +1,3 @@
-:numbered:
-
 = A custom walkthrough
 
 A custom walkthrough that shows users how to do something.
@@ -62,6 +60,16 @@ Heck 'em!
 
 This is a Che route, I hope: {che-url}
 
+[type=taskResource]
+=== Some resources
+
+Woop woop doop doop
+
+[type=taskResource]
+=== Some other resources
+
+This is super duper
+
 [time=15]
 == Second task
 
@@ -77,3 +85,4 @@ Well that should work too!
 === Ok, now I'll add in a step, and it'll work?
 
 Yep, only h3's are treated as steps . . . that's pretty cool if you ask me
+

--- a/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
+++ b/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
@@ -1,88 +1,101 @@
 = A custom walkthrough
 
-A custom walkthrough that shows users how to do something.
+This is the first sentence of the walkthrough's preamble. It will be used as the
+short description for the walkthrough.
 
-This walkthrough is so super awesome, wow! Everyone will learn so much from it.
+These lines will be included in the long description of the walkthrough. Normally
+this content will be shown on the overview page for a walkthough. However, it is
+excluded from the short description.
 
-fdsfds
-fdsfdsf
-
-
-fdsfdsfds
-
-fd
-sfdsf
-dsf
+To start a task we need to use a h2 heading.
 
 == First task
 
-This is the first task, super duper
+This is the overview for the first task in the walkthrough.
 
-Some stuff will be done in this task
+It can be spread over multiple paragraphs. To start a step we need to use a h3
+heading.
 
-=== This is the first step
+=== Custom blocks
 
-This is the first task, super duper
-
-The first step needs you to do 
+This is the content of the first step. Steps can contain any asciidoc. However,
+it can also contain a number of walkthrough-specific blocks. For example, below
+is a verification block. This is a paragraph that has been annotated with
+`[type=verification]`.
 
 [type=verification]
+This block will render as a verification box with a yes/no checkbox.
++
 . Check this thing.
 . Check that thing
 
-=== This is the second step
+=== More custom blocks
 
-The second step needs you to do this other thing.
+This is the second step of the first task. It is started with a h3 heading. Below
+we'll include some arbitrary asciidoc, a list, with a verification block in the
+middle of it. We need to use `[start=3]` annotation to continue the numbering of
+the list that the verification block has broken.
 
-. One
-. Two
+Also in this step is the two other types of verification block. These are used to
+define content that is shown when a user selects either `yes` or `no` on the
+checkbox. These are blocks annotated with `[type=verificationSuccess]` and
+`[type=verificationFail]` respectively.
+
+. First item
+. Second item
 
 [type=verification]
-Check that thing.
+A second verification block.
 
 [start=3]
-. Three
-. Four
+. Third item, I should have a 3 beside me
+. Fourth item
 
 [type=verificationFail]
-Breathe. Calm down. Try again. Contact your admin.
+A message to show when the user clicks `no`.
 
 [type=verificationSuccess]
-Well done. You're clearly a good person.
+A message to show when the user clicks `yes`.
 
-Woop woop doop doop
+Note that each verification block is a single block. Meaning there cannot be
+newlines in the block itself. This can be worked around using `+` on newlines or
+by any other means that maintains a single block of text.
 
-[type=verification]
-Check one more thing
+=== Using walkthrough attributes
 
-[type=verificationFail]
-Heck 'em!
+By default, a number of attributes about the environment will be provided to us.
+These attributes will include information such as the URLs of services. One of
+these attributes is the URL of Eclipse Che running in the cluster. This attribute
+is named `che-url`. We can access it like any other attribute in asciidoc, by
+surrounding it with `{}`.
 
-This is a Che route, I hope: {che-url}
+For example, here is the Che URL: `{che-url}`.
 
 [type=taskResource]
-=== Some resources
+=== A task resource
 
-Woop woop doop doop
-
-[type=taskResource]
-=== Some other resources
-
-This is super duper
+A step-level annotation can be used to add resources to the right-hand side of
+the walkthrough in the extra resources section. Any step annotated with
+`[type=taskResource]` will be included on the right-hand side instead of being
+included in the main content. Note that verification blocks will not work in here,
+these steps are treated as raw asciidoc.
 
 [time=15]
 == Second task
 
-This task has no inner steps. Wow, what a cool feature.
+This is the second task of the walkthrough. On this task we have specified a time
+in minutes that the task will take. This can be done using the `[time=15]` annotation,
+where `15` is the amount of minutes the task will take. This information will be
+used when displaying any overview pages for the walkthrough. If a `time` is not
+set on a task, it will be treated as `0` minutes.
 
-It's just loads of text so I can copy/paste all the jazz I want and it'll just
-render ok. Super duper!
+Tasks do not need to be split into steps. They can just be raw asciidoc dropped into
+the file. So as long as we do not include a h3 section in this task, there will be
+no steps in the task.
 
-==== What about adding a strange heading?
+==== A h4 heading
 
-Well that should work too!
-
-=== Ok, now I'll add in a step, and it'll work?
-
-Yep, only h3's are treated as steps . . . that's pretty cool if you ask me
+Only h3 headings are treated as steps, so adding in a h4 heading is treated as
+raw asciidoc. This also means that verification blocks cannot be specified in
+these blocks.
 

--- a/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
+++ b/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
@@ -1,28 +1,50 @@
+:numbered:
+
 = A custom walkthrough
 
 A custom walkthrough that shows users how to do something.
 
 This walkthrough is so super awesome, wow! Everyone will learn so much from it.
 
+fdsfds
+fdsfdsf
+
+
+fdsfdsfds
+
+fd
+sfdsf
+dsf
 
 == First task
 
 This is the first task, super duper
 
+Some stuff will be done in this task
+
 === This is the first step
+
+This is the first task, super duper
 
 The first step needs you to do 
 
 [type=verification]
-- Check this thing.
-- Check that thing
+. Check this thing.
+. Check that thing
 
 === This is the second step
 
 The second step needs you to do this other thing.
 
+. One
+. Two
+
 [type=verification]
 Check that thing.
+
+[start=3]
+. Three
+. Four
 
 [type=verificationFail]
 Breathe. Calm down. Try again. Contact your admin.
@@ -38,13 +60,20 @@ Check one more thing
 [type=verificationFail]
 Heck 'em!
 
+This is a Che route, I hope: {che-url}
+
 [time=15]
 == Second task
 
-=== Second task, first step
+This task has no inner steps. Wow, what a cool feature.
 
-Bleep.
+It's just loads of text so I can copy/paste all the jazz I want and it'll just
+render ok. Super duper!
 
-=== Second task, second step
+==== What about adding a strange heading?
 
-Bloop.
+Well that should work too!
+
+=== Ok, now I'll add in a step, and it'll work?
+
+Yep, only h3's are treated as steps . . . that's pretty cool if you ask me

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -3,12 +3,17 @@ import { DEFAULT_SERVICES, getDashboardUrl } from '../common/serviceInstanceHelp
 import { buildValidProjectNamespaceName, cleanUsername } from './openshiftHelpers';
 
 const getDocsForWalkthrough = (walkthrough, middlewareServices, walkthroughServices) => {
-  if (!walkthrough || window.OPENSHIFT_CONFIG.mockData) {
+  if (window.OPENSHIFT_CONFIG.mockData) {
     return {};
   }
 
   const userAttrs = getUserAttrs(walkthrough, middlewareServices.provisioningUser);
   const middlewareAttrs = getMiddlwareServiceUrls(walkthrough, middlewareServices);
+
+  if (!walkthrough) {
+    return Object.assign({}, userAttrs, middlewareAttrs);
+  }
+
   const walkthroughAttrs = getWalkthroughSpecificAttrs(walkthrough, middlewareServices, walkthroughServices);
 
   return Object.assign({}, middlewareAttrs, walkthroughAttrs, userAttrs, { 'walkthrough-id': walkthrough.id });
@@ -17,7 +22,7 @@ const getDocsForWalkthrough = (walkthrough, middlewareServices, walkthroughServi
 const getUserAttrs = (walkthrough, username) => ({
   'openshift-host': window.OPENSHIFT_CONFIG.masterUri,
   'project-namespace': buildValidProjectNamespaceName(username, 'walkthrough-projects'),
-  'walkthrough-namespace': buildValidProjectNamespaceName(username, walkthrough.namespaceSuffix),
+  'walkthrough-namespace': buildValidProjectNamespaceName(username, (walkthrough && walkthrough.namespaceSuffix) || buildValidProjectNamespaceName(username, 'walkthrough-projects')),
   'user-username': username,
   'user-sanitized-username': cleanUsername(username)
 });
@@ -72,10 +77,10 @@ const getMiddlwareServiceUrls = (walkthrough, middlewareServices) => {
     'che-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.CHE),
     'api-management-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE)
   };
-  if (walkthrough.id === WALKTHROUGH_IDS.ONE) {
+  if (walkthrough && walkthrough.id === WALKTHROUGH_IDS.ONE) {
     defaultServices['messaging-url'] = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.AMQ);
   }
-  if (walkthrough.id === WALKTHROUGH_IDS.ONE_A) {
+  if (walkthrough && walkthrough.id === WALKTHROUGH_IDS.ONE_A) {
     defaultServices['messaging-url'] = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.ENMASSE);
   }
   return defaultServices;

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -22,7 +22,10 @@ const getDocsForWalkthrough = (walkthrough, middlewareServices, walkthroughServi
 const getUserAttrs = (walkthrough, username) => ({
   'openshift-host': window.OPENSHIFT_CONFIG.masterUri,
   'project-namespace': buildValidProjectNamespaceName(username, 'walkthrough-projects'),
-  'walkthrough-namespace': buildValidProjectNamespaceName(username, (walkthrough && walkthrough.namespaceSuffix) || buildValidProjectNamespaceName(username, 'walkthrough-projects')),
+  'walkthrough-namespace': buildValidProjectNamespaceName(
+    username,
+    (walkthrough && walkthrough.namespaceSuffix) || buildValidProjectNamespaceName(username, 'walkthrough-projects')
+  ),
   'user-username': username,
   'user-sanitized-username': cleanUsername(username)
 });

--- a/src/common/walkthroughHelpers.js
+++ b/src/common/walkthroughHelpers.js
@@ -180,7 +180,11 @@ class WalkthroughResourceStep {
   }
 
   static canConvert(adoc) {
-    return adoc.context === CONTEXT_SECTION && adoc.level === BLOCK_LEVEL_STEP && adoc.getAttribute(BLOCK_ATTR_TYPE) === BLOCK_TYPE_TASK_RESOURCE;
+    return (
+      adoc.context === CONTEXT_SECTION &&
+      adoc.level === BLOCK_LEVEL_STEP &&
+      adoc.getAttribute(BLOCK_ATTR_TYPE) === BLOCK_TYPE_TASK_RESOURCE
+    );
   }
 
   static fromAdoc(adoc) {
@@ -271,12 +275,12 @@ class Walkthrough {
   }
 }
 
-const getNumberedTitle = (block) => {
+const getNumberedTitle = block => {
   if (block.context === CONTEXT_DOCUMENT || block.parent.context === CONTEXT_DOCUMENT) {
     return `${block.numbered ? block.number : null}`;
   }
   return `${getNumberedTitle(block.parent)}.${block.numbered ? block.number : null}`;
-}
+};
 
 const parseWalkthroughAdoc = (rawAdoc, attrs) => {
   const parsedAdoc = parseAdoc(rawAdoc, attrs);

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -13,7 +13,7 @@ class WalkthroughResources extends React.Component {
   }
 
   componentDidMount() {
-    this.buildResourceList();
+    //this.buildResourceList();
   }
 
   mapServiceLinks() {
@@ -101,8 +101,8 @@ class WalkthroughResources extends React.Component {
     return (
       <div>
         <h4 className="integr8ly-helpful-links-heading">Walkthrough Resources</h4>
-        {this.state.resourceList}
-        <div className={this.state.resourceList ? 'hidden' : 'show'}>No resources available.</div>
+        {this.props.resources.map((resource, i) => <div key={i} dangerouslySetInnerHTML={{ __html: resource.html }}/>)}
+        <div className={this.props.resources.length !== 0 ? 'hidden' : 'show'}>No resources available.</div>
       </div>
     );
   }

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -13,7 +13,7 @@ class WalkthroughResources extends React.Component {
   }
 
   componentDidMount() {
-    //this.buildResourceList();
+    // this.buildResourceList();
   }
 
   mapServiceLinks() {
@@ -101,7 +101,9 @@ class WalkthroughResources extends React.Component {
     return (
       <div>
         <h4 className="integr8ly-helpful-links-heading">Walkthrough Resources</h4>
-        {this.props.resources.map((resource, i) => <div key={i} dangerouslySetInnerHTML={{ __html: resource.html }}/>)}
+        {this.props.resources.map((resource, i) => (
+          <div key={i} dangerouslySetInnerHTML={{ __html: resource.html }} />
+        ))}
         <div className={this.props.resources.length !== 0 ? 'hidden' : 'show'}>No resources available.</div>
       </div>
     );

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -435,7 +435,7 @@ class TaskPage extends React.Component {
               <Grid.Col sm={3} className="integr8ly-module-frame">
                 {/* <h4 className="integr8ly-helpful-links-heading">Walkthrough Diagram</h4>
                 <img src="/images/st0.png" className="img-responsive" alt="integration" /> */}
-                <WalkthroughResources resources={thread.data.resources} />
+                <WalkthroughResources resources={threadTask.resources} />
               </Grid.Col>
             </Grid.Row>
           </Grid>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -249,9 +249,9 @@ class TaskPage extends React.Component {
     if (block instanceof WalkthroughTextBlock) {
       return (
         <React.Fragment key={id}>
-          <div dangerouslySetInnerHTML={{ __html: block.html}}/>
+          <div dangerouslySetInnerHTML={{ __html: block.html }} />
         </React.Fragment>
-      )
+      );
     }
     if (block instanceof WalkthroughStep) {
       return (
@@ -259,15 +259,12 @@ class TaskPage extends React.Component {
           <h3>{block.title}</h3>
           {block.blocks.map((block, i) => (
             <React.Fragment key={`${id}-${i}`}>
-              {block instanceof WalkthroughTextBlock && (
-                <div dangerouslySetInnerHTML={{ __html: block.html }} />
-              )}
-              {block instanceof WalkthroughVerificationBlock &&
-                this.renderVerificationBlock(`${id}-${i}`, block)}
+              {block instanceof WalkthroughTextBlock && <div dangerouslySetInnerHTML={{ __html: block.html }} />}
+              {block instanceof WalkthroughVerificationBlock && this.renderVerificationBlock(`${id}-${i}`, block)}
             </React.Fragment>
           ))}
         </React.Fragment>
-      )
+      );
     }
     return null;
   }

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -93,7 +93,7 @@ class TutorialPage extends React.Component {
                   </Button>
                 </div>
                 {this.renderPrereqs(thread)}
-                <div dangerouslySetInnerHTML={{ __html: parsedThread.descriptionHTML }} />
+                <div dangerouslySetInnerHTML={{ __html: parsedThread.preamble }} />
                 {/* <AsciiDocTemplate
                   adoc={thread}
                   attributes={Object.assign({}, thread.data.attributes)}


### PR DESCRIPTION
## What
* Add a new `type=taskResource` annotation for steps in a task, it'll get included on the right-hand side.
* Manually add any numbering where needed if numbering is enabled for that section.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
- [ ] Screen shots included (if applicable)

## Progress

- [x] Allow resources to be specified on the right-hand side
- [x] Inject attributes into the Asciidoc
- [x] Allow no steps to be specified in a task
- [x] Show title for tasks on the task page

## Additional Notes
PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
