### PR TITLE
Remove whitespace under navbar

### DIFF
--- a/src/styles/application/_nav.scss
+++ b/src/styles/application/_nav.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable selector-class-pattern */
 .navbar {
-  height: 40px;
   min-height: 40px;
   z-index: 5;
 }


### PR DESCRIPTION
## Motivation
Bug filed in the Trello card from UX.

## What
Remove the whitespace under the navigation.

## Why
Bug

## How
Delete fixed height property.

## Verification Steps

1. Run the webapp
2. View the dashboard, where the blue masthead is located - there should not be a space between the navbar and the masthead.

## Checklist:

- [X] Code has been tested locally by PR requester

## Progress

- [x] Finished task