### PR TITLE
Adjust height of App List to eliminate overlap

### DIFF
--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -20,18 +20,20 @@ class LandingPage extends React.Component {
       <div>
         <PfMasthead />
         <LandingPageMastHead />
-        <section className="integr8ly-landing-page-tutorial-dashboard-section">
-          <TutorialDashboard
-            className="integr8ly-landing-page-tutorial-dashboard-section-left"
-            userProgress={user.userProgress.threads}
-            walkthroughs={walkthroughServices.data.threads}
-          />
-          <InstalledAppsView
-            className="integr8ly-landing-page-tutorial-dashboard-section-right"
-            apps={Object.values(middlewareServices.data)}
-            customApps={middlewareServices.customServices}
-          />
-        </section>
+        <main>
+          <section className="integr8ly-landing-page-tutorial-dashboard-section">
+            <TutorialDashboard
+              className="integr8ly-landing-page-tutorial-dashboard-section-left"
+              userProgress={user.userProgress.threads}
+              walkthroughs={walkthroughServices.data.threads}
+            />
+            <InstalledAppsView
+              className="integr8ly-landing-page-tutorial-dashboard-section-right"
+              apps={Object.values(middlewareServices.data)}
+              customApps={middlewareServices.customServices}
+            />
+          </section>
+        </main>
       </div>
     );
   }

--- a/src/styles/application/_installedAppsView.scss
+++ b/src/styles/application/_installedAppsView.scss
@@ -1,5 +1,8 @@
 .integr8ly-installed-apps-view {
+  height: 100vh;
   margin-bottom: 0;
+  border-bottom: 0;
+  box-shadow: none;
 
   @media (max-width: 1091px) {
     width: 100%;

--- a/src/styles/application/_tutorialDashboard.scss
+++ b/src/styles/application/_tutorialDashboard.scss
@@ -1,6 +1,9 @@
 .integr8ly-tutorial-dashboard {
+  height: 100vh;
   margin-bottom: 0;
   background-color: $pf-color-black-150;
+  border: 0;
+  box-shadow: none;
 
   @media (max-width: 1091px) {
     width: 100%;


### PR DESCRIPTION
## Motivation
Fix issue https://github.com/integr8ly/tutorial-web-app/issues/236

## What
Adjust the height properties of the content containers for the cards and the application list. Remove the bottom borders from the panel components.

## Why
Fix issue https://github.com/integr8ly/tutorial-web-app/issues/236

## How
CSS property adjustments

## Verification Steps

1. Open up the webapp
2. Set the browser height so that the content scrolls
3. Scroll to the bottom of the page.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
- [X] Screen shots included (if applicable)

## Progress

- [x] Finished task

## Additional Notes
![screen shot 2018-11-13 at 9 45 54 am](https://user-images.githubusercontent.com/4032718/48420878-5e812f00-e729-11e8-9279-b9ec85f3dbb5.png)

 
