### PR TITLE
Add provisioning status to resources

### DIFF
--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -32,7 +32,7 @@ class WalkthroughResources extends React.Component {
         } else {
           const gaStatusApi = app.productDetails.gaStatus;
           url = getDashboardUrl(app);
-          const statusIcon = this.assignSerivceIcon(app);
+          const statusIcon = WalkthroughResources.assignSerivceIcon(app);
 
           if (gaStatusApi) {
             gaStatus = gaStatusApi;
@@ -56,8 +56,7 @@ class WalkthroughResources extends React.Component {
     return null;
   }
 
-  assignSerivceIcon(app) {
-    const { resources, middlewareServices } = this.props;
+  static assignSerivceIcon(app) {
     const provisioningStatus = <Icon className="integr8ly-state-provisioining" type="fa" name="chart-pie" />;
     const readyStatus = <Icon className="integr8ly-state-ready" type="fa" name="bolt" />;
     const unavailableStatus = <Icon className="integr8ly-state-unavailable" type="pf" name="error-circle-o" />;


### PR DESCRIPTION
## Motivation
Fixes https://github.com/integr8ly/tutorial-web-app/issues/232

## What and Why
Fixes an issue in which the original implementation only accounted for services that were available or unavailable, ignoring those that were in the process of being provisioned.

## How
Call the middleware services API for each service when building the resource list.

## Verification Steps
If you are testing using mock data, you will need to follow the instructions in the following markdown file to add services with a state of provisioning or unavailable, unless you have a live system that is set up with services with these statuses:

https://gist.github.com/aidenkeating/c6754e121fb3bca97a33ebb180c86199
 
1. Start a walkthrough.
2. In the walkthrough resources section, status icons should reflect the current status of the service (ready, unavailable, or provisioning).

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Screen shots included (if applicable)

## Progress

- [x] Finished task

## Additional Notes
Screen cap of test system that I set up with mock data for systems with a status of provisioning and unavailable:

![provisioning_status_in_walkthru](https://user-images.githubusercontent.com/39063664/48720144-13fe2780-ebed-11e8-877e-7edbd8275dbf.png)

