### PR TITLE
INTLY-110 - launch AMQ console directly

### DIFF
--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -101,7 +101,11 @@ class InstalledAppsView extends React.Component {
       const { prettyName, gaStatus } = InstalledAppsView.getProductDetails(app);
       return (
         <li
-          onClick={() => window.open(InstalledAppsView.getRouteForApp(app), '_blank')}
+          onClick={() =>
+            prettyName === 'Red Hat AMQ'
+              ? window.open(InstalledAppsView.getRouteForApp(app).concat('/console'), '_blank')
+              : window.open(InstalledAppsView.getRouteForApp(app), '_blank')
+          }
           key={`${app.spec.clusterServiceClassExternalName}_${index}`}
           value={index}
         >


### PR DESCRIPTION
## Motivation
INTLY-110

## What
Eliminates the extra screen click-through that you needed to go through to get to the AMQ console login page.

## How
Added logic that appends /console to the URL only for the AMQ app.

## Verification Steps

1. Go to the main webapp page that lists all walkthroughs.
2. In the Applications section on the right, click the 'Red Hat AMQ' application to go directly to the AMQ console login page.
3. Click other applications in the Applications section to verify they still work as expected.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Code has been tested on an OpenShift cluster running all middleware applications
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
