### PR TITLE
INTLY-399 Provide all attributes to overview asciidoc parser

### DIFF
--- a/src/pages/tutorial/__tests__/tutorial.test.js
+++ b/src/pages/tutorial/__tests__/tutorial.test.js
@@ -14,6 +14,12 @@ const completeThread = {
 };
 
 describe('TutorialPage Component', () => {
+  beforeAll(() => {
+    window.OPENSHIFT_CONFIG = {
+      mockData: {}
+    };
+  });
+
   const generateEmptyStore = (obj = {}) => configureMockStore()(obj);
   it('should render the ConnectedTutorialPage component', () => {
     const store = generateEmptyStore({ threadReducers: { thread: { pending: true } } });

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -7,7 +7,7 @@ import { connect, reduxActions } from '../../redux';
 import PfMasthead from '../../components/masthead/masthead';
 import WalkthroughResources from '../../components/walkthroughResources/walkthroughResources';
 import { parseWalkthroughAdoc } from '../../common/walkthroughHelpers';
-import { getDefaultAdocAttrs } from '../../common/docsHelpers';
+import { getDocsForWalkthrough, getDefaultAdocAttrs } from '../../common/docsHelpers';
 
 class TutorialPage extends React.Component {
   componentDidMount() {
@@ -79,7 +79,9 @@ class TutorialPage extends React.Component {
       return null;
     }
     if (thread.fulfilled && thread.data) {
-      const parsedThread = parseWalkthroughAdoc(thread.data, getDefaultAdocAttrs(id));
+      const attrs = getDocsForWalkthrough(id, this.props.middlewareServices, this.props.walkthroughResources);
+      const parsedAttrs = Object.assign({}, getDefaultAdocAttrs(id), attrs);
+      const parsedThread = parseWalkthroughAdoc(thread.data, parsedAttrs);
       return (
         <React.Fragment>
           <Grid fluid>
@@ -168,7 +170,9 @@ TutorialPage.propTypes = {
   }),
   getThread: PropTypes.func,
   thread: PropTypes.object,
-  getWalkthrough: PropTypes.func
+  getWalkthrough: PropTypes.func,
+  walkthroughResources: PropTypes.object,
+  middlewareServices: PropTypes.object
 };
 
 TutorialPage.defaultProps = {
@@ -183,7 +187,13 @@ TutorialPage.defaultProps = {
   },
   getThread: noop,
   thread: null,
-  getWalkthrough: noop
+  getWalkthrough: noop,
+  walkthroughResources: {},
+  middlewareServices: {
+    data: {},
+    amqCredentials: {},
+    enmasseCredentials: {}
+  }
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -192,7 +202,9 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-  ...state.threadReducers
+  ...state.threadReducers,
+  ...state.middlewareReducers,
+  ...state.walkthroughServiceReducers
 });
 
 const ConnectedTutorialPage = connect(


### PR DESCRIPTION
## Motivation
Currently, on the overview screen for a walkthrough, we do not
provide all of the attributes that we provide to each step. This
seems to have been an oversight from the pre-custom-walkthrough
format.

## What
This change provides all of the attribtues that we see in each
walkthrough step to the overview page so that things like resources
on the right-hand side can work.

## Verification Steps
* Using image: quay.io/aidenkeating/tutorial-web-app:INTLY-399
* Go to walkthrough overview screens and ensure right-hand links are working (vars are populated)

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member