### PR TITLE
Fix changing line height on provisioning screen

### DIFF
--- a/src/styles/application/_provisioning.scss
+++ b/src/styles/application/_provisioning.scss
@@ -164,6 +164,8 @@
 
 .integr8ly-status-ready {
   color: $pf-color-light-green-400 !important;
+  font-size: 1.5em !important;
+  display: block;
 }
 
 .integr8ly-status-error,


### PR DESCRIPTION
## Motivation
When service provisioning finishes, the icon on the left is changed, row height is changed and this causes vertical expansion of the rows - looks like they are jumping :)

## What
Fix style for integr8ly-status-ready css class.

## Why
To improve UX.

## How
a) change font-size, with 1.6em "ready" icon had height of 25.6px. Loading image has height of 24px
b) change display to block to avoid unnecessary empty space in the parent element

## Verification Steps
Open provisioning screen for a new user.
Height of the rows should not change when they transition from "Provisioning" to "Ready to use" 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes
Before:
![before](https://user-images.githubusercontent.com/1605799/51627133-7fdc7380-1f41-11e9-954d-7eb1c3e96217.png)
After:
![after](https://user-images.githubusercontent.com/1605799/51627140-8539be00-1f41-11e9-9ef6-e143ebd07f57.png)

