### PR TITLE
fix(content): Fix Note blocks to render correctly

### DIFF
--- a/src/styles/application/_patternfly4.scss
+++ b/src/styles/application/_patternfly4.scss
@@ -202,6 +202,23 @@ ol {
   .btn[disabled] > .fa {
     color: #8b8d8f !important;
   }
+
+  .paragraph {
+    p {
+      margin-bottom: var(--pf-c-content--MarginBottom);
+    }
+  }
+
+  .admonitionblock.note {
+    margin-bottom: var(--pf-c-content--MarginBottom);
+    padding: var(--pf-global--spacer--md);
+    font-weight: var(--pf-c-content--blockquote--FontWeight);
+    color: var(--pf-c-content--blockquote--Color);
+    border-left: var(--pf-c-content--blockquote--BorderLeftWidth) solid var(--pf-c-content--blockquote--BorderLeftColor);
+    .icon .title {
+      margin-right: var(--pf-global--spacer--md);
+    }
+  }
 }
 
 .form-control {


### PR DESCRIPTION
## Motivation
To fix the rendering of Note content blocks.

## What
Note content blocks were not rendering correctly in Walkthroughs.

## How
Apply PF4 content styles to the custom AsciiDoc elements.

## Verification Steps

1. Go to the 'Publishing walkthroughs to a cluster' walkthrough
2. Follow the steps until you see a 'Note' block of text.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

**Before**
<img width="1032" alt="screen shot 2019-01-24 at 11 45 00 am" src="https://user-images.githubusercontent.com/4032718/51694165-2ec69100-1fce-11e9-8268-350fc1861678.png">

**After**
<img width="946" alt="screen shot 2019-01-24 at 10 36 27 am" src="https://user-images.githubusercontent.com/4032718/51694175-35ed9f00-1fce-11e9-8469-44d09fc01540.png">
