### PR TITLE
INTLY-948 feat: add ability to specify custom path to walkthroughs in git url

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -194,6 +194,12 @@ If the walkthroughs are not inside the typical `walkthroughs/` folder in your re
 ----
 WALKTHROUGH_LOCATIONS="https://github.com/user/repo?walkthroughsFolder=/custom/location#branch-or-tag"
 ----
+
+You can specify multiple walkthrough folders in same repo if you want:
+
+----
+WALKTHROUGH_LOCATIONS="https://github.com/user/repo?walkthroughsFolder=/custom/location?walkthroughsFolder=/another/custom/location#branch-or-tag"
+----
 ====
 
 === Developing Walkthroughs on Openshift

--- a/README.adoc
+++ b/README.adoc
@@ -189,7 +189,7 @@ By default the master branch of the repository gets cloned. But you can specify 
 WALKTHROUGH_LOCATIONS="https://github.com/user/repo#branch-or-tag"
 ----
 
-If your walkthroughs are not inside the typical `walkthroughs/` folder in your repository you can specify the directory via querystring params like so:
+If the walkthroughs are not inside the typical `walkthroughs/` folder in your repository you can specify the directory via a querystring param like so:
 
 ----
 WALKTHROUGH_LOCATIONS="https://github.com/user/repo#branch-or-tag?walkthroughsFolder=/custom/location"

--- a/README.adoc
+++ b/README.adoc
@@ -192,7 +192,7 @@ WALKTHROUGH_LOCATIONS="https://github.com/user/repo#branch-or-tag"
 If the walkthroughs are not inside the typical `walkthroughs/` folder in your repository you can specify the directory via a querystring param like so:
 
 ----
-WALKTHROUGH_LOCATIONS="https://github.com/user/repo#branch-or-tag?walkthroughsFolder=/custom/location"
+WALKTHROUGH_LOCATIONS="https://github.com/user/repo?walkthroughsFolder=/custom/location#branch-or-tag"
 ----
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -186,7 +186,13 @@ You can also specify a git reference in the form of a URL in `WALKTHROUGH_LOCATI
 By default the master branch of the repository gets cloned. But you can specify a branch or tag by appending `#<branch or tag name>` to the URL, for example:
 
 ----
-https://github.com/user/repo#branch-or-tag
+WALKTHROUGH_LOCATIONS="https://github.com/user/repo#branch-or-tag"
+----
+
+If your walkthroughs are not inside the typical `walkthroughs/` folder in your repository you can specify the directory via querystring params like so:
+
+----
+WALKTHROUGH_LOCATIONS="https://github.com/user/repo#branch-or-tag?walkthroughsFolder=/custom/location"
 ----
 ====
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "i18next": "11.6.0",
     "i18next-xhr-backend": "1.5.1",
     "js-cookie": "2.2.0",
+    "lodash.flattendeep": "^4.4.0",
     "lodash.get": "4.4.2",
     "mustache": "^3.0.0",
     "npm": "6.4.1",

--- a/server.js
+++ b/server.js
@@ -9,12 +9,10 @@ const giteaClient = require('./gitea_client');
 const gitClient = require('./git_client');
 const bodyParser = require('body-parser');
 const uuid = require('uuid');
-<<<<<<< HEAD
 const promMid = require('express-prometheus-middleware');
 const Prometheus = require('prom-client');
-=======
 const querystring = require('querystring')
->>>>>>> feat: add ability to specify custom path to walkthroughs in git url
+const flattenDeep = require('lodash.flattendeep')
 
 const app = express();
 
@@ -186,34 +184,49 @@ function resolveWalkthroughLocations(locations) {
   }
 
   const tmpDirPrefix = uuid.v4();
-  const mappedLocations = locations.map(location => new Promise((resolve, reject) => {
+  const mappedLocations = locations.map(location => {
+    new Promise((resolve, reject) => {
       const locationResultTemplate = { origin: location };
       if (!location) {
         return reject(new Error(`Invalid location ${location}`));
       } else if (isPath(location)) {
         console.log(`Importing walkthrough from path ${location}`);
-        const locationResult = Object.assign({}, locationResultTemplate, { local: location });
+        const locationResult = Object.assign({ parentId: 'local' }, locationResultTemplate, { local: location });
         return resolve(locationResult);
       } else if (isGitRepo(location)) {
-        console.log(`Importing walkthrough from git ${location}`);
         const clonePath = path.join(TMP_DIR, tmpDirPrefix);
 
         // Need to parse out query params for walkthroughs, e.g custom directory
         const cloneUrl = generateCloneUrlFromLocation(location)
+        const repoName = retWalkthroughRepoNameFromLocation(location)
         const walkthroughParams = querystring.parse(url.parse(location).query)
 
+        console.log(`Importing walkthrough from git ${cloneUrl}`);
         return gitClient
           .cloneRepo(cloneUrl, clonePath)
           .then(cloned => {
-            const locationResult = Object.assign({}, locationResultTemplate, { local: path.join(cloned, walkthroughParams.walkthroughsFolder ? walkthroughParams.walkthroughsFolder : 'walkthroughs') });
-            return resolve(locationResult);
+            if (walkthroughParams.walkthroughsFolder && Array.isArray(walkthroughParams.walkthroughsFolder)) {
+              console.log(`Git walkthrough (${cloneUrl}) specified folders: ${walkthroughParams.walkthroughsFolder.join(', ')}`);
+              resolve(
+                walkthroughParams.walkthroughsFolder.map(l => {
+                  return Object.assign({ parentId: `${repoName}-${path.basename(l)}` }, locationResultTemplate, { local: path.join(cloned, l) })
+                })
+              )
+            } else {
+              const l = walkthroughParams.walkthroughsFolder ? walkthroughParams.walkthroughsFolder : 'walkthroughs'
+              console.log(`Git walkthrough (${cloneUrl}) specified folder: ${l}`)
+              resolve(Object.assign({ parentId: `${repoName}-${path.basename(l)}` }, locationResultTemplate, { local: path.join(cloned, l) }));
+            }
+            // return resolve(locationResult);
           })
           .catch(reject);
       }
       return reject(new Error(`${location} is neither a path nor a git repo`));
-    }));
 
-  return Promise.all(mappedLocations);
+    });
+  });
+  
+  return Promise.all(mappedLocations).then(flattenDeep);
 }
 
 /**
@@ -227,6 +240,13 @@ function generateCloneUrlFromLocation (location) {
   locationParsed.search = locationParsed.query = null
 
   return url.format(locationParsed)
+}
+
+function retWalkthroughRepoNameFromLocation (location) {
+  const locationParsed = url.parse(location)
+
+  // Return the repository name, i.e the highest-level identifier
+  return path.basename(locationParsed.path.split('?')[0])
 }
 
 /**
@@ -248,17 +268,21 @@ function lookupWalkthroughResources(location) {
         const basePath = path.join(location.local, dirName);
         const adocPath = path.join(basePath, 'walkthrough.adoc');
         const jsonPath = path.join(basePath, 'walkthrough.json');
+        
         if (!fs.existsSync(adocPath) || !fs.existsSync(jsonPath)) {
           console.log(
             `walkthrough.json and walkthrough.adoc must be included in walkthrough directory, skipping importing ${basePath}`
           );
           return acc;
-        }
+        } 
+
         acc.push({
+          parentId: location.parentId,
           dirName,
           basePath,
           adocPath
         });
+
         return acc;
       }, []);
       return resolve(adocInfo);
@@ -273,7 +297,7 @@ function lookupWalkthroughResources(location) {
  * @returns {Promise<any>}
  */
 function importWalkthroughAdoc(adocContext) {
-  const { adocPath, dirName, basePath } = adocContext;
+  const { parentId, adocPath, dirName, basePath } = adocContext;
 
   return new Promise((resolve, reject) => {
     fs.readFile(adocPath, (err, rawAdoc) => {
@@ -281,7 +305,7 @@ function importWalkthroughAdoc(adocContext) {
         return reject(err);
       }
       const loadedAdoc = adoc.load(rawAdoc);
-      const walkthroughInfo = getWalkthroughInfoFromAdoc(dirName, basePath, loadedAdoc);
+      const walkthroughInfo = getWalkthroughInfoFromAdoc(parentId, dirName, basePath, loadedAdoc);
       // Don't allow duplicate walkthroughs
       if (walkthroughs.find(wt => wt.id === walkthroughInfo.id)) {
         return reject(
@@ -401,7 +425,7 @@ function getConfigData(req) {
   };`;
 }
 
-function getWalkthroughInfoFromAdoc(id, dirName, doc) {
+function getWalkthroughInfoFromAdoc(parentId, id, dirName, doc) {
   // Retrieve the short description. There must be a gap between the document title and the short description.
   // Otherwise it's counted as the author field. For example, see this adoc file:
   // ````
@@ -423,7 +447,8 @@ function getWalkthroughInfoFromAdoc(id, dirName, doc) {
   }
 
   return {
-    id,
+    // Using the repo name plus folder name should be sufficiently unique
+    id: `${parentId}-${id}`,
     title: doc.getDocumentTitle(),
     shortDescription,
     time: getTotalWalkthroughTime(doc),

--- a/server.js
+++ b/server.js
@@ -185,7 +185,7 @@ function resolveWalkthroughLocations(locations) {
 
   const tmpDirPrefix = uuid.v4();
   const mappedLocations = locations.map(location => {
-    new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const locationResultTemplate = { origin: location };
       if (!location) {
         return reject(new Error(`Invalid location ${location}`));

--- a/server.js
+++ b/server.js
@@ -191,7 +191,7 @@ function resolveWalkthroughLocations(locations) {
         return reject(new Error(`Invalid location ${location}`));
       } else if (isPath(location)) {
         console.log(`Importing walkthrough from path ${location}`);
-        const locationResult = Object.assign({ parentId: 'local' }, locationResultTemplate, { local: location });
+        const locationResult = Object.assign({ parentId: path.basename(location) }, locationResultTemplate, { local: location });
         return resolve(locationResult);
       } else if (isGitRepo(location)) {
         const clonePath = path.join(TMP_DIR, tmpDirPrefix);

--- a/server.js
+++ b/server.js
@@ -9,8 +9,12 @@ const giteaClient = require('./gitea_client');
 const gitClient = require('./git_client');
 const bodyParser = require('body-parser');
 const uuid = require('uuid');
+<<<<<<< HEAD
 const promMid = require('express-prometheus-middleware');
 const Prometheus = require('prom-client');
+=======
+const querystring = require('querystring')
+>>>>>>> feat: add ability to specify custom path to walkthroughs in git url
 
 const app = express();
 
@@ -193,10 +197,16 @@ function resolveWalkthroughLocations(locations) {
       } else if (isGitRepo(location)) {
         console.log(`Importing walkthrough from git ${location}`);
         const clonePath = path.join(TMP_DIR, tmpDirPrefix);
+
+        // Need to parse out query params for walkthroughs, e.g custom directory
+        const locationParts = location.split('?')
+        const cloneUrl = locationParts[0]
+        const walkthroughParams = querystring.parse(locationParts[1])
+
         return gitClient
-          .cloneRepo(location, clonePath)
+          .cloneRepo(cloneUrl, clonePath)
           .then(cloned => {
-            const locationResult = Object.assign({}, locationResultTemplate, { local: path.join(cloned, 'walkthroughs') });
+            const locationResult = Object.assign({}, locationResultTemplate, { local: path.join(cloned, walkthroughParams.walkthroughsFolder ? walkthroughParams.walkthroughsFolder : 'walkthroughs') });
             return resolve(locationResult);
           })
           .catch(reject);

--- a/server.js
+++ b/server.js
@@ -199,9 +199,8 @@ function resolveWalkthroughLocations(locations) {
         const clonePath = path.join(TMP_DIR, tmpDirPrefix);
 
         // Need to parse out query params for walkthroughs, e.g custom directory
-        const locationParts = location.split('?')
-        const cloneUrl = locationParts[0]
-        const walkthroughParams = querystring.parse(locationParts[1])
+        const cloneUrl = generateCloneUrlFromLocation(location)
+        const walkthroughParams = querystring.parse(url.parse(location).query)
 
         return gitClient
           .cloneRepo(cloneUrl, clonePath)
@@ -215,6 +214,19 @@ function resolveWalkthroughLocations(locations) {
     }));
 
   return Promise.all(mappedLocations);
+}
+
+/**
+ * Given a URL to a repository, strip the query and rebuild the URL
+ * @param {String} location 
+ */
+function generateCloneUrlFromLocation (location) {
+  const locationParsed = url.parse(location)
+  
+  // Need to nullify query params since these are just used by us
+  locationParsed.search = locationParsed.query = null
+
+  return url.format(locationParsed)
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -217,7 +217,6 @@ function resolveWalkthroughLocations(locations) {
               console.log(`Git walkthrough (${cloneUrl}) specified folder: ${l}`)
               resolve(Object.assign({ parentId: `${repoName}-${path.basename(l)}` }, locationResultTemplate, { local: path.join(cloned, l) }));
             }
-            // return resolve(locationResult);
           })
           .catch(reject);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,6 +2450,11 @@ binary-extensions@^1.0.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -3999,7 +4004,7 @@ depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
-depd@~1.1.1, depd@~1.1.2:
+depd@~1.1.0, depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -4845,6 +4850,16 @@ expect@^23.6.0:
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
 
+express-prometheus-middleware@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/express-prometheus-middleware/-/express-prometheus-middleware-0.6.1.tgz#0f2d769f24940da8136981e234bf31cca7b5d20f"
+  integrity sha512-nhCr4/oZmwhZuCTLe0n33H4Mu7Ile6YNsbySE2VP2yWnO4+C0d9NEyfnxDlnbqKI+dMEQAFA7M/Kd0+ySMVBrw==
+  dependencies:
+    express "^4.16.3"
+    prom-client "^11.1.1"
+    response-time "^2.3.2"
+    url-value-parser "^2.0.0"
+
 express@4.16.3:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
@@ -4880,9 +4895,10 @@ express@4.16.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^4.16.2:
+express@^4.16.2, express@^4.16.3:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
+  integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
   dependencies:
     accepts "~1.3.5"
     array-flatten "1.1.1"
@@ -10269,6 +10285,13 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
 
+prom-client@^11.1.1:
+  version "11.2.1"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.2.1.tgz#486e7817de9b1d43c0a12aee26fc68830f4d1b16"
+  integrity sha512-7VwtjrkQS50NvDoeYNn2z6wzXB5BMGzUlmMOeLPaITtJsTVXnPywRta7QFiV4pKr0fbRx9oDfUcx1xibabjSAg==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-inflight@^1.0.1, promise-inflight@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -11326,6 +11349,14 @@ resolve@^1.3.2, resolve@^1.3.3, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1, 
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
   dependencies:
     path-parse "^1.0.6"
+
+response-time@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/response-time/-/response-time-2.3.2.tgz#ffa71bab952d62f7c1d49b7434355fbc68dffc5a"
+  integrity sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=
+  dependencies:
+    depd "~1.1.0"
+    on-headers "~1.0.1"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -12400,6 +12431,13 @@ tcomb@^3.2.21:
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.29.tgz#32404fe9456d90c2cf4798682d37439f1ccc386c"
 
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
+
 temp@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
@@ -12913,6 +12951,11 @@ url-parse@^1.1.8, url-parse@^1.4.3:
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
+
+url-value-parser@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/url-value-parser/-/url-value-parser-2.0.1.tgz#c8179a095ab9ec1f5aa17ca36af5af396b4e95ed"
+  integrity sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw==
 
 url@^0.11.0:
   version "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7490,6 +7490,7 @@ lodash.escape@^4.0.1:
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
 lodash.get@4.4.2:
   version "4.4.2"


### PR DESCRIPTION
## Motivation
See #392. Essentially some existing content being ported is in a particular format and can often contain multiple "tracks" of work in a single repo. To avoid splitting these repos up we should support a walkthroughs directory override.

## What
Added a parsing step for Git URLs passed via `WALKTHROUGH_LOCATIONS` environment variable. This will extract querystring params from the Git URL.

## Why
See motivation.

## How
By allowing users to override the default `walkthroughs/` path.

## Verification Steps
1. Using this branch start the application like so:

```
WALKTHROUGH_LOCATIONS="https://github.com/RedHatWorkshops/dayinthelife-integration?walkthroughsFolder=docs/labs/citizen-integrator-track&walkthroughsFolder=docs/labs/developer-track/#V2,/Users/eshortis/workspaces/work/integreatly/tutorial-web-app-walkthroughs/walkthroughs" yarn start:dev
```

2. The walkthroughs from `docs/labs/citizen-integrator-track/` for the repo `https://github.com/RedHatWorkshops/dayinthelife-integration#V2` should load in the UI despite not being in the typical `walkthroughs/` folder. The same should occur for `docs/labs/developer-track/` from the same repo. Also, note the URL when you load these walkthroughs - it contains the parent folder name, and the specific lab name to prevent conflicts since both contain `labNN` naming conventions.


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
