### PR TITLE
use single walkthrough resource component

### DIFF
--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -63,17 +63,10 @@ class WalkthroughResources extends React.Component {
     return provisioningStatus;
   }
 
-  renderHeading() {
-    if (!this.props.noHeadline) {
-      return <h4 className="integr8ly-helpful-links-heading">Walkthrough Resources</h4>;
-    }
-    return null;
-  }
-
   render() {
     return (
       <div>
-        {this.renderHeading()}
+        <h4 className="integr8ly-helpful-links-heading">Walkthrough Resources</h4>
         {this.props.resources.map((resource, i) => (
           <div key={i} dangerouslySetInnerHTML={{ __html: resource.html }} />
         ))}
@@ -85,14 +78,12 @@ class WalkthroughResources extends React.Component {
 
 WalkthroughResources.propTypes = {
   resources: PropTypes.array,
-  middlewareServices: PropTypes.object,
-  noHeadline: PropTypes.bool
+  middlewareServices: PropTypes.object
 };
 
 WalkthroughResources.defaultProps = {
   resources: [],
-  middlewareServices: { data: {} },
-  noHeadline: false
+  middlewareServices: { data: {} }
 };
 
 const mapStateToProps = state => ({

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -327,6 +327,7 @@ class TaskPage extends React.Component {
         this.getVerificationsForTask(threadTask)
       );
       const currentThreadProgress = this.getStoredProgressForCurrentTask();
+      const combinedResources = parsedThread.resources.concat(threadTask.resources);
       return (
         <React.Fragment>
           <Breadcrumb
@@ -445,8 +446,7 @@ class TaskPage extends React.Component {
               <Grid.Col sm={3} className="integr8ly-module-frame">
                 {/* <h4 className="integr8ly-helpful-links-heading">Walkthrough Diagram</h4>
                 <img src="/images/st0.png" className="img-responsive" alt="integration" /> */}
-                <WalkthroughResources resources={parsedThread.resources} />
-                <WalkthroughResources resources={threadTask.resources} noHeadline />
+                <WalkthroughResources resources={combinedResources} />
               </Grid.Col>
             </Grid.Row>
           </Grid>


### PR DESCRIPTION
This fixes the problem where `No resources available` was displayed twice.

We are now only using one `<WalkthroughResource ... >` component and combine the walkthrough and task level resources in task.js. Also removes the no longer needed `noHeadline` option.