### PR TITLE
align resources and walkthrough headings

### DIFF
--- a/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
+++ b/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
@@ -29,7 +29,6 @@ exports[`CopyField Component should render a multi-line copy component: multi-li
       class="integr8ly-copy-input expanded form-control"
       id="test"
       readonly=""
-      style="height: 33px;"
       type="text"
       value="{\\"hello\\":\\"world\\"}"
     />
@@ -72,7 +71,6 @@ exports[`CopyField Component should render a single-line copy component: single-
       class="integr8ly-copy-input false form-control"
       id="test"
       readonly=""
-      style="height: 33px;"
       type="text"
       value="{\\"hello\\":\\"world\\"}"
     />

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -66,7 +66,7 @@ class WalkthroughResources extends React.Component {
   render() {
     return (
       <div>
-        <h4 className="integr8ly-helpful-links-heading">Walkthrough Resources</h4>
+        <h3 className="integr8ly-helpful-links-heading">Walkthrough Resources</h3>
         {this.props.resources.map((resource, i) => (
           <div key={i} dangerouslySetInnerHTML={{ __html: resource.html }} />
         ))}

--- a/src/styles/application/_sidePanel.scss
+++ b/src/styles/application/_sidePanel.scss
@@ -9,7 +9,8 @@
     border-left-color: $pf-color-black-300;
 
     &-heading {
-      margin-bottom: 20px;
+      margin-top: 20px;
+      margin-bottom: 10px;
       font-weight: var(--pf-global--FontWeight--normal);
     }
 

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -1,6 +1,6 @@
 .integr8ly- {
   &module {
-    margin-top: 40px;
+    margin-top: 60px;
     margin-bottom: 80px;
 
     &-congratulations {


### PR DESCRIPTION
align the height of the headlines walkthrough and resources headlines:

![screenshot_20181127_141739](https://user-images.githubusercontent.com/1851198/49084339-7b505300-f24f-11e8-828d-d89188700fb0.png)

Verification:

1. Open a walkthrough
1. On the walkthrough overview the headlines of the walkthrough itself and the resources should be on the same height
1. Start a task. The headlines here should also be on the same height.