### PR TITLE
Fix: Limit the length of namespace names to prevent Routes that are too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "redux-logger": "3.0.6",
     "redux-promise-middleware": "5.1.1",
     "redux-thunk": "2.3.0",
-    "rimraf": "2.6.2"
+    "rimraf": "2.6.2",
+    "sha.js": "2.4.11"
   },
   "devDependencies": {
     "babel-eslint": "8.2.6",

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -19,10 +19,10 @@ const getDocsForWalkthrough = (walkthroughId, middlewareServices, walkthroughRes
 
 const getUserAttrs = (walkthroughId, username) => ({
   'openshift-host': window.OPENSHIFT_CONFIG.masterUri,
-  'project-namespace': buildValidProjectNamespaceName(username, 'walkthrough-projects'),
+  'project-namespace': buildValidProjectNamespaceName(username, 'shared'),
   'walkthrough-namespace': buildValidProjectNamespaceName(
     username,
-    walkthroughId || buildValidProjectNamespaceName(username, 'walkthrough-projects')
+    walkthroughId || buildValidProjectNamespaceName(username, 'shared')
   ),
   'user-username': username,
   'user-sanitized-username': cleanUsername(username)

--- a/src/common/openshiftHelpers.js
+++ b/src/common/openshiftHelpers.js
@@ -1,12 +1,15 @@
 import { create, list } from '../services/openshiftServices';
+import shajs from 'sha.js';
 
 /**
  * Construct a projects namespace from a given username.
  * Note that the namespace name might contain the full username as it is sanitized first.
+ * The namespace will be limited to 40 characters max so as to allow reasonable length route
+ * names to be created i.e. not hit a 65 character limit.
  * @param {string} username The username to create the namespace name from.
  * @param {string} suffix A suffix to append to the end of the users namespace.
  */
-const buildValidProjectNamespaceName = (username, suffix) => `${cleanUsername(username)}-${suffix}`;
+const buildValidProjectNamespaceName = (username, suffix) => trimAndHash(`${cleanUsername(username)}-${suffix}`);
 
 /**
  * Get a sanitized version of a username, so it can be used to name OpenShift.
@@ -17,6 +20,9 @@ const cleanUsername = username =>
     .replace(/@/g, '-')
     .replace(/\./g, '-')
     .replace(/\s/g, '-');
+
+const trimAndHash = namespace =>
+  namespace.length > 40 ? namespace.slice(0,35) + '-' + shajs('sha256').update(namespace).digest('hex').slice(-4) : namespace;
 
 const buildNamespacedServiceInstanceName = (prefix, si) => `${prefix}-${si.spec.to.name}`;
 

--- a/src/common/openshiftHelpers.js
+++ b/src/common/openshiftHelpers.js
@@ -1,5 +1,5 @@
-import { create, list } from '../services/openshiftServices';
 import shajs from 'sha.js';
+import { create, list } from '../services/openshiftServices';
 
 /**
  * Construct a projects namespace from a given username.
@@ -21,8 +21,18 @@ const cleanUsername = username =>
     .replace(/\./g, '-')
     .replace(/\s/g, '-');
 
-const trimAndHash = namespace =>
-  namespace.length > 40 ? namespace.slice(0,35) + '-' + shajs('sha256').update(namespace).digest('hex').slice(-4) : namespace;
+const trimAndHash = namespace => {
+  if (namespace.length > 40) {
+    namespace = `${namespace.slice(0, 35)}-${trimmedHash(namespace)}`;
+  }
+  return namespace;
+};
+
+const trimmedHash = namespace =>
+  shajs('sha256')
+    .update(namespace)
+    .digest('hex')
+    .slice(-4);
 
 const buildNamespacedServiceInstanceName = (prefix, si) => `${prefix}-${si.spec.to.name}`;
 

--- a/src/common/openshiftHelpers.js
+++ b/src/common/openshiftHelpers.js
@@ -9,7 +9,8 @@ import { create, list } from '../services/openshiftServices';
  * @param {string} username The username to create the namespace name from.
  * @param {string} suffix A suffix to append to the end of the users namespace.
  */
-const buildValidProjectNamespaceName = (username, suffix) => trimAndHash(`${cleanUsername(username)}-${suffix}`);
+const buildValidProjectNamespaceName = (username, suffix) =>
+  trimAndHash(`${cleanUsername(username)}-${suffix}`).toLowerCase();
 
 /**
  * Get a sanitized version of a username, so it can be used to name OpenShift.

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -91,7 +91,7 @@ const manageMiddlewareServices = (dispatch, user, config) => {
     type: FULFILLED_ACTION(middlewareTypes.GET_PROVISIONING_USER),
     payload: { provisioningUser: user.username }
   });
-  const userNamespace = buildValidProjectNamespaceName(user.username, 'walkthrough-projects');
+  const userNamespace = buildValidProjectNamespaceName(user.username, 'shared');
   const namespaceObj = namespaceResource(userNamespace);
   const namespaceRequestObj = namespaceRequestResource(userNamespace);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9549,7 +9549,7 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
-sha.js@^2.4.0, sha.js@^2.4.8:
+sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   dependencies:


### PR DESCRIPTION
Some examples of how this will affect namespace names:

`admin-example-com-walkthrough-projects` stays the same

`admin-example-com-1-integrating-event-and-api-driven-apps` becomes
`admin-example-com-1-integrating-eve-HASH`

`evals22-example-com-1-integrating-event-and-api-driven-apps` becomds
`evals22-example-com-1-integrating-e-HASH`

The namespace should still be deterministic.

This change is *NOT* backwards compatible, and will result in a new namespace being created on first login.
This is OK for all newly provisioned clusters.

fixes #329