### PR TITLE
Update Enmasse to AMQ Online

### DIFF
--- a/server.js
+++ b/server.js
@@ -268,7 +268,7 @@ function getMockConfigData() {
       serviceInstances: [
         {
           spec: {
-            clusterServiceClassExternalName: 'enmasse-standard'
+            clusterServiceClassExternalName: 'amq-online-standard'
           },
           status: {
             dashboardURL:'${process.env.OPENSHIFT_URL}',

--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -50,8 +50,8 @@ class EnMasseServiceInstanceTransform {
 }
 
 const DEFAULT_SERVICES = {
-  ENMASSE: 'enmasse-standard',
   AMQ: 'amq-broker-72-persistence',
+  ENMASSE: 'amq-online-standard',
   FUSE: 'fuse',
   CHE: 'che',
   LAUNCHER: 'launcher',

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -1,6 +1,6 @@
 // This file needs to live inside src to be importable
 export default {
-  'enmasse-standard': {
+  'amq-online-standard': {
     prettyName: 'Red Hat AMQ Online',
     gaStatus: 'preview'
   },

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -214,7 +214,7 @@ const handleEnmasseCredentialsWatchEvents = (dispatch, namespace, event) => {
   }
 
   const secret = event.payload;
-  if (secret.metadata.name.includes('enmasse-standard') && secret.metadata.name.includes('credentials')) {
+  if (secret.metadata.name.includes('amq-online-standard') && secret.metadata.name.includes('credentials')) {
     const amqpHost = window.atob(secret.data.messagingHost);
     const username = window.atob(secret.data.username);
     const password = window.atob(secret.data.password);


### PR DESCRIPTION
## Motivation
Update Enmasse to AMQ Online

## What
Update the Enmasse cluster service class name to `amq-online-standard` in order to provision AMQ Online instead of Enmasse during walkthrough setup.

## Verification Steps
1. Go to the webapp
2. Ensure that `AMQ Online (standard)` is provisioned. 
3. Ensure that `AMQ Online` is listed in the list of applications in the webapp dashboard.
3. Ensure that you can login to the AMQ Online dashboard.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member
