### PR TITLE
fix(labels): Update labels to show GA and match designs

### DIFF
--- a/src/styles/application/_labels.scss
+++ b/src/styles/application/_labels.scss
@@ -1,23 +1,13 @@
 .integr8ly-label {
-  &-community {
-    position: absolute;
-    right: var(--pf-global--spacer--lg);
-    padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
-    border: var(--pf-global--BorderWidth--sm) solid;
-    border-color: $pf-color-black-300;
-    background-color: $pf-color-black-300;
-    color: $pf-color-black-900;
-    font-size: var(--pf-global--FontSize--xs) !important; /* stylelint-disable-line declaration-no-important */
-    font-weight: var(--pf-global--FontWeight--bold);
-  }
-
+  &-community,
+  &-GA,
   &-preview {
     position: absolute;
     right: var(--pf-global--spacer--lg);
     padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
+    background-color: $pf-color-black-300;
     border: var(--pf-global--BorderWidth--sm) solid;
-    border-color: $pf-color-blue-200;
-    background-color: $pf-color-blue-200;
+    border-color: $pf-color-black-300;
     color: $pf-color-black-900;
     font-size: var(--pf-global--FontSize--xs) !important; /* stylelint-disable-line declaration-no-important */
     font-weight: var(--pf-global--FontWeight--bold);


### PR DESCRIPTION
## Motivation
Fix and close https://github.com/integr8ly/tutorial-web-app/issues/300

## What
The GA labels were not appearing in the UI, although the code is rendering them.

## Why
The CSS had not been updated to handle to GA label.

## How
Add a CSS class to match what the UI is rendering.

## Verification Steps

1. Open the webapp
2. View the dashboard
3. Check the Application list for the GA label

## Checklist:

- [X] Code has been tested locally by PR requester

## Progress

- [x] Finished task

## Additional Notes

This PR also addresses the new [designs](https://redhat.invisionapp.com/d/main#/console/15529764/324779895/preview), where the colors of the labels are simplified to be the same, no matter the label type.
![screen shot 2018-11-29 at 1 42 36 pm](https://user-images.githubusercontent.com/4032718/49244309-7e794980-f3dd-11e8-881b-16d6dfc1b3e2.png)
