### PR TITLE
Remove extra style imports

### DIFF
--- a/src/styles/application/_pf4Import.scss
+++ b/src/styles/application/_pf4Import.scss
@@ -12,44 +12,51 @@ $pf-global--enable-reset: false !default;
 @import "../node_modules/@patternfly/patternfly-next/patternfly-base.scss";
 
 // @import "../node_modules/@patternfly/patternfly-next/components/AboutModalBox/about-modal-box.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Alert/alert.scss";
+// @import "../node_modules/@patternfly/patternfly-next/components/Alert/alert.scss";
 
 // @import "../node_modules/@patternfly/patternfly-next/components/Avatar/avatar.scss";
 // @import "../node_modules/@patternfly/patternfly-next/components/Backdrop/backdrop.scss";
 @import "../node_modules/@patternfly/patternfly-next/components/BackgroundImage/background-image.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Badge/badge.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Brand/brand.scss";
+
+// @import "../node_modules/@patternfly/patternfly-next/components/Badge/badge.scss";
+
+// @import "../node_modules/@patternfly/patternfly-next/components/Brand/brand.scss";
 @import "../node_modules/@patternfly/patternfly-next/components/Button/button.scss";
 @import "../node_modules/@patternfly/patternfly-next/components/Card/card.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Check/check.scss";
+
+// @import "../node_modules/@patternfly/patternfly-next/components/Check/check.scss";
 @import "../node_modules/@patternfly/patternfly-next/components/Content/content.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Dropdown/dropdown.scss";
+
+// @import "../node_modules/@patternfly/patternfly-next/components/Dropdown/dropdown.scss";
 
 // @import "../node_modules/@patternfly/patternfly-next/components/Form/form.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/FormControl/form-control.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/InputGroup/input-group.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/List/list.scss";
+// @import "../node_modules/@patternfly/patternfly-next/components/FormControl/form-control.scss";
+// @import "../node_modules/@patternfly/patternfly-next/components/InputGroup/input-group.scss";
+// @import "../node_modules/@patternfly/patternfly-next/components/List/list.scss";
 
 // @import "../node_modules/@patternfly/patternfly-next/components/LoginBox/login-box.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/ModalBox/modal-box.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Nav/nav.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Popover/popover.scss";
+// @import "../node_modules/@patternfly/patternfly-next/components/ModalBox/modal-box.scss";
+// @import "../node_modules/@patternfly/patternfly-next/components/Nav/nav.scss";
+// @import "../node_modules/@patternfly/patternfly-next/components/Popover/popover.scss";
 @import "../node_modules/@patternfly/patternfly-next/components/Progress/progress.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Switch/switch.scss";
+
+// @import "../node_modules/@patternfly/patternfly-next/components/Switch/switch.scss";
 
 // @import "../node_modules/@patternfly/patternfly-next/components/Table/table.scss";
 @import "../node_modules/@patternfly/patternfly-next/components/Title/title.scss";
-@import "../node_modules/@patternfly/patternfly-next/components/Tooltip/tooltip.scss";
-@import "../node_modules/@patternfly/patternfly-next/layouts/Bullseye/bullseye.scss";
-@import "../node_modules/@patternfly/patternfly-next/layouts/Gallery/gallery.scss";
-@import "../node_modules/@patternfly/patternfly-next/layouts/Grid/grid.scss";
-@import "../node_modules/@patternfly/patternfly-next/layouts/Level/level.scss";
+
+// @import "../node_modules/@patternfly/patternfly-next/components/Tooltip/tooltip.scss";
+// @import "../node_modules/@patternfly/patternfly-next/layouts/Bullseye/bullseye.scss";
+// @import "../node_modules/@patternfly/patternfly-next/layouts/Gallery/gallery.scss";
+// @import "../node_modules/@patternfly/patternfly-next/layouts/Grid/grid.scss";
+// @import "../node_modules/@patternfly/patternfly-next/layouts/Level/level.scss";
 
 // @import "../node_modules/@patternfly/patternfly-next/layouts/Login/login.scss";
 @import "../node_modules/@patternfly/patternfly-next/layouts/Page/page.scss";
-@import "../node_modules/@patternfly/patternfly-next/layouts/Split/split.scss";
-@import "../node_modules/@patternfly/patternfly-next/layouts/Stack/stack.scss";
-@import "../node_modules/@patternfly/patternfly-next/layouts/Toolbar/toolbar.scss";
+
+// @import "../node_modules/@patternfly/patternfly-next/layouts/Split/split.scss";
+// @import "../node_modules/@patternfly/patternfly-next/layouts/Stack/stack.scss";
+// @import "../node_modules/@patternfly/patternfly-next/layouts/Toolbar/toolbar.scss";
 @import "../node_modules/@patternfly/patternfly-next/utilities/Accessibility/accessibility.scss";
 @import "../node_modules/@patternfly/patternfly-next/utilities/Alignment/alignment.scss";
 @import "../node_modules/@patternfly/patternfly-next/utilities/BoxShadow/box-shadow.scss";


### PR DESCRIPTION
## Motivation
Clean up the number of files imported as part of the PatternFly 4 integration. This should shrink the overall style footprint.

## What
Clean up the number of files imported as part of the PatternFly 4 integration.

## Why
There were styles being imported into that app that are not currently used. A future update with either use these styles, or remove them entirely (instead of just commenting out the individual imports).

## How
Commented our individual imports.

## Verification Steps

1. Run the build - `yarn build`

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task