### PR TITLE
INTLY-398 Restore task progress when coming from overview screen

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`TutorialPage Component should render the ConnectedTutorialPage component 1`] = `
 <Component
+  getProgress={[Function]}
   getThread={[Function]}
   getWalkthrough={[Function]}
   thread={

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -99,8 +99,11 @@ class TaskPage extends React.Component {
     updateWalkthroughProgress(currentUsername, oldProgress);
   };
 
-  getVerificationsForTask = task =>
-    task.blocks.reduce((acc, b, i) => {
+  getVerificationsForTask = task => {
+    if (!task || !task.blocks) {
+      return [];
+    }
+    return task.blocks.reduce((acc, b, i) => {
       if (b instanceof WalkthroughStep) {
         return acc.concat(this.getVerificationsForStep(i, b));
       }
@@ -109,6 +112,7 @@ class TaskPage extends React.Component {
       }
       return acc;
     }, []);
+  };
 
   getVerificationsForStep = (stepId, step) => {
     if (!step.blocks) {
@@ -223,7 +227,7 @@ class TaskPage extends React.Component {
   };
 
   taskVerificationStatus = (verifications, idsToVerify) => {
-    if (idsToVerify.length === 0) {
+    if (!idsToVerify || idsToVerify.length === 0) {
       return true;
     }
     for (const verificationId of idsToVerify) {

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -13,11 +13,13 @@ class TutorialPage extends React.Component {
   componentDidMount() {
     const {
       getWalkthrough,
+      getProgress,
       match: {
         params: { id }
       }
     } = this.props;
     getWalkthrough(id);
+    getProgress();
     // this.loadThread();
   }
 
@@ -36,8 +38,15 @@ class TutorialPage extends React.Component {
 
   getStarted(e, id) {
     e.preventDefault();
-    const { history } = this.props;
-    history.push(`/tutorial/${id}/task/0`);
+    const {
+      user: { userProgress = {} },
+      history
+    } = this.props;
+    let currentTask = 0;
+    if (userProgress[id] && userProgress[id].task) {
+      currentTask = userProgress[id].task;
+    }
+    history.push(`/tutorial/${id}/task/${currentTask}`);
   }
 
   renderPrereqs(thread) {
@@ -171,6 +180,8 @@ TutorialPage.propTypes = {
   getThread: PropTypes.func,
   thread: PropTypes.object,
   getWalkthrough: PropTypes.func,
+  getProgress: PropTypes.func,
+  user: PropTypes.object,
   walkthroughResources: PropTypes.object,
   middlewareServices: PropTypes.object
 };
@@ -186,6 +197,8 @@ TutorialPage.defaultProps = {
     params: {}
   },
   getThread: noop,
+  getProgress: noop,
+  user: {},
   thread: null,
   getWalkthrough: noop,
   walkthroughResources: {},
@@ -198,13 +211,15 @@ TutorialPage.defaultProps = {
 
 const mapDispatchToProps = dispatch => ({
   getThread: (language, id) => dispatch(reduxActions.threadActions.getThread(language, id)),
-  getWalkthrough: id => dispatch(reduxActions.threadActions.getCustomThread(id))
+  getWalkthrough: id => dispatch(reduxActions.threadActions.getCustomThread(id)),
+  getProgress: () => dispatch(reduxActions.userActions.getProgress())
 });
 
 const mapStateToProps = state => ({
   ...state.threadReducers,
   ...state.middlewareReducers,
-  ...state.walkthroughServiceReducers
+  ...state.walkthroughServiceReducers,
+  ...state.userReducers
 });
 
 const ConnectedTutorialPage = connect(


### PR DESCRIPTION
Currently, in a situation where a user enters a Walkthrough through
the overview screen they are brought to task 0 even if they have
made progress.

This change ensures that a user will be brought to the last step
that the user checked a verification box on. This is the same
functionality as entering a Walkthrough from the landing page.

There are also changes included which resolve various minor issues
noticed. Mostly around values being undefined.

Verification:
- Go into a walkthrough with no previous progress
- Click get started on the overview screen
- Ensure you are taken to task 0
- Complete a couple of tasks and take note of the task you last
verified.
- Click the name of the walkthrough in the breadcrumbs
- On the overview screen, click get started
- Ensure you are taken back to the task