### PR TITLE
Fix jumping loading screen animation

### DIFF
--- a/src/styles/application/_loading.scss
+++ b/src/styles/application/_loading.scss
@@ -20,6 +20,9 @@
   }
 
   &-throbber {
+    min-height: 380px;
+    min-width: 464px;
+
     @media (max-width: $pf-global--breakpoint--sm), (max-height: 550px) { // set display: none at max-width of 576px OR max-height of 550px
       display: none;
     }


### PR DESCRIPTION
## Motivation
After an initial fix, the loading screen animation still jumps at slower rendering speeds.

This is related to Issue https://github.com/integr8ly/tutorial-web-app/issues/215.

## What
Set a `min-height` and `min-width` property for the animation container that matches the size of the animation.

## How
See **What**

## Verification Steps
 
Enter a Walkthrough to see the animation screen. Refresh at different browser window sizes.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
 
