### PR TITLE
INTLY-380 clicking logo does hard refresh

### DIFF
--- a/src/components/masthead/__tests__/__snapshots__/masthead.test.js.snap
+++ b/src/components/masthead/__tests__/__snapshots__/masthead.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`Masthead Component should render a basic component: basic 1`] = `
 <Masthead
+  history={
+    Object {
+      "push": [Function],
+    }
+  }
   logoutUser={[Function]}
 />
 `;

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Icon, Masthead as PfMasthead, MenuItem } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { noop, Icon, Masthead as PfMasthead, MenuItem } from 'patternfly-react';
 import { withRouter } from 'react-router-dom';
 import { connect, reduxActions, store } from '../../redux';
 import { aboutModalTypes } from '../../redux/constants';
@@ -33,7 +34,8 @@ class Masthead extends React.Component {
   };
 
   onTitleClick = () => {
-    window.location.href = '/';
+    const { history } = this.props;
+    history.push(`/`);
   };
 
   renderMobileNav() {
@@ -109,6 +111,18 @@ class Masthead extends React.Component {
     );
   }
 }
+
+Masthead.propTypes = {
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  })
+};
+
+Masthead.defaultProps = {
+  history: {
+    push: noop
+  }
+};
 
 const mapDispatchToProps = dispatch => ({
   logoutUser: () => dispatch(reduxActions.userActions.logoutUser())


### PR DESCRIPTION
## Why
Currently, when the "Red Hat Solution Explorer" logo in the top
left-hand corner is clicked we set window.href explicitly, this
can result in a full refresh of the page, which then results in
the loading screen for the web app revealing itself momentarily.

## How
We do not need to perform this kind of full refresh normally.
Instead we can use the react router to change the state of the app
so that it's on the landing page, this results in a much faster
transition without a loading screen.


## Verification Steps
* On the landing page, select "Red Hat Solution Explorer"
* The page should appear again immediately
* Do the same from a Walkthrough overview page to ensure the loading
screen doesn't appear.
