### PR TITLE
WIP: add instructions to custom walkthrough example

### DIFF
--- a/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
+++ b/public/walkthroughs/my-custom-walkthrough/walkthrough.adoc
@@ -1,11 +1,47 @@
 = A custom walkthrough
 
-This is the first sentence of the walkthrough's preamble. It will be used as the
-short description for the walkthrough.
+The first sentence is used as the short description for the walkthrough.
 
-These lines will be included in the long description of the walkthrough. Normally
-this content will be shown on the overview page for a walkthough. However, it is
-excluded from the short description.
+----
+= Demonstrating a custom walkthrough // <1>
+
+A short description for the walkthrough. // <2>
+
+But this text is displayed on the {intro} page.
+
+== Doing a task <3>
+
+This is the overview for the first task in the walkthrough.
+
+=== Doing a step <4>
+
+. Do this first: <5>
+. Do this second: <5>
+
+[type=verification] <6>
+****
+This block will render as a verification box with a yes/no checkbox.
+
+. Check this thing.
+. Check that thing.
+****
+
+=== Doing a second step
+
+. Do first item.
+
+[type=verification]
+Notice that a single line verification does not require `****`.
+
+[type=verificationFail]
+If you have a workaround, put it here.
+
+[start=2]
+. Do third item.
+----
+
+<1> The walkthrough title
+
 
 To start a task we need to use a h2 heading.
 

--- a/public/walkthroughs/writing-walkthroughs/walkthrough.adoc
+++ b/public/walkthroughs/writing-walkthroughs/walkthrough.adoc
@@ -1,172 +1,70 @@
-= A custom walkthrough
+= Writing Walkthroughs
 
-The first sentence is used as the short description for the walkthrough.
+An introduction to writing walkthroughs.
+
+The Integreatly web app allows you publish your own walkthroughs to a cluster using:
+
+* Asciidoc - a simple mark up language, similar to markdown
+* git repo - push your asciidoc file to a git repo
+* config file - edit this config file to point to your git repo
+* deploy web app - use openshift to redeploy your web app and view the new walkthrough
+
+
+The simplest walkthrough file might look like:
 
 ----
-= Demonstrating a custom walkthrough // <1>
+= Demonstrating a custom walkthrough <1>
 
-A short description for the walkthrough. // <2>
-
-But this text is displayed on the {intro} page.
+A short description for the walkthrough. <2>
 
 == Doing a task <3>
-
-This is the overview for the first task in the walkthrough.
 
 === Doing a step <4>
 
 . Do this first: <5>
 . Do this second: <5>
-
-[type=verification] <6>
-****
-This block will render as a verification box with a yes/no checkbox.
-
-. Check this thing.
-. Check that thing.
-****
-
-=== Doing a second step
-
-. Do first item.
-
-[type=verification]
-Notice that a single line verification does not require `****`.
-
-[type=verificationFail]
-If you have a workaround, put it here.
-
-[start=2]
-. Do third item.
 ----
 
-<1> The walkthrough title
+<1> Walkthrough title, you can only have one level 1 heading per file
+<2> The first line of the introduction is displayed as a tag line for the walkthrough.
+<3> A task contains one or more steps (level 3 headings)
+<4> Steps are displayed together on the {task} page
+<5> Procedures are numbered lists, one per step.
+
+Each of the tasks below demonstrates the features and constraints of the walkthrough file format.
 
 
-To start a task we need to use a h2 heading.
+[type=walkthroughResource,serviceName=asciidoc]
+=== Asciidoc
+* link:{openshift-host}/console[Open Console]
+* link:https://help.openshift.com/[Openshift Online Help Center]
+* link:https://blog.openshift.com/[Openshift Blog]
 
-[type=walkthroughResource]
-=== A Walkthrough resource
 
-Use annotations of type `[type=walkthroughResource]` in the preamble
-section to declare global resources that will be displayed on the tutorial
-overview page as well as on every task.
 
-== First task
+[time=5]
+== Converting from markdown
 
-This is the overview for the first task in the walkthrough.
+[time=5]
+== Adding steps
 
-It can be spread over multiple paragraphs. To start a step we need to use a h3
-heading.
+[time=5]
+== Adding tasks
 
-=== Custom blocks
+[time=5]
+== Adding walkthrough resources
 
-This is the content of the first step. Steps can contain any asciidoc. However,
-it can also contain a number of walkthrough-specific blocks. For example, below
-is a verification block. This is a paragraph that has been annotated with
-`[type=verification]`.
+[time=5]
+== Adding images
 
-=== Code blocks
+[time=5]
+== Adding task resources
 
-Content wrapped in `----` becomes a code block. It retains spacing and offers
-copy and paste functionality.
+[time=5]
+== Adding verifications 
 
-----
-this.is = {
-    "a": "code block"
-};
-----
+[time=5]
+== Using attributes
 
-[type=verification]
-****
-This block will render as a verification box with a yes/no checkbox.
-
-. Check this thing.
-. Check that thing
-****
-
-=== More custom blocks
-
-This is the second step of the first task. It is started with a h3 heading. Below
-we'll include some arbitrary asciidoc, a list, with a verification block in the
-middle of it. We need to use `[start=3]` annotation to continue the numbering of
-the list that the verification block has broken.
-
-Also in this step is the two other types of verification block. These are used to
-define content that is shown when a user selects either `yes` or `no` on the
-checkbox. These are blocks annotated with `[type=verificationSuccess]` and
-`[type=verificationFail]` respectively.
-
-. First item
-. Second item
-
-[type=verification]
-A second verification block.
-
-[start=3]
-. Third item, I should have a 3 beside me
-. Fourth item
-
-[type=verificationFail]
-A message to show when the user clicks `no`.
-
-[type=verificationSuccess]
-A message to show when the user clicks `yes`.
-
-Note that each verification block is a single block. Meaning there cannot be
-newlines in the block itself. This can be worked around by surrounding the separate
-paragraphs with `\****` or by any other means that maintains a single block of text.
-
-=== Using walkthrough attributes
-
-By default, a number of attributes about the environment will be provided to us.
-These attributes will include information such as the URLs of services. One of
-these attributes is the URL of Eclipse Che running in the cluster. This attribute
-is named `che-url`. We can access it like any other attribute in asciidoc, by
-surrounding it with `{}`.
-
-* Default attributes:
-** OpenShift App Host: `{openshift-app-host}`
-** Che URL: `{che-url}`.
-** Fuse URL: `{fuse-url}`
-** Launcher URL: `{launcher-url}`
-** API Management URL: `{api-management-url}`
-** AMQ URL: `{amq-url}`
-** AMQ Broker URL: `{amq-broker-url}`
-** AMQ Credential Username: `{amq-credentials-username}`
-** AMQ Credential Password: `{amq-credentials-password}`
-** EnMasse URL: `{enmasse-url}`
-** EnMasse Broker URL: `{enmasse-broker-url}`
-** EnMasse Credential Username: `{enmasse-credentials-username}`
-** EnMasse Credential Password: `{enmasse-credentials-password}`
-* Custom attributes:
-** NodeJS Frontend App Route (provisioned from walkthrough.json): `{route-frontend-host}`
-
-[type=taskResource]
-=== A task resource
-
-A step-level annotation can be used to add resources to the right-hand side of
-the walkthrough in the extra resources section. Any step annotated with
-`[type=taskResource]` will be included on the right-hand side instead of being
-included in the main content. Note that verification blocks will not work in here,
-these steps are treated as raw asciidoc.
-
-[time=15]
-== Second task
-
-This is the second task of the walkthrough. On this task we have specified a time
-in minutes that the task will take. This can be done using the `[time=15]` annotation,
-where `15` is the amount of minutes the task will take. This information will be
-used when displaying any overview pages for the walkthrough. If a `time` is not
-set on a task, it will be treated as `0` minutes.
-
-Tasks do not need to be split into steps. They can just be raw asciidoc dropped into
-the file. So as long as we do not include a h3 section in this task, there will be
-no steps in the task.
-
-==== A h4 heading
-
-Only h3 headings are treated as steps, so adding in a h4 heading is treated as
-raw asciidoc. This also means that verification blocks cannot be specified in
-these blocks.
+== Advanced asciidoc
 

--- a/public/walkthroughs/writing-walkthroughs/walkthrough.adoc
+++ b/public/walkthroughs/writing-walkthroughs/walkthrough.adoc
@@ -1,11 +1,47 @@
 = A custom walkthrough
 
-This is the first sentence of the walkthrough's preamble. It will be used as the
-short description for the walkthrough.
+The first sentence is used as the short description for the walkthrough.
 
-These lines will be included in the long description of the walkthrough. Normally
-this content will be shown on the overview page for a walkthough. However, it is
-excluded from the short description.
+----
+= Demonstrating a custom walkthrough // <1>
+
+A short description for the walkthrough. // <2>
+
+But this text is displayed on the {intro} page.
+
+== Doing a task <3>
+
+This is the overview for the first task in the walkthrough.
+
+=== Doing a step <4>
+
+. Do this first: <5>
+. Do this second: <5>
+
+[type=verification] <6>
+****
+This block will render as a verification box with a yes/no checkbox.
+
+. Check this thing.
+. Check that thing.
+****
+
+=== Doing a second step
+
+. Do first item.
+
+[type=verification]
+Notice that a single line verification does not require `****`.
+
+[type=verificationFail]
+If you have a workaround, put it here.
+
+[start=2]
+. Do third item.
+----
+
+<1> The walkthrough title
+
 
 To start a task we need to use a h2 heading.
 

--- a/public/walkthroughs/writing-walkthroughs/walkthrough.json
+++ b/public/walkthroughs/writing-walkthroughs/walkthrough.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": {
+    "repos": [{
+      "repoName": "test",
+      "cloneUrl": "https://github.com/pb82/awesome-operators"
+    }],
+    "serviceInstances": [{
+      "metadata": {
+        "name": "nodejs-messaging-work-queue-frontend",
+        "labels": { "creates-route": "frontend" }
+      },
+      "spec": {
+        "clusterServiceClassExternalName": "nodejs-messaging-work-queue-frontend",
+        "clusterServicePlanExternalName": "default"
+      }
+    }]
+  }
+}


### PR DESCRIPTION
## Motivation
Custom walkthroughs contain a lot of i8 specific syntax, that needs to be explained
## What
add samples with callouts to explain syntax

## Progress

- [x] draft callout wt
- [x] split into small samples
- [x] overview sample
- [ ] task resources sample
- [ ] walkthrough resources and attributes
- [ ] verfications - fails, and numbering
- [ ] using sectnums
