### PR TITLE
Remove uneeded instructions for choosing the OpenShift identity provider, and accepting permissions.

### DIFF
--- a/docs/modules/ROOT/pages/_partials/task-creating-addresses.adoc
+++ b/docs/modules/ROOT/pages/_partials/task-creating-addresses.adoc
@@ -24,7 +24,7 @@ To route messages to the Spring Boot app, you create an address in EnMasse.
 // end::intro[]
 endif::location[]
 
-. Log into link:{messaging-url}[EnMasse, window="_blank"] by selecting the *OpenShift* button on the log in screen and accepting the permissions request.
+. Log into link:{messaging-url}[EnMasse, window="_blank"].
 . Select *Addresses* from the left hand menu.
 
 . Create a *requests* address:

--- a/public/steelthreads/asciidocs/en/task-creating-addresses.adoc
+++ b/public/steelthreads/asciidocs/en/task-creating-addresses.adoc
@@ -19,7 +19,7 @@
 ===== 1.1 Creating an address in EnMasse space
 
 
-. Log into link:{messaging-url}[EnMasse, window="_blank"] by selecting the *OpenShift* button on the log in screen and accepting the permissions request.
+. Log into link:{messaging-url}[EnMasse, window="_blank"].
 . Select *Addresses* from the left hand menu.
 
 . Create a *requests* address:


### PR DESCRIPTION


Since the upgrade to enmasse 0.24, these steps are no longer required

