### PR TITLE
INTLY-185 Skip importing walkthrough if walkthrough.json is absent

### DIFF
--- a/server.js
+++ b/server.js
@@ -202,15 +202,16 @@ function lookupWalkthroughResources(location) {
       const adocInfo = files.reduce((acc, dirName) => {
         const basePath = path.join(location.local, dirName);
         const adocPath = path.join(basePath, 'walkthrough.adoc');
-        if (fs.existsSync(adocPath)) {
-          acc.push({
-            dirName,
-            basePath,
-            adocPath
-          });
-        } else {
-          console.log(`No walkthrough.adoc present in ${basePath}`);
+        const jsonPath = path.join(basePath, 'walkthrough.json');
+        if (!fs.existsSync(adocPath) || !fs.existsSync(jsonPath)) {
+          console.log(`walkthrough.json and walkthrough.adoc must be included in walkthrough directory, skipping importing ${basePath}`);
+          return acc;
         }
+        acc.push({
+          dirName,
+          basePath,
+          adocPath
+        });
         return acc;
       }, []);
       return resolve(adocInfo);


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-185

Currently, when walkthrough.json does not exist in a walkthrough
directory it is still shown in the landing page. This can result
in issues when starting/going through a walkthrough.

This change filters out any walkthroughs that do not include a
walkthrough.json and a walkthrough.adoc file. If these are not
included then a message is logged to the console about the
walkthrough not being included, so that the user knows what is
going wrong.

Verification:
- Remove walkthrough.json from any walkthrough
- Restart the server
- Ensure the walkthrough is not included on the landing page
- Ensure there is a log from the server about the walkthrough
being skipped
