### PR TITLE
force copy paste input and buttons to same height

### DIFF
--- a/src/components/copyField/copyField.js
+++ b/src/components/copyField/copyField.js
@@ -171,7 +171,6 @@ class CopyField extends React.Component {
             readOnly
             aria-label={expandDescription}
             onClick={this.onSelect}
-            style={{ height: '33px' }}
           />
           <InputGroup.Button>{this.renderButton()}</InputGroup.Button>
         </InputGroup>

--- a/src/styles/application/_copyField.scss
+++ b/src/styles/application/_copyField.scss
@@ -1,4 +1,12 @@
 .integr8ly-copy {
+  button {
+    height: 32px;
+  }
+
+  input {
+    height: 32px;
+  }
+
   &-input {
     &.false { /* stylelint-disable-line selector-class-pattern */
       width: 200px;


### PR DESCRIPTION
The copy and paste input consists of inputs and buttons. Force all of them always to the same height.

Verification steps:

1. Open a few walkthroughs with copy & paste fields. Make sure the buttons and inputs are aligned.
1. Open the example walkthrough (it has a multiline field). This one should also look good (buttons and input aligned).