### PR TITLE
Fix progress

### DIFF
--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -7,7 +7,7 @@ const TutorialDashboard = props => {
   const { walkthroughs, userProgress } = props;
   const cards = [];
   walkthroughs.map((walkthrough, i) => {
-    const currentProgress = userProgress.find(thread => thread.threadId === walkthrough.id);
+    const currentProgress = userProgress[walkthrough.id];
     let startedText;
     if (currentProgress === undefined) startedText = 'Get Started';
     else if (currentProgress.progress === 100) startedText = 'Completed';
@@ -73,12 +73,12 @@ const TutorialDashboard = props => {
 };
 
 TutorialDashboard.propTypes = {
-  userProgress: PropTypes.array,
+  userProgress: PropTypes.object,
   walkthroughs: PropTypes.array
 };
 
 TutorialDashboard.defaultProps = {
-  userProgress: [],
+  userProgress: {},
   walkthroughs: []
 };
 

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -24,7 +24,7 @@ class LandingPage extends React.Component {
           <section className="integr8ly-landing-page-tutorial-dashboard-section">
             <TutorialDashboard
               className="integr8ly-landing-page-tutorial-dashboard-section-left"
-              userProgress={user.userProgress.threads}
+              userProgress={user.userProgress}
               walkthroughs={walkthroughServices.data}
             />
             <InstalledAppsView

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -88,13 +88,14 @@ class TaskPage extends React.Component {
     const newCurrentProgress = Object.assign({}, oldProgress[id][task] || {}, verificationState);
     oldProgress[id][task] = newCurrentProgress;
 
+    // Update progress if the walkthrough has at least one step
     const totalSteps = this.getTotalSteps(data);
-    const completedSteps = this.getCompletedSteps(oldProgress[id]);
+    if (totalSteps > 0) {
+      const completedSteps = this.getCompletedSteps(oldProgress[id]);
+      oldProgress[id].progress = Math.floor((completedSteps / totalSteps) * 100);
+      oldProgress[id].task = task;
+    }
 
-    // `progress` and `task` are used on the dashboard to let the user jump directly to
-    // the last task they worked on
-    oldProgress[id].progress = Math.floor((completedSteps / totalSteps) * 100);
-    oldProgress[id].task = task;
     updateWalkthroughProgress(currentUsername, oldProgress);
   };
 

--- a/src/services/userServices.js
+++ b/src/services/userServices.js
@@ -195,7 +195,7 @@ const setProgress = progress => {
 };
 
 const getProgress = () =>
-  JSON.parse(window.localStorage.getItem(`userProgress-${window.localStorage.getItem('currentUserName')}`));
+  JSON.parse(window.localStorage.getItem(`walkthroughProgress_${window.localStorage.getItem('currentUserName')}`));
 
 export {
   checkUser,


### PR DESCRIPTION
The progress displayed on the tutorial dashboard is calculated by knowing the total number of steps vs. the completed number of steps. With the custom walkthroughs we don't easily know the total number steps anymore: all we get is a chunk of asciidoc and we only parse it during `render`.

The solution in this PR is to use a regex on the asciidoc string to search for `[type=verification]` which gives us the total number of steps. The way the per-task progress is stored has also changed and this PR also accounts for that.

Verification:

1. Start a walkthrough, complete some steps (verifications)
1. Go back to the dashboard: you should see the progress now
1. Click on `Resume`: you should directly jump to your last task