### PR TITLE
allow importing walkthroughs from git repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,16 @@ FROM bucharestgold/centos7-s2i-nodejs:10.x
 EXPOSE 5001
 
 ENV BUILD_ENV=OCP
+ENV GIT_COMMITTER_NAME=integreatly
+ENV GIT_COMMITTER_EMAIL=integreatly@redhat.com
 
 USER default
 
 COPY . ./
 
 USER root
+
+RUN yum -y install git
 
 RUN chmod g+w yarn.lock
 

--- a/git_client.js
+++ b/git_client.js
@@ -1,5 +1,12 @@
 const simpleGit = require('simple-git/promise')(__dirname);
+const path = require('path');
+const url = require('url');
 const fs = require('fs');
+
+function getRepoName(repoUrl) {
+  const parsed = url.parse(repoUrl);
+  return path.basename(parsed.path);
+}
 
 exports.cloneRepo = (repoUrl, targetDir) =>
   new Promise((resolve, reject) => {
@@ -8,8 +15,11 @@ exports.cloneRepo = (repoUrl, targetDir) =>
       fs.mkdirSync(targetDir);
     }
 
+    const repoName = getRepoName(repoUrl);
+    const clonePath = path.join(targetDir, repoName);
+
     simpleGit
-      .clone(repoUrl, targetDir, { '--depth': 1 })
-      .then(resolve)
+      .clone(repoUrl, clonePath, { '--depth': 1 })
+      .then(() => resolve(clonePath))
       .catch(reject);
   });

--- a/git_client.js
+++ b/git_client.js
@@ -1,0 +1,15 @@
+const simpleGit = require('simple-git/promise')(__dirname);
+const fs = require('fs');
+
+exports.cloneRepo = (repoUrl, targetDir) =>
+  new Promise((resolve, reject) => {
+    // Ensure directory exists
+    if (!fs.existsSync(targetDir)) {
+      fs.mkdirSync(targetDir);
+    }
+
+    simpleGit
+      .clone(repoUrl, targetDir, { '--depth': 1 })
+      .then(resolve)
+      .catch(reject);
+  });

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "watch:css": "yarn build:css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/styles/index.scss -o src/styles/.css --watch --recursive",
     "build:js": "react-scripts build",
     "start": "node server.js",
-    "start:dev": "WALKTHROUGH_LOCATIONS=https://github.com/integr8ly/tutorial-web-app-walkthroughs FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" run-p -l watch:css start:local start:server",
+    "start:dev": "FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" run-p -l watch:css start:local start:server",
     "start:local": "react-scripts start",
     "start:server": "nodemon --watch server.js --exec 'node server.js'",
     "commit:hash": "echo REACT_APP_UI_COMMIT_HASH=$(git rev-list -1 --all) > .env",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "redux-logger": "3.0.6",
     "redux-promise-middleware": "5.1.1",
     "redux-thunk": "2.3.0",
-    "rimraf": "2.6.2"
+    "rimraf": "2.6.2",
+    "simple-git": "^1.107.0"
   },
   "devDependencies": {
     "babel-eslint": "8.2.6",
@@ -75,7 +76,7 @@
     "watch:css": "yarn build:css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/styles/index.scss -o src/styles/.css --watch --recursive",
     "build:js": "react-scripts build",
     "start": "node server.js",
-    "start:dev": "WALKTHROUGH_LOCATIONS=../tutorial-web-app-walkthroughs/walkthroughs SHOW_EXAMPLE_WALKTHROUGH=true FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" run-p -l watch:css start:local start:server",
+    "start:dev": "WALKTHROUGH_LOCATIONS=https://github.com/integr8ly/tutorial-web-app-walkthroughs FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 OPENSHIFT_OAUTHCLIENT_ID=\"tutorial-web-app\" run-p -l watch:css start:local start:server",
     "start:local": "react-scripts start",
     "start:server": "nodemon --watch server.js --exec 'node server.js'",
     "commit:hash": "echo REACT_APP_UI_COMMIT_HASH=$(git rev-list -1 --all) > .env",

--- a/server.js
+++ b/server.js
@@ -147,9 +147,9 @@ function resolveWalkthroughLocations(locations) {
       } else if (isGitRepo(location)) {
         console.log(`Importing walkthrough from git ${location}`);
         const clonePath = path.join(TMP_DIR, TMP_DIR_PREFIX);
-        const walkthroughsPath = path.join(clonePath, 'walkthroughs');
-        return gitClient.cloneRepo(location, clonePath)
-          .then(() => resolve(walkthroughsPath))
+        return gitClient
+          .cloneRepo(location, clonePath)
+          .then(cloned => resolve(path.join(cloned, 'walkthroughs')))
           .catch(reject);
       }
       return reject(new Error(`${location} is neither a path nor a git repo`));

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ const DEFAULT_CUSTOM_CONFIG_DATA = {
   services: []
 };
 
-const walkthroughLocations = process.env.WALKTHROUGH_LOCATIONS || './public/walkthroughs';
+const walkthroughLocations = process.env.WALKTHROUGH_LOCATIONS || 'https://github.com/integr8ly/tutorial-web-app-walkthroughs';
 const IGNORED_WALKTHROUGH_SEARCH_PATHS = ['.git', '.idea', '.DS_Store'];
 
 const CONTEXT_PREAMBLE = 'preamble';

--- a/server.js
+++ b/server.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const path = require('path');
+const url = require('url');
 const fs = require('fs');
 const asciidoctor = require('asciidoctor.js');
 const adoc = asciidoctor();
 const Mustache = require('mustache');
 const { fetchOpenshiftUser } = require('./server_middleware');
 const giteaClient = require('./gitea_client');
+const gitClient = require('./git_client');
 const bodyParser = require('body-parser');
 
 const app = express();
@@ -24,6 +26,8 @@ const IGNORED_WALKTHROUGH_SEARCH_PATHS = ['.git', '.idea', '.DS_Store'];
 const CONTEXT_PREAMBLE = 'preamble';
 const CONTEXT_PARAGRAPH = 'paragraph';
 const LOCATION_SEPARATOR = ',';
+const TMP_DIR = process.env.TMP_DIR || '/tmp';
+const TMP_DIR_PREFIX = require('uuid').v4();
 
 const walkthroughs = [];
 
@@ -93,8 +97,9 @@ app.get('/walkthroughs/:walkthroughId/files/*', (req, res) => {
 
 /**
  * Load walkthroughs from the passed locations.
- * @param location (string) Either a single path or a number of paths separated
- * by comma
+ * @param location (string) A string that can contains one or more walkthrough locations.
+ * Locations can either be paths in the filesystem or URLs pointing to git repositories. IF
+ * multiple locations are provided they must be separated by LOCATION_SEPARATOR
  */
 function loadAllWalkthroughs(location) {
   let locations = [];
@@ -104,49 +109,111 @@ function loadAllWalkthroughs(location) {
     locations.push(location);
   }
 
-  locations.forEach(p => {
-    if (p && fs.existsSync(p)) {
-      return loadCustomWalkthroughs(p);
+  return resolveWalkthroughLocations(locations)
+    .then(l => Promise.all(l.map(lookupWalkthroughResources)))
+    .then(l => l.reduce((a, b) => a.concat(b)), []) // flatten walkthrough arrays of all locations
+    .then(l => l.map(importWalkthroughAdoc))
+    .then(l => Promise.all(l));
+}
+
+/**
+ * Parses the locations provided in the env var `WALKTHROUGH_LOCATIONS` and resolves them:
+ * If the location is a git repository it will be cloned and the path to the cloned repository
+ * will be returned.
+ * If the location is a path in the filesystem it will be returned directly.
+ * @param locations An array of paths or URLs
+ * @returns {Promise<any[]>}
+ */
+function resolveWalkthroughLocations(locations) {
+  function isGitRepo(p) {
+    if (!p) {
+      return false;
     }
-    console.error(`Invalid walkthrough location ${p}`);
-    return process.exit(1);
+    const parsed = url.parse(p);
+    return parsed.host && parsed.protocol;
+  }
+
+  function isPath(p) {
+    return p && fs.existsSync(p);
+  }
+
+  const mappedLocations = locations.map(location => {
+    return new Promise((resolve, reject) => {
+      if (!location) {
+        return reject(new Error(`Invalid location ${location}`));
+      } else if (isPath(location)) {
+        console.log(`Importing walkthrough from path ${location}`);
+        return resolve(location);
+      } else if (isGitRepo(location)) {
+        console.log(`Importing walkthrough from git ${location}`);
+        const clonePath = path.join(TMP_DIR, TMP_DIR_PREFIX);
+        const walkthroughsPath = path.join(clonePath, 'walkthroughs');
+        return gitClient.cloneRepo(location, clonePath)
+          .then(() => resolve(walkthroughsPath))
+          .catch(reject);
+      }
+      return reject(new Error(`${location} is neither a path nor a git repo`));
+    });
+  });
+
+  return Promise.all(mappedLocations);
+}
+
+/**
+ * Check if a walkthrough location is valid and contains `walkthrough.adoc`
+ * @param location Path to the walkthrough directory
+ * @returns {Promise<any>}
+ */
+function lookupWalkthroughResources(location) {
+  return new Promise((resolve, reject) => {
+    fs.readdir(location, (err, files) => {
+      if (err) {
+        return reject(err);
+      }
+
+      const adocInfo = files.reduce((acc, dirName) => {
+        const basePath = path.join(location, dirName);
+        const adocPath = path.join(basePath, 'walkthrough.adoc');
+        if (fs.existsSync(adocPath)) {
+          acc.push({
+            dirName,
+            basePath,
+            adocPath
+          });
+        } else {
+          console.log(`No walkthrough.adoc present in ${basePath}`);
+        }
+        return acc;
+      }, []);
+      return resolve(adocInfo);
+    });
   });
 }
 
-function loadCustomWalkthroughs(walkthroughsPath) {
-  fs.readdir(walkthroughsPath, (err, files) => {
+/**
+ * Load and process the Asciidoc of a walkthrough. Also checks if any of the walkthrough
+ * IDs are duplicate and rejects them in that case.
+ * @param adocContext (Object) Contains filesystem info about the walkthrough location
+ * @returns {Promise<any>}
+ */
+function importWalkthroughAdoc(adocContext) {
+  const { adocPath, dirName, basePath } = adocContext;
 
-    files.forEach(dirName => {
-      const basePath = path.join(walkthroughsPath, dirName);
-
-      if (IGNORED_WALKTHROUGH_SEARCH_PATHS.indexOf(dirName) >= 0) {
-        console.log(`Skipping ignored search path ${dirName}`);
-        return;
+  return new Promise((resolve, reject) => {
+    fs.readFile(adocPath, (err, rawAdoc) => {
+      if (err) {
+        return reject(err);
       }
-
-      if (!fs.statSync(basePath).isDirectory()) {
-        console.log(`Skipping non-directory location ${dirName}`);
-        return;
+      const loadedAdoc = adoc.load(rawAdoc);
+      const walkthroughInfo = getWalkthroughInfoFromAdoc(dirName, basePath, loadedAdoc);
+      // Don't allow duplicate walkthroughs
+      if (walkthroughs.find(wt => wt.id === walkthroughInfo.id)) {
+        return reject(
+          new Error(`Duplicate walkthrough with id ${walkthroughInfo.id} (${walkthroughInfo.shortDescription})`)
+        );
       }
-
-      fs.readFile(path.join(basePath, 'walkthrough.adoc'), (readError, rawAdoc) => {
-        if (readError) {
-          console.error(readError);
-          process.exit(1);
-        }
-
-        const loadedAdoc = adoc.load(rawAdoc);
-        // Don't show example walkthrough by default
-        if (process.env.SHOW_EXAMPLE_WALKTHROUGH === 'true' || dirName !== 'my-custom-walkthrough') {
-          const walkthroughInfo = getWalkthroughInfoFromAdoc(dirName, basePath, loadedAdoc);
-          // Don't allow duplicate walkthroughs
-          if (walkthroughs.find(wt => wt.id === walkthroughInfo.id)) {
-            console.error(`Duplicate walkthrough with id ${walkthroughInfo.id} (${walkthroughInfo.shortDescription})`);
-            process.exit(1);
-          }
-          walkthroughs.push(walkthroughInfo);
-        }
-      });
+      walkthroughs.push(walkthroughInfo);
+      return resolve();
     });
   });
 }
@@ -302,6 +369,15 @@ if (process.env.NODE_ENV === 'production') {
   });
 }
 
-loadAllWalkthroughs(walkthroughLocations);
+function run() {
+  loadAllWalkthroughs(walkthroughLocations)
+    .then(() => {
+      app.listen(port, () => console.log(`Listening on port ${port}`));
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
 
-app.listen(port, () => console.log(`Listening on port ${port}`));
+run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,7 +2823,7 @@ debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.1.0:
+debug@^4.0.0, debug@^4.0.1, debug@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   dependencies:
@@ -9589,6 +9589,12 @@ shellwords@^0.1.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-git@^1.107.0:
+  version "1.107.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.107.0.tgz#12cffaf261c14d6f450f7fdb86c21ccee968b383"
+  dependencies:
+    debug "^4.0.1"
 
 sisteransi@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
## Motivation

Allow importing walkthroughs from git repositories. Git repos can be specified in the `WALKTHROUGH_LOCATIONS` env var. Multiple repos and mixing repos and paths is supported.

The repositories will by default be cloned into a randomized directory under `/tmp`, but the base directory can be overridden using an env var `TMP_DIR`.

## Verification steps

1. run `yarn start:dev`. It's already pointing to included walkthroughs repo (https://github.com/integr8ly/tutorial-web-app-walkthroughs). Everything should work as usual.
1. Check your `/tmp` directory. There should be a randomized subdirectory (uuid) containing the walkthrough.
1. If you run it again, it will create a new directory.