### PR TITLE
Use available key for loading screen list in dev mode

### DIFF
--- a/src/components/provisioning/provisioning.js
+++ b/src/components/provisioning/provisioning.js
@@ -151,7 +151,7 @@ function buildProvisioningScreen(WrappedComponent) {
       return (
         <div
           className={`list-group-item ${isProvisionFailed ? 'list-group-error-item' : null}`}
-          key={svc.metadata.name}
+          key={svc.spec.clusterServiceClassExternalName}
         >
           <div className="list-group-item-header">
             <div className="list-view-pf-main-info">


### PR DESCRIPTION
## Motivation
In React, you need to set a key prop when listing components.
However the key we are currently using may not be available in
development mode.

This change updates the key to something that will be available.

## Verification
* Try the webapp in dev mode
* Try the webapp against a cluster