### PR TITLE
Add space between diagram and header

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -104,7 +104,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
         xs={12}
       >
         <h1
-          className="pf-c-title pf-m-2xl integr8ly-header-after-diagram"
+          className="pf-c-title pf-m-2xl pf-u-mt-xl"
         >
           tutorial.tasksToComplete
           <div

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -104,7 +104,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
         xs={12}
       >
         <h1
-          className="pf-c-title pf-m-2xl"
+          className="pf-c-title pf-m-2xl integr8ly-header-after-diagram"
         >
           tutorial.tasksToComplete
           <div

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -93,7 +93,7 @@ class TutorialPage extends React.Component {
             </Grid.Row>
             <Grid.Row>
               <Grid.Col xs={12} sm={9}>
-                <h1 className="pf-c-title pf-m-2xl">
+                <h1 className="pf-c-title pf-m-2xl integr8ly-header-after-diagram">
                   {t('tutorial.tasksToComplete')}
                   <div className="pull-right integr8ly-task-dashboard-time-to-completion">
                     <Icon type="fa" name="clock" style={{ marginRight: 5 }} />

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -93,7 +93,7 @@ class TutorialPage extends React.Component {
             </Grid.Row>
             <Grid.Row>
               <Grid.Col xs={12} sm={9}>
-                <h1 className="pf-c-title pf-m-2xl integr8ly-header-after-diagram">
+                <h1 className="pf-c-title pf-m-2xl pf-u-mt-xl">
                   {t('tutorial.tasksToComplete')}
                   <div className="pull-right integr8ly-task-dashboard-time-to-completion">
                     <Icon type="fa" name="clock" style={{ marginRight: 5 }} />

--- a/src/styles/application/_patternfly4.scss
+++ b/src/styles/application/_patternfly4.scss
@@ -198,6 +198,10 @@ ol {
 }
 /* stylelint-enable */
 
+.integr8ly-header-after-diagram {
+  margin-top: 30px;
+}
+
 .integr8ly-docs-header {
   h5 {
     font-size: $h3-font-size;

--- a/src/styles/application/_patternfly4.scss
+++ b/src/styles/application/_patternfly4.scss
@@ -198,10 +198,6 @@ ol {
 }
 /* stylelint-enable */
 
-.integr8ly-header-after-diagram {
-  margin-top: 30px;
-}
-
 .integr8ly-docs-header {
   h5 {
     font-size: $h3-font-size;


### PR DESCRIPTION
## Motivation
Was logged as an issue on the trello card for single walkthrough that there was not enough space between the diagram and the h1 that followed.

## What
Added a new style to handle this case.

## Why
Space was too small between diagram and H1.

## How
CSS addition for this case.

## Verification Steps
1. Navigate to the landing page for a specific walkthrough.
2. Verify that there is sufficient space between the diagram and the 'Tasks to Complete in this Walkthrough' header

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

**Before:**
![diagram_before](https://user-images.githubusercontent.com/39063664/49298916-8512ca00-f48c-11e8-94a0-69716c467f9f.png)

**After:**
![diagram_after](https://user-images.githubusercontent.com/39063664/49298926-880dba80-f48c-11e8-8595-fa70e77bf75a.png)
