### PR TITLE
Remove 'Launch OpenShift Console' button as it doesn't make sense to direct the user to OpenShift after finishing a walkthrough

### DIFF
--- a/src/pages/congratulations/congratulations.js
+++ b/src/pages/congratulations/congratulations.js
@@ -37,9 +37,6 @@ class CongratulationsPage extends React.Component {
                 </p>
                 <div className="integr8ly-congratulations_buttons">
                   <Button onClick={e => this.exitTutorial(e)}>Return to Home Page</Button>
-                  <Button onClick={() => window.open(`${window.OPENSHIFT_CONFIG.masterUri}/console`, '_blank')}>
-                    Launch OpenShift Console
-                  </Button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
As requested in feedback https://trello.com/c/PSgYIwVy/353-integreatly-waterford-workshop-feedback-nov-2018

![image](https://user-images.githubusercontent.com/878251/48951836-eb9d6280-ef37-11e8-9d75-e8e05c6535d3.png)
