### PR TITLE
Remove direct call to initWalkthrough, which causes initDeps to be called. initDeps is already called in prepareCustomWalkthrough

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -37,7 +37,6 @@ class TaskPage extends React.Component {
       }
     } = this.props;
     getWalkthrough(id);
-    initWalkthrough(id);
     prepareCustomWalkthrough(id);
     const { prepareWalkthroughOne, prepareWalkthroughOneA, prepareWalkthroughTwo } = this.props;
     if (this.props.match.params.id === WALKTHROUGH_IDS.ONE) {


### PR DESCRIPTION
Currently the below error occurs when starting the custom walkthrough

```
[start:server] Cloning into test from https://github.com/pb82/awesome-operators
[start:server] Cloning into test from https://github.com/pb82/awesome-operators
[start:server] Error creating repositories: Error: Request failed with status code 500
```

It did successfully create the repo, but the error caused the error page to show in the UI.
It looks like 2 calls were being made to create the repo in parallel, with 1 of them failing.

Refreshing shows that it was created, but that there's still 2 calls happening

```
[start:server] Repository test already exists
[start:server] Repository test already exists
```

This change removes 1 of those calls so only a single call to initThread is made from the UI