### PR TITLE
INTLY-869 Fix logo navigation

### DIFF
--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -60,8 +60,7 @@ class Masthead extends React.Component {
 
   onTitleClick = () => {
     const { history } = this.props;
-    history.push(`/`);
-    window.location.href = '/';
+    history.push('/');
   };
 
   onUserDropdownToggle(isUserDropdownOpen) {
@@ -147,4 +146,4 @@ const ConnectedMasthead = connect(
 
 const RoutedConnectedMasthead = withRouter(ConnectedMasthead);
 
-export { RoutedConnectedMasthead as default, ConnectedMasthead, Masthead };
+export { Masthead as default, ConnectedMasthead, RoutedConnectedMasthead, Masthead };

--- a/src/pages/congratulations/congratulations.js
+++ b/src/pages/congratulations/congratulations.js
@@ -14,7 +14,7 @@ import {
 import { withRouter } from 'react-router-dom';
 import { noop } from 'patternfly-react';
 import { FlagCheckeredIcon } from '@patternfly/react-icons';
-import { Masthead } from '../../components/masthead/masthead';
+import RoutedConnectedMasthead from '../../components/masthead/masthead';
 import { connect, reduxActions } from '../../redux';
 
 class CongratulationsPage extends React.Component {
@@ -28,7 +28,7 @@ class CongratulationsPage extends React.Component {
     return (
       <React.Fragment>
         <Page className="pf-u-h-100vh">
-          <Masthead />
+          <RoutedConnectedMasthead />
           <PageSection variant={PageSectionVariants.darker}>
             <Bullseye>
               <EmptyState>

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -5,7 +5,7 @@ import { Grid, GridItem, Page, PageSection } from '@patternfly/react-core';
 import TutorialDashboard from '../../components/tutorialDashboard/tutorialDashboard';
 import InstalledAppsView from '../../components/installedAppsView/InstalledAppsView';
 import { connect, reduxActions } from '../../redux';
-import { Masthead } from '../../components/masthead/masthead';
+import { RoutedConnectedMasthead } from '../../components/masthead/masthead';
 
 class LandingPage extends React.Component {
   componentDidMount() {
@@ -31,7 +31,7 @@ class LandingPage extends React.Component {
     return (
       <React.Fragment>
         <Page className="pf-u-h-100vh">
-          <Masthead />
+          <RoutedConnectedMasthead />
           <LandingPageMastHead />
           <PageSection className="pf-u-py-0 pf-u-pl-lg pf-u-pr-0">
             <Grid gutter="md">

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -37,13 +37,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
     onPageResize={null}
     sidebar={null}
   >
-    <Masthead
-      history={
-        Object {
-          "push": [Function],
-        }
-      }
-    />
+    <withRouter(Connect(Masthead)) />
     <PageSection
       className="integr8ly-landing-page-tutorial-dashboard-section"
       variant="default"

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -18,7 +18,7 @@ import { connect, reduxActions } from '../../redux';
 import WalkthroughResources from '../../components/walkthroughResources/walkthroughResources';
 import { parseWalkthroughAdoc } from '../../common/walkthroughHelpers';
 import { getDocsForWalkthrough, getDefaultAdocAttrs } from '../../common/docsHelpers';
-import { Masthead } from '../../components/masthead/masthead';
+import { RoutedConnectedMasthead } from '../../components/masthead/masthead';
 
 class TutorialPage extends React.Component {
   componentDidMount() {
@@ -103,7 +103,7 @@ class TutorialPage extends React.Component {
         <React.Fragment>
           <BackgroundImage src={bgImages} />
           <Page className="pf-u-h-100vh">
-            <Masthead />
+            <RoutedConnectedMasthead />
             <PageSection className="integr8ly-landing-page-tutorial-dashboard-section">
               <Grid gutter="md" className="pf-c-content">
                 <GridItem sm={12} md={9} className="integr8ly-task-container">


### PR DESCRIPTION
## Motivation
INTLY-869 Regression: Loading screen displays when clicking Solutions Explorer logo

## What
After I made the PF4 changes, when the Solutions Explorer logo was clicked, it would display the loading screen for a second before navigating home.

## Why
It's cleaner and faster to use history and react-router to navigate back to the home screen instead of a hard page reset.

## How
Replaced window.location.href with history using react-router.

## Verification Steps
1. Navigate to any page that has the masthead (which contains the Red Hat Solutions Enabler logo) - which includes the main home page, the walkthrough overview page, or the congratulations page. 
2. Click the Red Hat Solutions Enabler logo.
3. Verify that it navigates back to the home page without displaying an interim loading screen.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task
