### PR TITLE
Reduce namespace length down to 20 characters

### DIFF
--- a/src/common/__tests__/openshiftHelpers.test.js
+++ b/src/common/__tests__/openshiftHelpers.test.js
@@ -1,0 +1,21 @@
+import { buildValidProjectNamespaceName } from '../openshiftHelpers';
+
+describe('OpenShift Helpers', () => {
+  it('should correctly trim the namespace name when it is too long', () => {
+    const namespace = buildValidProjectNamespaceName('verylongusername', 'verylongsuffix');
+    expect(namespace).toHaveLength(20);
+    expect(namespace).toBe('verylongus-very-c423');
+  });
+
+  it('should have a longer suffix if the username is short', () => {
+    const namespace = buildValidProjectNamespaceName('u', 'myverylongsuffix');
+    expect(namespace).toHaveLength(20);
+    expect(namespace).toBe('u-myverylongsuf-e2f4');
+  });
+
+  it('should not trim the namespace when username and suffix are too short', () => {
+    const namespace = buildValidProjectNamespaceName('u', 's');
+    expect(namespace).toHaveLength(8);
+    expect(namespace).toBe('u-s-b507');
+  });
+});

--- a/src/common/openshiftResourceDefinitions.js
+++ b/src/common/openshiftResourceDefinitions.js
@@ -3,22 +3,19 @@ const namespaceRequestDef = {
   version: 'v1',
   group: 'project.openshift.io'
 };
-const namespaceRequestResource = name => ({
+const namespaceRequestResource = (displayName, metadata) => ({
   kind: 'ProjectRequest',
-  metadata: {
-    name
-  }
+  displayName,
+  metadata
 });
 const namespaceDef = {
   name: 'projects',
   version: 'v1',
   group: 'project.openshift.io'
 };
-const namespaceResource = name => ({
+const namespaceResource = metadata => ({
   kind: 'projects',
-  metadata: {
-    name
-  }
+  metadata
 });
 const statefulSetDef = namespace => ({
   name: 'statefulsets',

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -8,6 +8,7 @@ import {
 } from '../common/serviceInstanceHelpers';
 import {
   buildValidProjectNamespaceName,
+  buildValidNamespaceDisplayName,
   cleanUsername,
   findOpenshiftResource,
   findOrCreateOpenshiftResource
@@ -92,8 +93,9 @@ const manageMiddlewareServices = (dispatch, user, config) => {
     payload: { provisioningUser: user.username }
   });
   const userNamespace = buildValidProjectNamespaceName(user.username, 'shared');
-  const namespaceObj = namespaceResource(userNamespace);
-  const namespaceRequestObj = namespaceRequestResource(userNamespace);
+  const namespaceDisplayName = buildValidNamespaceDisplayName(user.username, 'Shared Services');
+  const namespaceObj = namespaceResource({ name: userNamespace });
+  const namespaceRequestObj = namespaceRequestResource(namespaceDisplayName, { name: userNamespace });
 
   // Namespace
   findOrCreateOpenshiftResource(

--- a/src/services/walkthroughServices.js
+++ b/src/services/walkthroughServices.js
@@ -3,7 +3,11 @@ import Mustache from 'mustache';
 import serviceConfig from './config';
 import { watch, currentUser, OpenShiftWatchEvents } from './openshiftServices';
 import { initCustomThread } from './threadServices';
-import { buildValidProjectNamespaceName, findOrCreateOpenshiftResource } from '../common/openshiftHelpers';
+import {
+  buildValidProjectNamespaceName,
+  findOrCreateOpenshiftResource,
+  buildValidNamespaceDisplayName
+} from '../common/openshiftHelpers';
 import { buildServiceInstanceCompareFn } from '../common/serviceInstanceHelpers';
 import {
   namespaceResource,
@@ -47,8 +51,9 @@ const prepareCustomWalkthroughNamespace = (dispatch, walkthoughName, attrs = {})
       dispatch(initCustomThreadSuccess(manifest));
       currentUser().then(user => {
         const userNamespace = buildValidProjectNamespaceName(user.username, walkthoughName);
-        const namespaceObj = namespaceResource(userNamespace);
-        const namespaceRequestObj = namespaceRequestResource(userNamespace);
+        const namespaceDisplayName = buildValidNamespaceDisplayName(user.username, walkthoughName);
+        const namespaceObj = namespaceResource({ name: userNamespace });
+        const namespaceRequestObj = namespaceRequestResource(namespaceDisplayName, { name: userNamespace });
 
         return findOrCreateOpenshiftResource(
           namespaceDef,


### PR DESCRIPTION
Currently, we are seeing issues with route lengths going above the
maximum limit. This is partially because namespace lengths are too
long. This change reduces the namespace length down to 20 characters
with the format {trimmedUsername}-{trimmedSuffix}-{hash} where:

- trimmedUsername is 10 characters or less
- hash is 4 characters
- trimmedSuffix makes up the remaining characters
