### PR TITLE
Hide the example walkthrough by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "watch:css": "yarn build:css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/styles/index.scss -o src/styles/.css --watch --recursive",
     "build:js": "react-scripts build",
     "start": "node server.js",
-    "start:dev": "FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" run-p -l watch:css start:local start:server",
+    "start:dev": "SHOW_EXAMPLE_WALKTHROUGH=true FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" run-p -l watch:css start:local start:server",
     "start:local": "react-scripts start",
     "start:server": "nodemon --watch server.js --exec 'node server.js'",
     "commit:hash": "echo REACT_APP_UI_COMMIT_HASH=$(git rev-list -1 --all) > .env",

--- a/server.js
+++ b/server.js
@@ -79,7 +79,10 @@ function loadCustomWalkthroughs(walkthroughsPath) {
           process.exit(1);
         }
         const loadedAdoc = adoc.load(rawAdoc);
-        walkthroughs.push(getWalkthroughInfoFromAdoc(dirName, loadedAdoc));
+        // Don't show example walkthrough by default
+        if (process.env.SHOW_EXAMPLE_WALKTHROUGH === 'true' || dirName !== 'my-custom-walkthrough') {
+          walkthroughs.push(getWalkthroughInfoFromAdoc(dirName, loadedAdoc));
+        }
       });
     });
   });


### PR DESCRIPTION
Only show it if `SHOW_EXAMPLE_WALKTHROUGH=true` is set.
This is the case for the `start:dev` script

Purposely going with a simple dirname check for a couple reasons:

* avoid unnecessary overhead of reading in extra metadata (i.e. json files) on startup for each walkthrough
* a future feature for labelling walkthroughs, coupled waith a feature for showing/hiding particularly labelled walkthroughs would supercede this