### PR TITLE
render copy blocks

### DIFF
--- a/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
+++ b/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
@@ -30,6 +30,17 @@ it can also contain a number of walkthrough-specific blocks. For example, below
 is a verification block. This is a paragraph that has been annotated with
 `[type=verification]`.
 
+=== Code blocks
+
+Content wrapped in `----` becomes a code block. It retains spacing and offers
+copy and paste functionality.
+
+----
+this.is = {
+    "a": "code block"
+};
+----
+
 [type=verification]
 ****
 This block will render as a verification box with a yes/no checkbox.

--- a/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
+++ b/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
@@ -29,6 +29,7 @@ exports[`CopyField Component should render a multi-line copy component: multi-li
       class="integr8ly-copy-input expanded form-control"
       id="test"
       readonly=""
+      style="height: 33px;"
       type="text"
       value="{\\"hello\\":\\"world\\"}"
     />
@@ -71,6 +72,7 @@ exports[`CopyField Component should render a single-line copy component: single-
       class="integr8ly-copy-input false form-control"
       id="test"
       readonly=""
+      style="height: 33px;"
       type="text"
       value="{\\"hello\\":\\"world\\"}"
     />

--- a/src/components/copyField/copyField.js
+++ b/src/components/copyField/copyField.js
@@ -171,6 +171,7 @@ class CopyField extends React.Component {
             readOnly
             aria-label={expandDescription}
             onClick={this.onSelect}
+            style={{height: "33px"}}
           />
           <InputGroup.Button>{this.renderButton()}</InputGroup.Button>
         </InputGroup>

--- a/src/components/copyField/copyField.js
+++ b/src/components/copyField/copyField.js
@@ -171,7 +171,7 @@ class CopyField extends React.Component {
             readOnly
             aria-label={expandDescription}
             onClick={this.onSelect}
-            style={{height: "33px"}}
+            style={{ height: '33px' }}
           />
           <InputGroup.Button>{this.renderButton()}</InputGroup.Button>
         </InputGroup>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import CopyField from '../../../components/copyField/copyField';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { translate } from 'react-i18next';
@@ -20,6 +19,7 @@ import {
   WalkthroughTextBlock,
   WalkthroughStep
 } from '../../../common/walkthroughHelpers';
+import CopyField from '../../../components/copyField/copyField';
 
 class TaskPage extends React.Component {
   constructor(props) {

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
+import CopyField from '../../../components/copyField/copyField';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { translate } from 'react-i18next';
@@ -20,6 +22,20 @@ import {
 } from '../../../common/walkthroughHelpers';
 
 class TaskPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.rootDiv = React.createRef();
+  }
+
+  componentDidUpdate() {
+    if (this.rootDiv.current) {
+      const codeBlocks = this.rootDiv.current.querySelectorAll('pre');
+      codeBlocks.forEach(block => {
+        ReactDOM.render(<CopyField value={block.innerText} multiline={block.clientHeight > 40} />, block.parentNode);
+      });
+    }
+  }
+
   componentDidMount() {
     const {
       getWalkthrough,
@@ -29,6 +45,9 @@ class TaskPage extends React.Component {
         params: { id }
       }
     } = this.props;
+
+    this.rootDiv = React.createRef();
+
     getWalkthrough(id);
     prepareCustomWalkthrough(id);
     const currentUsername = localStorage.getItem('currentUserName');
@@ -322,7 +341,7 @@ class TaskPage extends React.Component {
               <Grid.Col xs={12} sm={9} className="integr8ly-module">
                 <div className="integr8ly-module-column">
                   <h2>{threadTask.title}</h2>
-                  <div className="integr8ly-module-column--steps">
+                  <div className="integr8ly-module-column--steps" ref={this.rootDiv}>
                     {threadTask.steps.map((step, i) => this.renderStepBlock(i, step))}
                   </div>
 


### PR DESCRIPTION
Previously the code block converstion was done in the `AsciidocTemplate` component. This one is no longer used in the new walkthrough format.

This PR applies the same conversion now in the `Tasks` component.

I initially tried to use Asciidoc.js postprocessor extensions. But due to react that was not practical.

Verification:

1. Run the Webapp from this branch and open the walkthrough.
1. On the first task there should be a code template. It should have the copy&paste feature.
1. Make sure copy & paste works.