### PR TITLE
make context_dir an external env var so you can use something like /d…

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ const DEFAULT_CUSTOM_CONFIG_DATA = {
 };
 
 const walkthroughLocations = process.env.WALKTHROUGH_LOCATIONS || (process.env.NODE_ENV === 'production' ? 'https://github.com/integr8ly/tutorial-web-app-walkthroughs' : '../tutorial-web-app-walkthroughs/walkthroughs');
+const walkthroughContextDir = process.env.WALKTHROUGH_CONTEXT_DIR || (process.env.NODE_ENV === 'production' ? 'walkthroughs' : 'walkthroughs');
 
 const CONTEXT_PREAMBLE = 'preamble';
 const CONTEXT_PARAGRAPH = 'paragraph';
@@ -172,7 +173,10 @@ function resolveWalkthroughLocations(locations) {
         return gitClient
           .cloneRepo(location, clonePath)
           .then(cloned => {
-            const locationResult = Object.assign({}, locationResultTemplate, { local: path.join(cloned, 'walkthroughs') });
+            if (process.env.WALKTHROUGH_CONTEXT_DIR) {
+              console.log(`Custom context dir ${walkthroughContextDir}`);
+            }
+            const locationResult = Object.assign({}, locationResultTemplate, { local: path.join(cloned, walkthroughContextDir) });
             return resolve(locationResult);
           })
           .catch(reject);


### PR DESCRIPTION
…ocs/labs instead of just 'walkthroughs'

## Motivation
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->
#392 
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
added CONTEXT_DIR env var with default to walkthroughs
## Why
<!-- Add a short answer for: Why it was done? (E.g The feature X was deprecated.) -->
needed for DIL workshops
## How
<!-- Add a short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) -->
adding env var, then when joining the path use the value from var instead of hardcoded text.
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
