### PR TITLE
INTLY-416 Fix duplicate task resources in single step tasks

### DIFF
--- a/src/common/walkthroughHelpers.js
+++ b/src/common/walkthroughHelpers.js
@@ -297,6 +297,9 @@ class WalkthroughTask {
     const collectedResources = [];
     this.collectTaskResources(adoc, collectedResources);
     const steps = adoc.blocks.reduce((acc, b, i, blockList) => {
+      if (WalkthroughResourceStep.canConvert(b)) {
+        return acc;
+      }
       if (WalkthroughStep.canConvert(b)) {
         acc.push(WalkthroughStep.fromAdoc(b));
       } else if (WalkthroughVerificationBlock.canConvert(b)) {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-416

## Motivation
Currently, when defining a single step task that includes a task
resource block it will be included on both the right hand panel
and in the main content.

This is because the task resource blocks are not filtered out in
single step tasks.

## How
This is resolved by filtering out the task resource blocks when
defining the main body blocks for the task.

## Verification Steps
* Have a single step task with a taskResource block inside it
* Ensure the taskResource block is rendered on the right panel and
not in the main body
* Ensure the normal, multi-step, steps work as expected

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
