### PR TITLE
INTLY-383 If preamble doesn't have lines ignore shortDescription

### DIFF
--- a/server.js
+++ b/server.js
@@ -371,7 +371,11 @@ function getWalkthroughInfoFromAdoc(id, dirName, doc) {
   // ````
   // So it's better to just tell the user to put a blank line between the title and short description
   let shortDescription = '';
-  if (doc.blocks[0] && doc.blocks[0].context === 'preamble' && doc.blocks[0].blocks.length > 0) {
+  if (doc.blocks[0]&& 
+    doc.blocks[0].context === 'preamble' &&
+    doc.blocks[0].blocks.length > 0 &&
+    doc.blocks[0].blocks[0].lines &&
+    doc.blocks[0].blocks[0].lines.length > 0) {
     shortDescription = doc.blocks[0].blocks[0].lines[0];
   }
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-383

Currently, in the server-side parsing of the walkthrough files, if
the walkthrough has a preamble that does not start with a paragraph
containing at least one line then the parsing will fail. This is
due to the parser expecting that a walkthrough preamble being a
paragraph.

This change performs a check on the preamble to ensure that it
checks before trying to retrieve the shortDescription that the
preamble starts with a paragraph that contains at least one line.

Verification:
- Put a bulleted list as the preamble of a paragraph (first content
after the title)
- Restart the server and ensure it does not error
- Go through the walkthrough, ensure it works and the overview
renders correctly
