### PR TITLE
[WIP] Include tutorial walkthroughs in the web app

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,13 @@ First you need to clone the https://github.com/integr8ly/tutorial-web-app-walkth
 $ git clone https://github.com/integr8ly/tutorial-web-app-walkthroughs.git
 ----
 
+To include walkthroughs on how to develop custom walkthroughs, the https://github.com/integr8ly/tutorial-web-app-walkthroughs.git[tutorials repository] should be cloned next to the tutorial web app
+
+[source,shell]
+----
+$ git clone https://github.com/integr8ly/tutorial-web-app-walkthroughs.git
+----
+
 === Install dependencies
 Then change to the webapp directory, install its dependencies and run the development server:
 
@@ -59,6 +66,13 @@ IMPORTANT: The webapp will automatically open (http://localhost:3006) in your br
 When running locally, the available services list is mocked, and service urls set via env vars.
 
 The webapp will also automatically load the walkthroughs from `../tutorial-web-app-walkthroughs/walkthroughs`.
+
+To include the walkthroughs on how to add a custom walkthrough, override the `WALKTHROUGH_LOCATIONS` environment variable:
+
+[source,shell]
+----
+$ WALKTHROUGH_LOCATIONS=../tutorial-web-app-walkthroughs/walkthroughs,../example-customisations/walkthroughs yarn start:dev
+----
 
 === Setup Local Development of Walkthroughs
 

--- a/server.js
+++ b/server.js
@@ -11,6 +11,9 @@ const gitClient = require('./git_client');
 const bodyParser = require('body-parser');
 const uuid = require('uuid');
 
+const DEFAULT_WALKTHROUGH_REPOS = 'https://github.com/integr8ly/tutorial-web-app-walkthroughs.git,https://github.com/integr8ly/example-customisations.git';
+const DEFAULT_WALKTHROUGH_PATHS = '../tutorial-web-app-walkthroughs/walkthroughs';
+
 const app = express();
 app.use(bodyParser.json());
 
@@ -21,7 +24,7 @@ const DEFAULT_CUSTOM_CONFIG_DATA = {
   services: []
 };
 
-const walkthroughLocations = process.env.WALKTHROUGH_LOCATIONS || (process.env.NODE_ENV === 'production' ? 'https://github.com/integr8ly/tutorial-web-app-walkthroughs' : '../tutorial-web-app-walkthroughs/walkthroughs');
+const walkthroughLocations = process.env.WALKTHROUGH_LOCATIONS || (process.env.NODE_ENV === 'production' ? DEFAULT_WALKTHROUGH_REPOS : DEFAULT_WALKTHROUGH_PATHS);
 const IGNORED_WALKTHROUGH_SEARCH_PATHS = ['.git', '.idea', '.DS_Store'];
 
 const CONTEXT_PREAMBLE = 'preamble';


### PR DESCRIPTION
Add instructions for how to use the tutorial walkthroughs repo in the web app when in local development mode. For production, include the example-customisations repo by default.