### PR TITLE
Round the percentages on the provisioning screen

### DIFF
--- a/src/components/provisioning/provisioning.js
+++ b/src/components/provisioning/provisioning.js
@@ -77,7 +77,7 @@ function buildProvisioningScreen(WrappedComponent) {
     }
 
     static loadingScreen(services, servicesToProvision) {
-      const provisionProgress = Provisioning.getMiddlwareServiceProgress(services, servicesToProvision);
+      const provisionProgress = Math.ceil(Provisioning.getMiddlwareServiceProgress(services, servicesToProvision));
       return (
         <div className="integr8ly-loadingscreen">
           <div className="integr8ly-loadingscreen-backdrop">


### PR DESCRIPTION
## Motivation

This is a cherry-pick of some changes made to a DIL specific branch. This should probably be on master to avoid things like a `66.666666666%` progress on the provisioning screen when a user decides to only provision 3 services.

@jasonmadigan @david-martin Mind taking a look?
