### PR TITLE
fixes issue with GA appending to service names

### DIFF
--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -107,7 +107,11 @@ class InstalledAppsView extends React.Component {
         >
           <div className="integr8ly-installed-apps-view-title">
             <p>{prettyName}</p>
-            <span className={`integr8ly-label-${gaStatus}`}>{gaStatus}</span>
+            {gaStatus && (gaStatus === 'preview' || gaStatus === 'community') ? (
+              <span className={`integr8ly-label-${gaStatus}`}>{gaStatus}</span>
+            ) : (
+              <span />
+            )}
           </div>
           {InstalledAppsView.getStatusForApp(app)}
           <small />


### PR DESCRIPTION
## Motivation
Fixes issue #304 

## What
Small code change to only allow display of preview or community status for ga status, so if GA is added, it will be ignored (but also deals with any other rogue status typed into the json).

## Why
'GA' was being appended to any service that had a gastatus of 'GA' in the json files.

## How
Added a conditional that checks for a gastatus of preview or community before displaying.

## Verification Steps
1. Go to home page.
2. View Applications list on the right.
3. Verify that there are no longer application names that have 'GA' at the end (e.g. Red Hat AMQGA)

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

**Before:**
![screen shot 2018-11-29 at 2 44 11 pm](https://user-images.githubusercontent.com/39063664/49252370-df128180-f3f1-11e8-9f70-6a116b330f6b.png)

**After:**
![screen shot 2018-11-29 at 4 15 35 pm](https://user-images.githubusercontent.com/39063664/49252437-0e28f300-f3f2-11e8-90ec-35dce05e8edb.png)


