### PR TITLE
INTLY-1080: Fix header rendering and add responsive fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "5.7.1",
+    "@fortawesome/fontawesome-free": "5.7.2",
     "@patternfly/react-core": "2.1.4",
     "@patternfly/patternfly": "1.0.203",
     "asciidoctor.js": "1.5.7",
@@ -34,6 +34,7 @@
     "redux-promise-middleware": "5.1.1",
     "redux-thunk": "2.3.0",
     "rimraf": "2.6.2",
+    "rfs": "8.0.1",
     "sha.js": "2.4.11",
     "simple-git": "^1.107.0"
   },

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, CardBody, Label, TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { Card, CardBody, Label, TextContent } from '@patternfly/react-core';
 import { BoltIcon, ChartPieIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { connect } from '../../redux';
 
@@ -93,7 +93,7 @@ class WalkthroughResources extends React.Component {
       <Card>
         <CardBody>
           <TextContent className="integr8ly-walkthrough-resources pf-u-pl-md">
-            <Text component={TextVariants.h2}>Walkthrough Resources</Text>
+            <h2>Walkthrough Resources</h2>
             {this.state.resourceList}
             <div className={this.props.resources.length !== 0 ? 'hidden' : 'show'}>No resources available.</div>
           </TextContent>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -408,7 +408,7 @@ class TaskPage extends React.Component {
                   <Card className="integr8ly-c-card--content pf-u-mb-xl">
                     <CardBody>
                       <TextContent className="integr8ly-module-column pf-u-pb-sm">
-                        <Text component={TextVariants.h2}>{threadTask.title}</Text>
+                        <h2>{threadTask.title}</h2>
                         <div className="integr8ly-module-column--steps" ref={this.rootDiv}>
                           {threadTask.steps.map((step, i) => this.renderStepBlock(i, step))}
                         </div>

--- a/src/styles/application/_variables.scss
+++ b/src/styles/application/_variables.scss
@@ -4,6 +4,9 @@
 // Font path
 $pf-global--font-path: "/assets/fonts" !default;
 
+// Responsive font sizes
+$enable-responsive-font-sizes: true !default;
+
 // Icon path
 $fa-font-path: "/assets/fonts/webfonts" !default;
 $icon-font-path: "~patternfly/dist/fonts/";

--- a/src/styles/application/utilities/_patternfly4.scss
+++ b/src/styles/application/utilities/_patternfly4.scss
@@ -6,12 +6,40 @@
 // This doesn't affect PF3.
 // https://github.com/twbs/bootstrap/blob/v3.4.0-dev/less/scaffolding.less#L23
 
+// RFS Imports
+@import "../../../../node_modules/rfs/scss.scss";
+
 /* stylelint-disable */
 /* allows the override of default styles */
 html {
   font-size: unset !important; // the important is needed because we don't know if pf3 will be loaded after pfnext
 }
 
+$rfs-base-font-size: 16;
+
+:root {
+  --pf-global--FontSize--4xl: $pf-global--FontSize--4xl;
+  --pf-global--FontSize--3xl: $pf-global--FontSize--3xl;
+  --pf-global--FontSize--2xl: $pf-global--FontSize--2xl;
+  --pf-global--FontSize--xl: $pf-global--FontSize--xl;
+  --pf-global--FontSize--lg: $pf-global--FontSize--lg;
+  --pf-global--FontSize--md: $pf-global--FontSize--md;
+  --pf-global--FontSize--sm: $pf-global--FontSize--sm;
+  --pf-global--FontSize--xs: $pf-global--FontSize--xs;
+}
+
+h1, .pf-m-4xl, .pf-c-title.pf-m-4xl, .pf-c-content h1, .pf-c-content h1[data-pf-content] { @include font-size(2.25rem); }
+h2, .pf-m-3xl, .pf-c-title.pf-m-3xl, .pf-c-content h2 { @include font-size(1.75rem); }
+.pf-c-content h2[data-pf-content] { @include font-size(1.75rem); }
+h3, .pf-m-2xl, .pf-c-title.pf-m-2xl, .pf-c-content h3, .pf-c-content h3[data-pf-content] { @include font-size(1.5rem); }
+h4, .pf-m-xl, .pf-c-title.pf-m-xl, .pf-c-content h4, .pf-c-content h4[data-pf-content] { @include font-size(1.3125rem); }
+h5, .pf-m-lg, .pf-c-title.pf-m-lg, .pf-c-content h5, .pf-c-content h5[data-pf-content] { @include font-size(1.125rem); }
+p, .pf-c-content p, .pf-c-content .paragraph p { @include font-size(1rem); }
+.pf-c-label, .pf-c-button { @include font-size(1rem); }
+.pf-c-label.pf-m-compact { @include font-size(0.875rem); }
+
+// Button / Form styling
+// remove once Copy-to-Clipboard is part of PF4
 button,
 [type="button"],
 [type="reset"],
@@ -22,12 +50,6 @@ button,
   }
 }
 
-p {
-  font-size: var(--pf-global--FontSize--md);
-}
-
-// Button / Form styling
-// remove once Copy-to-Clipboard is part of PF4
 .btn,
 .form-control {
   font-size: var(--pf-global--FontSize--md);
@@ -38,6 +60,7 @@ p {
 }
 
 .pf-c-content {
+
   .paragraph {
     p {
       margin-bottom: var(--pf-c-content--MarginBottom);

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,9 +950,9 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
 
-"@fortawesome/fontawesome-free@5.7.1":
-  version "5.7.1"
-  resolved "https://npm.fontawesome.com/4A831275-95CD-4498-B07A-83658138807C/@fortawesome/fontawesome-free/-/fontawesome-free-5.7.1.tgz#e4bdc6fd2a7b5a41d5b599bcb62cf22c78f7f535"
+"@fortawesome/fontawesome-free@5.7.2":
+  version "5.7.2"
+  resolved "https://npm.fontawesome.com/4A831275-95CD-4498-B07A-83658138807C/@fortawesome/fontawesome-free/-/fontawesome-free-5.7.2.tgz#1498c3eb78ee7c78c5488418707de90aaf58d5d7"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -983,8 +983,8 @@
     tippy.js "^3.4.1"
 
 "@patternfly/react-icons@^3.0.0":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.0.2.tgz#259ca46374b7558addb36f72e9a66a4c8f93259a"
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.0.1.tgz#47d0184f40686f3fb6a0b9b0e835013d95320f06"
 
 "@patternfly/react-styles@^2.3.2":
   version "2.3.2"
@@ -11344,6 +11344,10 @@ retry@^0.10.0:
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+
+rfs@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/rfs/-/rfs-8.0.1.tgz#14219282aa3d4cb0c2e890b517057830ba0f7391"
 
 rgb-hex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Motivation
Update Walkthrough headers to render correctly. Add responsive font system to accommodate smaller devices.

## What
Fix [INTLY-1080](https://issues.jboss.org/browse/INTLY-1080)

## How
Swap out component usage for rendering headers and add Bootstrap's Responsive Font System as a dependency.

## Verification Steps

1. Navigate to a Walkthrough
2. The headings should render correctly (larger than the body text)
3. When resizing the browser window, the headings should shrink accordingly.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task