### PR TITLE
Remove copyright from About modal

### DIFF
--- a/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
+++ b/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
@@ -24,7 +24,7 @@ exports[`AboutModal Component should render a non-connected component: hidden mo
     logoImageSrc="logo-alt.svg"
     onClose={null}
     productName="Red Hat Solution Explorer"
-    trademark="Copyright (c) 2019 Red Hat, Inc."
+    trademark=""
   >
     <Portal
       containerInfo={<div />}
@@ -42,7 +42,7 @@ exports[`AboutModal Component should render a non-connected component: hidden mo
         logoImageSrc="logo-alt.svg"
         onClose={null}
         productName="Red Hat Solution Explorer"
-        trademark="Copyright (c) 2019 Red Hat, Inc."
+        trademark=""
       />
     </Portal>
   </AboutModal>
@@ -73,7 +73,7 @@ exports[`AboutModal Component should render a non-connected component: show moda
     logoImageSrc="logo-alt.svg"
     onClose={null}
     productName="Red Hat Solution Explorer"
-    trademark="Copyright (c) 2019 Red Hat, Inc."
+    trademark=""
   >
     <Portal
       containerInfo={<div />}
@@ -91,7 +91,7 @@ exports[`AboutModal Component should render a non-connected component: show moda
         logoImageSrc="logo-alt.svg"
         onClose={null}
         productName="Red Hat Solution Explorer"
-        trademark="Copyright (c) 2019 Red Hat, Inc."
+        trademark=""
       />
     </Portal>
   </AboutModal>

--- a/src/components/aboutModal/aboutModal.js
+++ b/src/components/aboutModal/aboutModal.js
@@ -27,7 +27,6 @@ class AboutModal extends React.Component {
           isOpen={isOpen}
           onClose={closeAboutModal}
           productName="Red Hat Solution Explorer"
-          trademark={`Copyright (c) ${new Date().getFullYear()} Red Hat, Inc.`}
           heroImageSrc={pfBackgroundImage}
           heroImageAlt="Red Hat Solutions Explorer background image"
           brandImageSrc={redHatLogo}


### PR DESCRIPTION
## Motivation
Decision was made to remove the Copyright line from the About box.

## What
Simple change to just remove the copyright line from the About modal.

## Verification Steps
1. Invoke the About box from the user menu.
2. Verify that the copyright no longer displays at the top of the info block.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**Screen cap before changes:**
![about-before](https://user-images.githubusercontent.com/39063664/52880090-06decf00-312f-11e9-867b-cfc03bf778f9.png)

**Screen cap after changes:**
![about-after](https://user-images.githubusercontent.com/39063664/52880102-10683700-312f-11e9-9012-b74a5235b965.png)
