### PR TITLE
feat: make images responsive by default

### DIFF
--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -57,6 +57,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
           </Button>
         </div>
         <div
+          className="integr8ly-task-overview"
           dangerouslySetInnerHTML={
             Object {
               "__html": "<div class=\\"literalblock\\">

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -92,7 +92,7 @@ class TutorialPage extends React.Component {
                   </Button>
                 </div>
                 {this.renderPrereqs(thread)}
-                <div dangerouslySetInnerHTML={{ __html: parsedThread.preamble }} />
+                <div className="integr8ly-task-overview" dangerouslySetInnerHTML={{ __html: parsedThread.preamble }} />
                 {/* <AsciiDocTemplate
                   adoc={thread}
                   attributes={Object.assign({}, thread.data.attributes)}

--- a/src/styles/application/_taskLayout.scss
+++ b/src/styles/application/_taskLayout.scss
@@ -1,5 +1,11 @@
 .integr8ly- {
-  &img-responsive {
+  &img-not-responsive {
+    img {
+      max-width: inherit;
+    }
+  }
+
+  &task-overview {
     img {
       max-width: 100%;
     }
@@ -47,6 +53,10 @@
       }
 
       &--steps {
+        .imageblock .content img {
+          max-width: 100%;
+        }
+
         margin-right: -20px;
         margin-bottom: 56px;
         margin-left: -20px;


### PR DESCRIPTION
## Motivation
By default it would make sense for images to be responsive so users don't need to add a "role" in asciidoc. This is a better flow since it improves developer experience and is less surprising to see than an overflowing image.

## What
n/a

## Why
To simplify walkthrough creation.

## How
Changed default behaviour of image CSS

## Verification Steps
1. Load a large image into a walkthrough without applying the responsive image role
2. View the walkthrough
3. Verify image is sized within the content area correctly

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes
n/a
