### PR TITLE
rely on asciidoc sectnums only for numbering

### DIFF
--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -123,7 +123,7 @@ class TutorialPage extends React.Component {
                   {parsedThread.tasks.map((task, i) => (
                     <ListView.Item
                       key={i}
-                      heading={`${i + 1}. ${task.title}`}
+                      heading={`${task.title}`}
                       description={task.shortDescription}
                       actions={
                         <div className="integr8ly-task-dashboard-estimated-time">


### PR DESCRIPTION
We're using asciidoc `:sectnums:` to automate the numbering. This PR removes the built-in numbering in the tutorial overview to avoid double numbers.

Before:
![bildschirmfoto 2018-11-28 um 12 45 16](https://user-images.githubusercontent.com/1851198/49149942-c3cd4680-f30b-11e8-85ba-0baadda5f257.png)

After:
![bildschirmfoto 2018-11-28 um 12 45 37](https://user-images.githubusercontent.com/1851198/49149954-c92a9100-f30b-11e8-8f46-32d6e7f7badd.png)
