### PR TITLE
feat: make images responsive by default

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -57,6 +57,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
           </Button>
         </div>
         <div
+          className="integr8ly-task-overview"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<div class=\\"literalblock\\">

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -92,7 +92,7 @@ class TutorialPage extends React.Component {
                   </Button>
                 </div>
                 {this.renderPrereqs(thread)}
-                <div dangerouslySetInnerHTML={{ __html: parsedThread.preamble }} />
+                <div className="integr8ly-task-overview" dangerouslySetInnerHTML={{ __html: parsedThread.preamble }} />
                 {/* <AsciiDocTemplate
                   adoc={thread}
                   attributes={Object.assign({}, thread.data.attributes)}

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -1,5 +1,11 @@
 .integr8ly- {
-  &img-responsive {
+  &img-not-responsive {
+    img {
+      max-width: inherit;
+    }
+  }
+
+  &task-overview {
     img {
       max-width: 100%;
     }
@@ -47,6 +53,10 @@
       }
 
       &--steps {
+        .imageblock .content img {
+          max-width: 100%;
+        }
+
         margin-right: -20px;
         margin-bottom: 56px;
         margin-left: -20px;


### PR DESCRIPTION
## Motivation
Addresses #396 

## What
* Added a new class for the task overview page.
* Updated styles to make images width to max out at 100% of the container width instead of overflow.
* Changed `img-responsive` to `img-not-responsive` so authors can make images overflow if that's somehow necessary

## Why
See #396 

## How
Answered above in "What"

## Verification Steps
1. Update the core walkthroughs repo to remove all `role="integr8ly-img-responsive"` from images
2. Run the webapp against updated core walkthroughs
3. Verify images are constrained to walkthrough content pane width
4. Add `role="integr8ly-img-not-responsive"` to a wide image file in a walktrough
5. Load the walkthrough and shrink the browser window. The image should be obscured by the right hand walkthrough resources panel

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
- [ ] Core walkthroughs have been updated (optional, this can be done later since the walkthroughs as they are will still look fine)

## Progress

- [x] Finished task

