### PR TITLE
Fix alignment of card footer items in Edge

### DIFF
--- a/src/styles/application/_tutorialCard.scss
+++ b/src/styles/application/_tutorialCard.scss
@@ -18,18 +18,12 @@
   }
 
   &-pf-footer {
+    display: flex;
+    justify-content: space-between;
     position: absolute;
     width: 100%;
     bottom: 0;
     padding-bottom: 20px;
-    display: flex;
-
-    .progress-bar-table { /* stylelint-disable-line selector-class-pattern */
-      display: table;
-      width: auto;
-      float: right;
-      margin-left: 50px;
-    }
 
     .progress { /* stylelint-disable-line selector-class-pattern */
       display: table-cell;


### PR DESCRIPTION
## Motivation
Trello card: https://trello.com/c/0IcMgL7m/349-in-edge-the-card-progress-indicator-is-not-aligned-or-spaced-correctly

## What
Using Microsoft Edge, the progress indicator was not aligned properly in the footer.

## Why
Fix alignment issues of the progress indicator, in relation to the time indicator.

## How
Add CSS to justify the content along the grid.

## Verification Steps
 
1. Load the webapp in Microsoft Edge
2. Start a walkthrough (if one is not already in process)
3. Return to the dashboard to see the progress indicator in the card

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
- [X] Screen shots included (if applicable)

## Progress

- [x] Finished task

## Additional Notes

![screen shot 2018-11-13 at 1 04 42 pm](https://user-images.githubusercontent.com/4032718/48433599-79fa3300-e745-11e8-8ac6-83e64d017e1e.png)
 
