### PR TITLE
INTLY-424 - remove subsequent dashes from generated namespace name

### DIFF
--- a/src/common/openshiftHelpers.js
+++ b/src/common/openshiftHelpers.js
@@ -24,7 +24,9 @@ const buildValidProjectNamespaceName = (username, suffix) => {
   // The 2 accounts for the hyphens used.
   const namespaceSuffixLength = NAMESPACE_NAME_LENGTH - trimmedUsername.length - NAMESPACE_HASH_LENGTH - 2;
   const trimmedSuffix = suffix.substring(0, namespaceSuffixLength);
-  return `${trimmedUsername}-${trimmedSuffix}-${shortHash}`.toLowerCase();
+  const namespaceName = `${trimmedUsername}-${trimmedSuffix}-${shortHash}`.toLowerCase();
+  // Remove subsequent dashes before returning to avoid substitution for "em dash" by asciidoctor [INTLY-424]
+  return namespaceName.replace(/-{2,}/g, '-');
 };
 
 const buildValidNamespaceDisplayName = (username, suffix) => `${username} - ${suffix}`;


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-424

## What
Remove subsequent dashes from generated namespace names.

## Why
Two or more dashes in namespace name were being replaced for "em dash" by asciidoctor and caused issues in W2.

## How
Replace dashes via simple regex before returning value from buildValidProjectNamespaceName function.

## Verification Steps

1. Start walk-through 2. ("Integrating API-driven applications").
2. Check that link to Launcher, in "Log in to the __Launcher__ wizard.", only contains simple dashes, e.g.:
http://launcher-launcher.apps.tremes-88ad.openshiftworkshop.com/launch/wizard/evals02-2-fuse-f5f2
and doesn't contain any HTML entities, e.g:
http://launcher-launcher.apps.tremes-88ad.openshiftworkshop.com/launch/wizard/evals02-2-fuse&#8212;&#8203;f5f2

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
