### PR TITLE
INTLY-775 swich to codeready ga

### DIFF
--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -53,7 +53,7 @@ const DEFAULT_SERVICES = {
   AMQ: 'amq-broker-72-persistence',
   ENMASSE: 'amq-online-standard',
   FUSE: 'fuse',
-  CHE: 'che',
+  CHE: 'codeready',
   LAUNCHER: 'launcher',
   THREESCALE: '3scale',
   APICURIO: 'apicurio'

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -12,7 +12,7 @@ export default {
     prettyName: 'Red Hat Fuse Online',
     gaStatus: 'GA'
   },
-  che: {
+  codeready: {
     prettyName: 'CodeReady',
     gaStatus: 'GA'
   },

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -13,8 +13,8 @@ export default {
     gaStatus: 'GA'
   },
   che: {
-    prettyName: 'Eclipse Che',
-    gaStatus: 'community'
+    prettyName: 'CodeReady',
+    gaStatus: 'GA'
   },
   launcher: {
     prettyName: 'Red Hat Developer Launcher',


### PR DESCRIPTION
## What
change to codeready as che is now GA

## Verification Steps
Login to the webapp 
Codeready should provision as che did before
It should not longer show up as community and should be called CodeReady
You should be able to access and login via the services url