### PR TITLE
More flexible resources

### DIFF
--- a/public/walkthroughs/walkthrough-2/walkthrough.adoc
+++ b/public/walkthroughs/walkthrough-2/walkthrough.adoc
@@ -33,25 +33,25 @@ This walkthrough describes how to create such an integration, using OpenShift, {
 <img src="/images/wt2.png" class="img-responsive" alt="integration">
 ++++
 
-[type=walkthroughResource]
+[type=walkthroughResource,serviceName=openshift]
 === Red Hat OpenShift
 * link:{openshift-host}/console[Open Console]
 * link:https://help.openshift.com/[Openshift Online Help Center]
 * link:https://blog.openshift.com/[Openshift Blog]
 
-[type=walkthroughResource]
+[type=walkthroughResource,serviceName=launcher]
 === Launcher
 * link:{launcher-url}[Open Console]
 * link:https://developers.redhat.com/products/openshiftio/overview/[Launcher Overview]
 * link:https://launcher.fabric8.io/docs/[Launcher Documentation]
 
-[type=walkthroughResource]
+[type=walkthroughResource,serviceName=che]
 === Eclipse Che
 * link:{che-url}[Open Console]
 * link:https://developers.redhat.com/products/che/overview/[Eclipse Che Overview]
 * link:https://www.eclipse.org/che/docs/index.html[Eclipse Che Documentation]
 
-[type=walkthroughResource]
+[type=walkthroughResource,serviceName=3scale]
 === 3Scale
 * link:{api-management-url}[Open Console]
 * link:https://developers.redhat.com/products/3scale/overview/[3Scale Overview]

--- a/src/common/walkthroughHelpers.js
+++ b/src/common/walkthroughHelpers.js
@@ -170,19 +170,14 @@ class WalkthroughStep {
 }
 
 class WalkthroughResourceStep {
-  constructor(html, service, id, title) {
+  constructor(html, service, title) {
     this._html = html;
     this._serviceName = service;
-    this._id = id;
     this._title = title;
   }
 
   get title() {
     return this._title;
-  }
-
-  get id() {
-    return this._id;
   }
 
   get html() {
@@ -203,26 +198,20 @@ class WalkthroughResourceStep {
 
   static fromAdoc(adoc) {
     const service = adoc.getAttribute('serviceName');
-    const { id, title } = adoc;
     const html = adoc.blocks[0] ? adoc.blocks[0].convert() : '';
-    return new WalkthroughResourceStep(html, service, id, title);
+    return new WalkthroughResourceStep(html, service, adoc.title);
   }
 }
 
 class WalkthroughResource {
-  constructor(html, service, id, title) {
+  constructor(html, service, title) {
     this._html = html;
     this._serviceName = service;
-    this._id = id;
     this._title = title;
   }
 
   get title() {
     return this._title;
-  }
-
-  get id() {
-    return this._id;
   }
 
   get html() {
@@ -234,24 +223,17 @@ class WalkthroughResource {
   }
 
   static canConvert(adoc) {
-    const result = (
+    return (
       adoc.context === CONTEXT_SECTION &&
       adoc.level === BLOCK_LEVEL_STEP &&
       adoc.getAttribute(BLOCK_ATTR_TYPE) === BLOCK_TYPE_WALKTHROUGH_RESOURCE
     );
-
-    if (result) {
-      console.log('--- a walkthrough resource');
-      console.log(adoc);
-    }
-    return result;
   }
 
   static fromAdoc(adoc) {
     const service = adoc.getAttribute('serviceName');
-    const { id, title } = adoc;
     const html = adoc.blocks[0] ? adoc.blocks[0].convert() : '';
-    return new WalkthroughResource(html, service, id, title);
+    return new WalkthroughResource(html, service, adoc.title);
   }
 }
 

--- a/src/common/walkthroughHelpers.js
+++ b/src/common/walkthroughHelpers.js
@@ -170,12 +170,27 @@ class WalkthroughStep {
 }
 
 class WalkthroughResourceStep {
-  constructor(html) {
+  constructor(html, service, id, title) {
     this._html = html;
+    this._serviceName = service;
+    this._id = id;
+    this._title = title;
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  get id() {
+    return this._id;
   }
 
   get html() {
     return this._html;
+  }
+
+  get serviceName() {
+    return this._serviceName;
   }
 
   static canConvert(adoc) {
@@ -187,29 +202,56 @@ class WalkthroughResourceStep {
   }
 
   static fromAdoc(adoc) {
-    return new WalkthroughResourceStep(adoc.convert());
+    const service = adoc.getAttribute('serviceName');
+    const { id, title } = adoc;
+    const html = adoc.blocks[0] ? adoc.blocks[0].convert() : '';
+    return new WalkthroughResourceStep(html, service, id, title);
   }
 }
 
 class WalkthroughResource {
-  constructor(html) {
+  constructor(html, service, id, title) {
     this._html = html;
+    this._serviceName = service;
+    this._id = id;
+    this._title = title;
+  }
+
+  get title() {
+    return this._title;
+  }
+
+  get id() {
+    return this._id;
   }
 
   get html() {
     return this._html;
   }
 
+  get serviceName() {
+    return this._serviceName;
+  }
+
   static canConvert(adoc) {
-    return (
+    const result = (
       adoc.context === CONTEXT_SECTION &&
       adoc.level === BLOCK_LEVEL_STEP &&
       adoc.getAttribute(BLOCK_ATTR_TYPE) === BLOCK_TYPE_WALKTHROUGH_RESOURCE
     );
+
+    if (result) {
+      console.log('--- a walkthrough resource');
+      console.log(adoc);
+    }
+    return result;
   }
 
   static fromAdoc(adoc) {
-    return new WalkthroughResource(adoc.convert());
+    const service = adoc.getAttribute('serviceName');
+    const { id, title } = adoc;
+    const html = adoc.blocks[0] ? adoc.blocks[0].convert() : '';
+    return new WalkthroughResource(html, service, id, title);
   }
 }
 

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -76,7 +76,7 @@ class WalkthroughResources extends React.Component {
       resourceList = resources.map(resource => {
         console.log(resource);
         return (
-          <div key={resource.id}>
+          <div key={resource.title}>
             <h4 className="integr8ly-helpful-links-product-title">
               {resource.statusIcon}
               &nbsp;

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon } from 'patternfly-react';
 import { connect } from '../../redux';
-import { getDashboardUrl } from '../../common/serviceInstanceHelpers';
 
 class WalkthroughResources extends React.Component {
   constructor(props) {

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -92,7 +92,7 @@ class WalkthroughResources extends React.Component {
                 <span />
               )}
             </h4>
-            <div className="list-unstyled" dangerouslySetInnerHTML={{ __html: resource.html }} />
+            <div className="integr8ly-helpful-resources-list" dangerouslySetInnerHTML={{ __html: resource.html }} />
           </div>
         );
       });

--- a/src/styles/application/_sidePanel.scss
+++ b/src/styles/application/_sidePanel.scss
@@ -1,4 +1,11 @@
 .integr8ly-helpful {
+  &-resources-list {
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+    }
+  }
+
   &-links {
     position: fixed;
     top: 0;

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -131,6 +131,11 @@
       border-left: var(--pf-global--BorderWidth--sm) solid;
       border-left-color: $pf-color-black-300;
 
+      ul {
+        list-style-type: none;
+        padding-left: 0;
+      }
+
       @media (max-width: var(--pf-global--breakpoint--md)) {
         display: none;
       }

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -131,11 +131,6 @@
       border-left: var(--pf-global--BorderWidth--sm) solid;
       border-left-color: $pf-color-black-300;
 
-      ul {
-        list-style-type: none;
-        padding-left: 0;
-      }
-
       @media (max-width: var(--pf-global--breakpoint--md)) {
         display: none;
       }


### PR DESCRIPTION
Fixes the styling of the walkthrough resources and adds the missing features like service and GA status.

The `walkthroughResource` annotation accepts a new attribute:

```
[type=walkthroughResource,serviceName=openshift]
=== Red Hat OpenShift
* link:{openshift-host}/console[Open Console]
* link:https://help.openshift.com/[Openshift Online Help Center]
* link:https://blog.openshift.com/[Openshift Blog]
```

`serviceName` can be used to link the resource to a service. The side effect is that now resources can only have one block of markdown, all further blocks are ignored. Is that ok for you @finp ?

The result looks like this:

![screenshot_20181127_182648](https://user-images.githubusercontent.com/1851198/49100199-a5b40780-f273-11e8-8ccb-0b5ac5112bc3.png)

Verification steps:

1. Open walkthrough 2 (the only one with custom resources defined)
1. Check that the resources on the side panel look and work ok
