### PR TITLE
INTLY-444 single task footer fix

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -347,6 +347,7 @@ class TaskPage extends React.Component {
         this.getStoredProgressForCurrentTask(),
         this.getVerificationsForTask(threadTask)
       );
+
       const currentThreadProgress = this.getStoredProgressForCurrentTask();
       const combinedResources = parsedThread.resources.concat(threadTask.resources);
       return (
@@ -399,7 +400,9 @@ class TaskPage extends React.Component {
                               className="integr8ly-module-column--footer_status"
                               key={`verification-id-${verificationId}`}
                             >
-                              {parseInt(task, 10) + 1}.{parseInt(i, 10) + 1}
+                              {threadTask.steps.length === 1
+                                ? parseInt(task, 10) + 1
+                                : `${parseInt(task, 10) + 1}.${parseInt(i, 10) + 1}`}
                             </span>
                           ) : (
                             <span
@@ -410,7 +413,9 @@ class TaskPage extends React.Component {
                               }
                               key={`verification-id-${verificationId}`}
                             >
-                              {parseInt(task, 10) + 1}.{parseInt(i, 10) + 1}
+                              {threadTask.steps.length === 1
+                                ? parseInt(task, 10) + 1
+                                : `${parseInt(task, 10) + 1}.${parseInt(i, 10) + 1}`}
                             </span>
                           )}
                         </React.Fragment>


### PR DESCRIPTION
## Motivation
We used to number steps #.#, as in, 1.1, 1.2, 1.3. Single step tasks would still be numbered this way, e.g. 1.1. The footer was originally coded to match this numbering. The newer asciidoc does not use .1 for single step tasks, so this fix makes the footer number match accordingly.

## What
Changed the footer numbering so it only displays the first number for single step tasks (1) and both numbers for multi-step tasks (1.1, 1.2, etc). FYI, ran it past the UX team and they seemed to prefer a single digit (1) as opposed to 1., or 1.0. If that changes after user testing, it should be easy to update now that the logic is in there to differentiate single and multistep numbering.

## Why
Inconsistent numbering between footer and steps.

## How
Check for the number of verification steps when numbering the footer, and only use single digit for single-step tasks, otherwise, use old format.

## Verification Steps
Open scenario 2 (AMQ).
Proceed to Task 1 of 3 (Creating Connections). Numbering in footer should match tasks (1.1, 1.2, 1.3).
Proceed to Task 2 or Task 3 (both single step tasks). Numbering in footer should match tasks (2, 3).

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

**Multi-step task/footer:**
![multi-step](https://user-images.githubusercontent.com/39063664/50876277-3c5b0480-139a-11e9-86e7-18a772819e26.png)

**Single-step task/footer:**
![single-step](https://user-images.githubusercontent.com/39063664/50876271-37965080-139a-11e9-9940-ed6d97ea656a.png)


