### PR TITLE
fix: add 3scale url undefined check

### DIFF
--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -44,10 +44,10 @@ const retrieveRouteAttributes = (resourceId, route) => {
 };
 
 const getMiddlewareServiceAttrs = middlewareServices => {
-  const threescaleUrl = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE)
+  const threescaleUrl = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE);
 
   return {
-    'openshift-app-host': threescaleUrl ? threescaleUrl.replace('https://3scale-admin.', '') :  threescaleUrl,
+    'openshift-app-host': threescaleUrl ? threescaleUrl.replace('https://3scale-admin.', '') : threescaleUrl,
     'fuse-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.FUSE),
     'launcher-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.LAUNCHER),
     'che-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.CHE),
@@ -62,7 +62,7 @@ const getMiddlewareServiceAttrs = middlewareServices => {
     'amq-credentials-username': middlewareServices.amqCredentials.username,
     'amq-credentials-password': middlewareServices.amqCredentials.password,
     'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO)
-  }
+  };
 };
 
 const getUrlFromMiddlewareServices = (middlewareServices, serviceName) => {

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -43,26 +43,27 @@ const retrieveRouteAttributes = (resourceId, route) => {
   return routeAttrs;
 };
 
-const getMiddlewareServiceAttrs = middlewareServices => ({
-  'openshift-app-host': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE).replace(
-    'https://3scale-admin.',
-    ''
-  ),
-  'fuse-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.FUSE),
-  'launcher-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.LAUNCHER),
-  'che-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.CHE),
-  'api-management-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE),
-  'enmasse-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.ENMASSE),
-  'amq-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.AMQ),
-  'enmasse-broker-url': middlewareServices.enmasseCredentials.url,
-  'enmasse-credentials-username': middlewareServices.enmasseCredentials.username,
-  'enmasse-credentials-password': middlewareServices.enmasseCredentials.password,
-  'amq-broker-tcp-url': middlewareServices.amqCredentials.tcpUrl,
-  'amq-broker-amqp-url': middlewareServices.amqCredentials.url,
-  'amq-credentials-username': middlewareServices.amqCredentials.username,
-  'amq-credentials-password': middlewareServices.amqCredentials.password,
-  'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO)
-});
+const getMiddlewareServiceAttrs = middlewareServices => {
+  const threescaleUrl = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE)
+
+  return {
+    'openshift-app-host': threescaleUrl ? threescaleUrl.replace('https://3scale-admin.', '') :  threescaleUrl,
+    'fuse-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.FUSE),
+    'launcher-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.LAUNCHER),
+    'che-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.CHE),
+    'api-management-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE),
+    'enmasse-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.ENMASSE),
+    'amq-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.AMQ),
+    'enmasse-broker-url': middlewareServices.enmasseCredentials.url,
+    'enmasse-credentials-username': middlewareServices.enmasseCredentials.username,
+    'enmasse-credentials-password': middlewareServices.enmasseCredentials.password,
+    'amq-broker-tcp-url': middlewareServices.amqCredentials.tcpUrl,
+    'amq-broker-amqp-url': middlewareServices.amqCredentials.url,
+    'amq-credentials-username': middlewareServices.amqCredentials.username,
+    'amq-credentials-password': middlewareServices.amqCredentials.password,
+    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO)
+  }
+};
 
 const getUrlFromMiddlewareServices = (middlewareServices, serviceName) => {
   if (!middlewareServices || !middlewareServices.data || !middlewareServices.data[serviceName]) {


### PR DESCRIPTION
## Motivation
If the 3scale URL doesn't exist then loading a walkthrough fails since it's missing a null check before trying to operate on the URL.

## What
Added the required null check.

## Why
To ensure the application continues working if 3scale is not deployed or not in the custom config.

## How
n/a

## Verification Steps
Create a custom config such as this one and try use it before applying this PR:

```
{
  "servicesToProvision": [
    "fuse",
    "launcher",
    "che"
  ],
  "services": [
    {
      "name": "3scale Developer Dashboard",
      "url": "https://user101.apps.openbanking-fe8e.openshiftworkshop.com"
    },
    {
      "name": "3scale Admin Dashboard",
      "url": "https://user101-admin.apps.openbanking-fe8e.openshiftworkshop.com"
    },
    {
      "name": "Gogs",
      "url": "http://gogs.apps.openbanking-fe8e.openshiftworkshop.com"
    },
    {
      "name": "Microcks",
      "url": "http://microcks.apps.openbanking-fe8e.openshiftworkshop.com"
    },
    {
      "name": "Apicurio",
      "url": "http://apicurio-studio.apps.openbanking-fe8e.openshiftworkshop.com"
    }
  ]
}
```

Try load a walkthrough. It will fail on the `replace` call. Now add `"3scale"` to the `"servicesToProvision"` and it will work.

With this PR applied BOTH of the described configs will work.

## Checklist:

- [X] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

Check `integreatly-dev` channel for more info
