### PR TITLE
fix(INTLY-525): fix content wrapping issues and alignments

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -33,7 +33,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
     >
       <Col
         bsClass="col"
-        className="integr8ly-task-container pf-u-mt-lg"
+        className="integr8ly-task-container pf-u-mt-lg pf-u-px-lg"
         componentClass="div"
         sm={9}
         xs={12}

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -362,7 +362,7 @@ class TaskPage extends React.Component {
           <Grid fluid>
             <Grid.Row>
               <Grid.Col xs={12} sm={9} className="integr8ly-module">
-                <div className="integr8ly-module-column">
+                <div className="integr8ly-module-column pf-c-content pf-u-mt-lg pf-u-px-lg">
                   <h2>{threadTask.title}</h2>
                   <div className="integr8ly-module-column--steps" ref={this.rootDiv}>
                     {threadTask.steps.map((step, i) => this.renderStepBlock(i, step))}

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -89,7 +89,7 @@ class TutorialPage extends React.Component {
               <PfMasthead />
             </Grid.Row>
             <Grid.Row>
-              <Grid.Col xs={12} sm={9} className="integr8ly-task-container pf-u-mt-lg">
+              <Grid.Col xs={12} sm={9} className="integr8ly-task-container pf-u-mt-lg pf-u-px-lg">
                 <div className="integr8ly-task-dashboard-header">
                   <h3>{parsedThread.title}</h3>
                   <Button bsStyle="primary" onClick={e => this.getStarted(e, id)}>

--- a/src/styles/application/_patternfly4.scss
+++ b/src/styles/application/_patternfly4.scss
@@ -186,11 +186,22 @@ ol {
 }
 
 // Button / Form styling
-/* stylelint-disable selector-class-pattern */
+/* stylelint-disable */
 /* allows the override of default PF3/Bootstrap 3 styles */
 .btn,
 .form-control {
   font-size: $pf-global--FontSize--md;
+}
+
+.pf-c-content {
+  .btn-primary,
+  .btn-primary > .fa {
+    color: $pf-color-white;
+  }
+
+  .btn[disabled] > .fa {
+    color: #8b8d8f !important;
+  }
 }
 
 .form-control {


### PR DESCRIPTION
## Motivation
Fix padding and margin issues on walkthrough content - found through the walkthrough sessions.

## What
Walkthrough content did not have proper padding and margin, leaving content on the edge of their containers and difficult to read. Formatting was also broken.

## How
Add proper container classes and padding/margin classes.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task