### PR TITLE
Intly 184

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,7 +22,6 @@ const DEFAULT_CUSTOM_CONFIG_DATA = {
 };
 
 const walkthroughLocations = process.env.WALKTHROUGH_LOCATIONS || (process.env.NODE_ENV === 'production' ? 'https://github.com/integr8ly/tutorial-web-app-walkthroughs' : '../tutorial-web-app-walkthroughs/walkthroughs');
-const IGNORED_WALKTHROUGH_SEARCH_PATHS = ['.git', '.idea', '.DS_Store'];
 
 const CONTEXT_PREAMBLE = 'preamble';
 const CONTEXT_PARAGRAPH = 'paragraph';

--- a/src/common/__tests__/walkthroughHelpers.test.js
+++ b/src/common/__tests__/walkthroughHelpers.test.js
@@ -8,22 +8,30 @@ This is a sample description
 This is a sample overview
 
 [type=walkthroughResource]
-=== A global resource
-
+.A global resource
+****
 resource text
+****
 
 == First task
 
 First task overview
-  
+
+[type=taskResource]
+.A task resource defined at task level
+****
+resource text
+****
+
 === First step
 
 The first task description
 
 [type=taskResource]
-=== A task resource
-
+.A task resource defined at step level
+****
 resource text
+****
 `;
 
 describe('Walkthrough Helpers', () => {
@@ -32,6 +40,6 @@ describe('Walkthrough Helpers', () => {
     expect(walkthrough.title).toBe('Example');
     expect(walkthrough.tasks).toHaveLength(1);
     expect(walkthrough.resources).toHaveLength(1);
-    expect(walkthrough.tasks[0].resources).toHaveLength(1);
+    expect(walkthrough.tasks[0].resources).toHaveLength(2);
   });
 });

--- a/src/common/walkthroughHelpers.js
+++ b/src/common/walkthroughHelpers.js
@@ -275,6 +275,8 @@ class WalkthroughTask {
     return adoc.context === CONTEXT_SECTION && adoc.level === BLOCK_LEVEL_TASK;
   }
 
+  // Task resources can be defined at task or step level so we have to recursively check all blocks
+  // that are lower in the document hierarchy
   static collectTaskResources(task, collected) {
     task.blocks.forEach(block => {
       if (WalkthroughResourceStep.canConvert(block)) {
@@ -332,7 +334,8 @@ class Walkthrough {
     return this._resources;
   }
 
-  static extractWalkthroughResources(preamble) {
+  // Walkthrough resources are always defined at preamble level
+  static collectWalkthroughResources(preamble) {
     const resources = [];
     preamble.blocks = preamble.blocks.reduce((acc, block) => {
       if (WalkthroughResource.canConvert(block)) {
@@ -351,7 +354,7 @@ class Walkthrough {
       throw new Error(`Invalid Walkthrough ${title}`);
     }
 
-    const resources = this.extractWalkthroughResources(adoc.blocks[0]);
+    const resources = this.collectWalkthroughResources(adoc.blocks[0]);
     const preamble = adoc.blocks[0].convert();
     const tasks = adoc.blocks.filter(b => WalkthroughTask.canConvert(b)).map(b => WalkthroughTask.fromAdoc(b));
     const time = tasks.reduce((acc, t) => acc + t._time || 0, 0);


### PR DESCRIPTION
Changes the Syntax for Walkthrough and Task resources. Previously we required the use of third level headings for resources. This conflicts with the Asciidoc standard because a walkthrough resource placed in the Preamble (a h1) can't directly contain a h3 element.

The new Syntax uses delimited blocks:

```asciidoc
[type=walkthroughResource,serviceName=openshift]
.Openshift
****
* link:{openshift-host}/console[Console]
****
```

Verification steps:

1. Create a Walkthrough that uses the new resource format
1. Import that walkthrough locally using `WALKTHROUGH_LOCATIONS`
1. Make sure the resources are rendered correctly

Before this can be merged we need to update all the walkthroughs in https://github.com/integr8ly/tutorial-web-app-walkthroughs to the new format.
