### PR TITLE
Change logout label to match openshift

### DIFF
--- a/src/components/masthead/__tests__/__snapshots__/masthead.test.js.snap
+++ b/src/components/masthead/__tests__/__snapshots__/masthead.test.js.snap
@@ -36,7 +36,7 @@ exports[`Masthead Component should render a basic component: user dropdown 1`] =
     header={false}
     onClick={[Function]}
   >
-    Logout
+    Log Out
   </MenuItem>
 </MastheadDropdown>
 `;

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -95,7 +95,7 @@ class Masthead extends React.Component {
 
     return (
       <PfMasthead.Dropdown id="app-user-dropdown" title={title}>
-        <MenuItem onClick={this.onLogoutUser}>Logout</MenuItem>
+        <MenuItem onClick={this.onLogoutUser}>Log Out</MenuItem>
       </PfMasthead.Dropdown>
     );
   }


### PR DESCRIPTION
## Motivation
Fixes issue #213 . Simple string change, fixing because it would take longer to create a JIRA than to just fix now.

## What
Changed 'Logout' label to 'Log Out' to match OpenShift logout command in the masthead.

## Why
Fix bug in which it was called out for inconsistency.

## How
Simple label change

## Verification Steps
Click the user menu and verify command appears a 'Log Out'

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

![screen shot 2018-12-20 at 2 45 27 pm](https://user-images.githubusercontent.com/39063664/50307293-fd562500-0465-11e9-840f-22223bde3dfb.png)
