### PR TITLE
INTLY-107 Allow single step tasks without a title

### DIFF
--- a/src/common/walkthroughHelpers.js
+++ b/src/common/walkthroughHelpers.js
@@ -267,6 +267,10 @@ class WalkthroughTask {
     return this._steps.filter(s => !(s instanceof WalkthroughResourceStep));
   }
 
+  get blocks() {
+    return this._steps;
+  }
+
   get resources() {
     return this._resources;
   }
@@ -292,9 +296,14 @@ class WalkthroughTask {
     const time = parseInt(adoc.getAttribute(BLOCK_ATTR_TIME), 10) || 0;
     const collectedResources = [];
     this.collectTaskResources(adoc, collectedResources);
-    const steps = adoc.blocks.reduce((acc, b) => {
+    const steps = adoc.blocks.reduce((acc, b, i, blockList) => {
       if (WalkthroughStep.canConvert(b)) {
         acc.push(WalkthroughStep.fromAdoc(b));
+      } else if (WalkthroughVerificationBlock.canConvert(b)) {
+        const remainingBlocks = blockList.slice(i + 1, blockList.length);
+        const successBlock = WalkthroughVerificationSuccessBlock.findNextForVerification(remainingBlocks);
+        const failBlock = WalkthroughVerificationFailBlock.findNextForVerification(remainingBlocks);
+        acc.push(new WalkthroughVerificationBlock(b.convert(), successBlock, failBlock));
       } else if (WalkthroughTextBlock.canConvert(b)) {
         acc.push(WalkthroughTextBlock.fromAdoc(b));
       }

--- a/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
+++ b/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
@@ -46,7 +46,7 @@ exports[`AboutModal Component should render a non-connected component: hidden mo
       />
     }
     show={false}
-    trademarkText="Copyright (c) 2018 Red Hat Inc."
+    trademarkText="Copyright (c) 2019 Red Hat Inc."
   >
     <Modal
       animation={true}
@@ -139,7 +139,7 @@ exports[`AboutModal Component should render a non-connected component: show moda
       />
     }
     show={false}
-    trademarkText="Copyright (c) 2018 Red Hat Inc."
+    trademarkText="Copyright (c) 2019 Red Hat Inc."
   >
     <Modal
       animation={true}

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -99,11 +99,16 @@ class TaskPage extends React.Component {
     updateWalkthroughProgress(currentUsername, oldProgress);
   };
 
-  getVerificationsForTask = task => {
-    const stepVerifications = task.steps.map((step, i) => this.getVerificationsForStep(i, step));
-    // Flatten the array of arrays. Array.prototype.flat() is not IE/Edge compatible. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#Browser_compatibility)
-    return [].concat(...stepVerifications);
-  };
+  getVerificationsForTask = task =>
+    task.blocks.reduce((acc, b, i) => {
+      if (b instanceof WalkthroughStep) {
+        return acc.concat(this.getVerificationsForStep(i, b));
+      }
+      if (b instanceof WalkthroughVerificationBlock) {
+        return acc.concat(`${i}`);
+      }
+      return acc;
+    }, []);
 
   getVerificationsForStep = (stepId, step) => {
     if (!step.blocks) {
@@ -286,6 +291,9 @@ class TaskPage extends React.Component {
           <div dangerouslySetInnerHTML={{ __html: block.html }} />
         </React.Fragment>
       );
+    }
+    if (block instanceof WalkthroughVerificationBlock) {
+      return this.renderVerificationBlock(`${id}`, block);
     }
     if (block instanceof WalkthroughStep) {
       return (


### PR DESCRIPTION
## Motivation
Currently, when creating a Walkthrough if a writer would like to
have a task that contains a single step they must still define a
h3 block and give the block a title. Otherwise features like the
verification block cannot be used.

In some cases, when creating this type of single step task, the
title of the task is the title of the step also.

## What
This change allows tasks to contain verification blocks, instead
of them only being allowed in steps. Meaning that a writer can
create a single step task without having to specify a h3 block.

Verification blocks will still work as expected in the web app.

## How
The `WalkthroughTask#fromAdoc` function now also allows for verifications to be included at its top level, instead of needing to be nested inside steps.

## Verification Steps

* Add a task that looks something like the following to an existing walkthrough, and ensure it renders correctly and that the `Next` button only goes blue when all verifications are complete.

```
== Example task

An example task with no steps, but it includes verification blocks.

[type=verification]
This should be the first verification

[type=verificationFail]
This should be the first verification fail message

[type=verification]
This should be a second verification

[type=verificationFail]
This should be a second verification fail message
```
* Ensure the rest of the walkthrough verifications show and work as expected
