### PR TITLE
fix(navbar): Change border from blue to red

### DIFF
--- a/src/styles/application/_nav.scss
+++ b/src/styles/application/_nav.scss
@@ -6,6 +6,8 @@
 }
 
 .navbar-pf-vertical {
+  border-top-color: $pf-color-red-100;
+
   .navbar-brand {
     padding: 8px 0 0;
     min-height: auto;


### PR DESCRIPTION
## Motivation
Close https://github.com/integr8ly/tutorial-web-app/issues/302

## What
Navbar border incorrect color.

## Why
A bug was introduced where the border was changed to blue. It should be red.

## How
Add `border-top-color` to overwrite the blue color.

## Verification Steps

1. Start/open the webapp
2. Look at the top border of the navbar

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task