### PR TITLE
Display thread init error

### DIFF
--- a/gitea_client.js
+++ b/gitea_client.js
@@ -124,7 +124,7 @@ exports.createRepoForUser = (username, repo) => {
   const normalizedUser = normalizeUser(username);
   return new Promise((resolve, reject) => {
     if (!GITEA_HOST || !GITEA_TOKEN) {
-      return reject(new Error('Gitea not installed'));
+      return reject(new Error('Gitea is not configured. Repositories cannot be created.'));
     }
 
     if (!repo || !repo.repoName) {

--- a/src/redux/actions/threadActions.js
+++ b/src/redux/actions/threadActions.js
@@ -1,5 +1,6 @@
 import { threadTypes } from '../constants';
 import { threadServices } from '../../services';
+import { PENDING_ACTION, FULFILLED_ACTION, REJECTED_ACTION } from '../helpers';
 
 const getThread = (language, id) => ({
   type: threadTypes.GET_THREAD,
@@ -16,9 +17,31 @@ const initCustomThread = id => ({
   payload: threadServices.initCustomThread(id)
 });
 
+const initCustomThreadPending = () => ({
+  type: PENDING_ACTION(threadTypes.INIT_THREAD)
+});
+
+const initCustomThreadSuccess = payload => ({
+  type: FULFILLED_ACTION(threadTypes.INIT_THREAD),
+  payload
+});
+
+const initCustomThreadFailure = error => ({
+  type: REJECTED_ACTION(threadTypes.INIT_THREAD),
+  payload: { error }
+});
+
 const updateThreadProgress = (id, progress) => ({
   type: threadTypes.UPDATE_THREAD_PROGRESS,
   payload: threadServices.updateThreadProgress(id, progress)
 });
 
-export { getThread, getCustomThread, initCustomThread, updateThreadProgress };
+export {
+  getThread,
+  getCustomThread,
+  initCustomThread,
+  updateThreadProgress,
+  initCustomThreadSuccess,
+  initCustomThreadFailure,
+  initCustomThreadPending
+};

--- a/src/redux/reducers/threadReducers.js
+++ b/src/redux/reducers/threadReducers.js
@@ -68,8 +68,8 @@ const threadReducers = (state = initialState, action) => {
       return setStateProp(
         'manifest',
         {
-          error: action.error,
-          errorMessage: action.payload.message
+          error: action.payload.error,
+          errorMessage: action.payload.error.message
         },
         {
           state,
@@ -97,7 +97,7 @@ const threadReducers = (state = initialState, action) => {
         {
           pending: false,
           fulfilled: true,
-          data: action.payload.data
+          data: action.payload
         },
         {
           state,

--- a/src/services/threadServices.js
+++ b/src/services/threadServices.js
@@ -15,7 +15,11 @@ const initDeps = response =>
       })
         .then(resp => {
           if (resp.status !== 200) {
-            return reject(new Error('An error occurred while initializing the dependencies'));
+            const errorMsg =
+              resp.response && resp.response.data && resp.response.data.error
+                ? resp.response.data.error
+                : 'An error occurred while initializing the dependencies';
+            return reject(new Error(errorMsg));
           }
           return resolve(response);
         })

--- a/src/services/walkthroughServices.js
+++ b/src/services/walkthroughServices.js
@@ -13,6 +13,11 @@ import {
   routeDef
 } from '../common/openshiftResourceDefinitions';
 import { addWalkthroughService, removeWalkthroughService } from '../redux/actions/walkthroughServiceActions';
+import {
+  initCustomThreadPending,
+  initCustomThreadSuccess,
+  initCustomThreadFailure
+} from '../redux/actions/threadActions';
 
 const DEFAULT_SERVICE_INSTANCE = {
   kind: 'ServiceInstance',
@@ -34,9 +39,11 @@ const prepareCustomWalkthroughNamespace = (dispatch, walkthoughName) => {
   if (window.OPENSHIFT_CONFIG.mockData) {
     return Promise.resolve([]);
   }
+  dispatch(initCustomThreadPending());
   return initCustomThread(walkthoughName)
     .then(res => res.data)
     .then(manifest => {
+      dispatch(initCustomThreadSuccess(manifest));
       currentUser().then(user => {
         const userNamespace = buildValidProjectNamespaceName(user.username, walkthoughName);
         const namespaceObj = namespaceResource(userNamespace);
@@ -67,7 +74,8 @@ const prepareCustomWalkthroughNamespace = (dispatch, walkthoughName) => {
             );
         });
       });
-    });
+    })
+    .catch(e => dispatch(initCustomThreadFailure(e)));
 };
 
 /**


### PR DESCRIPTION
## Motivation
Currently when an error occurs during provisioning we show a generic screen with a message. This change instead displays the error message, so a user has a better idea of how to resolve the issue (Whether to try again or contact an admin).

The main place we were seeing this issue is when trying to init my-custom-walkthrough without having GITEA_HOST or GITEA_TOKEN set. Instead of seeing a generic message, you should now see the error message from the server explaining that Gitea is not configured. 
