### PR TITLE
INTLY-1074: Correct icon usage and add FA shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.7.1",
     "@patternfly/react-core": "2.1.4",
-    "@patternfly/patternfly": "1.0.200",
+    "@patternfly/patternfly": "1.0.203",
     "asciidoctor.js": "1.5.7",
     "axios": "0.18.0",
     "body-parser": "^1.18.3",

--- a/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
@@ -14,11 +14,12 @@ exports[`Breadcrumb component should handle home clicked 1`] = `
     target={null}
     to={null}
   >
-    <Icon
+    <HomeIcon
       aria-label="Back to the Dashboard"
       className="fa-lg"
-      name="home"
-      type="fa"
+      color="currentColor"
+      size="sm"
+      title={null}
     />
   </BreadcrumbItem>
   <BreadcrumbItem
@@ -57,11 +58,12 @@ exports[`Breadcrumb component should render breadcrumb with props 1`] = `
     target={null}
     to={null}
   >
-    <Icon
+    <HomeIcon
       aria-label="Back to the Dashboard"
       className="fa-lg"
-      name="home"
-      type="fa"
+      color="currentColor"
+      size="sm"
+      title={null}
     />
   </BreadcrumbItem>
   <BreadcrumbItem
@@ -100,11 +102,12 @@ exports[`Breadcrumb component should render default breadcrumb 1`] = `
     target={null}
     to={null}
   >
-    <Icon
+    <HomeIcon
       aria-label="Back to the Dashboard"
       className="fa-lg"
-      name="home"
-      type="fa"
+      color="currentColor"
+      size="sm"
+      title={null}
     />
   </BreadcrumbItem>
 </Breadcrumb>

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
-import { Icon } from 'patternfly-react';
 import { BreadcrumbItem, Breadcrumb as PfBreadcrumb } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
+import { HomeIcon } from '@patternfly/react-icons';
 
 class Breadcrumb extends React.Component {
   homeClicked = () => {
@@ -18,7 +18,7 @@ class Breadcrumb extends React.Component {
     return (
       <PfBreadcrumb>
         <BreadcrumbItem onClick={this.homeClicked} id="breadcrumb-home">
-          <Icon className="fa-lg" type="fa" name="home" aria-label="Back to the Dashboard" />
+          <HomeIcon className="fa-lg" aria-label="Back to the Dashboard" />
         </BreadcrumbItem>
         {threadName && !taskPosition && <BreadcrumbItem isActive>{threadName}</BreadcrumbItem>}
         {threadName &&

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from 'patternfly-react';
 import { Label, DataList, DataListItem } from '@patternfly/react-core';
+import { BoltIcon, ChartPieIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
 
 class InstalledAppsView extends React.Component {
   state = {
@@ -31,17 +31,17 @@ class InstalledAppsView extends React.Component {
   static getStatusForApp(app) {
     const provisioningStatus = (
       <div className="integr8ly-state-provisioining">
-        <Icon type="fa" name="chart-pie" /> &nbsp;Provisioning
+        <ChartPieIcon /> &nbsp;Provisioning
       </div>
     );
     const readyStatus = (
       <div className="integr8ly-state-ready">
-        <Icon type="fa" name="bolt" /> &nbsp;Ready for use
+        <BoltIcon /> &nbsp;Ready for use
       </div>
     );
     const unavailableStatus = (
       <div className="integr8ly-state-unavailable">
-        <Icon type="pf" name="error-circle-o" /> &nbsp;Unavailable
+        <ErrorCircleOIcon /> &nbsp;Unavailable
       </div>
     );
 
@@ -80,7 +80,7 @@ class InstalledAppsView extends React.Component {
           <div className="pf-u-display-flex pf-u-flex-direction-column">
             <p className="pf-u-mr-lg">Red Hat OpenShift</p>
             <div className="integr8ly-state-ready">
-              <Icon type="fa" name="bolt" /> &nbsp;Ready for use
+              <BoltIcon /> &nbsp;Ready for use
             </div>
           </div>
         </DataListItem>
@@ -101,7 +101,7 @@ class InstalledAppsView extends React.Component {
             <p className="pf-u-mr-lg">{customApp.name}</p>
             <Label isCompact>custom</Label>
             <div className="integr8ly-state-ready">
-              <Icon type="fa" name="bolt" /> &nbsp;Ready for use
+              <BoltIcon /> &nbsp;Ready for use
             </div>
           </div>
         </DataListItem>

--- a/src/components/tutorialCard/tutorialCard.js
+++ b/src/components/tutorialCard/tutorialCard.js
@@ -31,12 +31,12 @@ const TutorialCard = props => (
           }
           href={props.getStartedLink}
         >
-          <span className="pf-u-mr-xs">{props.getStartedIcon}</span>
+          {props.getStartedIcon}
           {props.getStartedText}
         </Button>
         {props.progress === 0 ? (
           <div className="integr8ly-c-card__time">
-            <span className="pf-u-mr-xs">{props.minsIcon}</span>
+            {props.minsIcon}
             {props.mins} <span>min</span>
           </div>
         ) : (

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CardGrid, Icon } from 'patternfly-react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { ClockIcon } from '@patternfly/react-icons';
 import TutorialCard from '../tutorialCard/tutorialCard';
 
 const TutorialDashboard = props => {
@@ -29,13 +30,13 @@ const TutorialDashboard = props => {
               type="fa"
               name={
                 currentProgress !== undefined && currentProgress.progress === 100
-                  ? 'check-circle integr8ly-c-card__status--complete-icon'
-                  : 'arrow-circle-right'
+                  ? 'check-circle pf-u-mr-xs integr8ly-c-card__status--complete-icon'
+                  : 'arrow-circle-right pf-u-mr-xs'
               }
               className="fa-lg"
             />
           }
-          minsIcon={<Icon type="fa" name="clock" className="fa-lg" arrow-alt-circle-right="true" />}
+          minsIcon={<ClockIcon className="fa-lg pf-u-mr-xs" />}
           progress={currentProgress === undefined ? 0 : currentProgress.progress}
           mins={walkthrough.time}
         >

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, CardBody, Label, TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { BoltIcon, ChartPieIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { connect } from '../../redux';
 
 class WalkthroughResources extends React.Component {
@@ -29,7 +30,7 @@ class WalkthroughResources extends React.Component {
 
         if (resource.serviceName === 'openshift') {
           gaStatus = '';
-          icon = <i className="fas fa-bolt integr8ly-state-ready" />;
+          icon = <BoltIcon className="pf-u-mr-xs integr8ly-state-ready" />;
         } else {
           const gaStatusApi = app.productDetails.gaStatus;
           const statusIcon = WalkthroughResources.assignSerivceIcon(app);
@@ -51,9 +52,9 @@ class WalkthroughResources extends React.Component {
   }
 
   static assignSerivceIcon(app) {
-    const provisioningStatus = <i className="fas fa-chart-pie integr8ly-state-provisioining" />;
-    const readyStatus = <i className="fas fa-bolt integr8ly-state-ready" />;
-    const unavailableStatus = <i className="fas fa-exclamation-circle integr8ly-state-unavailable" />;
+    const provisioningStatus = <ChartPieIcon className="pf-u-mr-xs integr8ly-state-provisioining" />;
+    const readyStatus = <BoltIcon className="pf-u-mr-xs integr8ly-state-ready" />;
+    const unavailableStatus = <ExclamationCircleIcon className="pf-u-mr-xs integr8ly-state-unavailable" />;
 
     if (app.metadata && app.metadata.deletionTimestamp) {
       return unavailableStatus;
@@ -75,7 +76,7 @@ class WalkthroughResources extends React.Component {
       resourceList = resources.map(resource => (
         <div key={resource.title}>
           <div className="pf-u-pb-sm">
-            <span className="pf-u-mr-xs">{resource.statusIcon}</span>
+            {resource.statusIcon}
             <span className="pf-u-mr-md">{resource.title}</span>
             {resource.gaStatus === 'community' ? <Label isCompact>community</Label> : <span />}
             {resource.gaStatus === 'preview' ? <Label isCompact>preview</Label> : <span />}

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -170,12 +170,8 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
                   className="pull-right integr8ly-task-dashboard-time-to-completion"
                 >
                   <Icon
+                    className="pf-u-mr-xs"
                     name="clock"
-                    style={
-                      Object {
-                        "marginRight": 5,
-                      }
-                    }
                     type="fa"
                   />
                   <span>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -455,7 +455,7 @@ class TaskPage extends React.Component {
                               type="fa"
                               className="integr8ly-module-column--footer_status icon pf-u-ml-md pf-u-pr-sm"
                               key={`verification-icon-${verificationId}`}
-                              name="circle"
+                              name="circle-thin"
                             />
                           ) : (
                             <Icon

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -139,7 +139,7 @@ class TutorialPage extends React.Component {
                       <h3 className="pf-u-mt-xl">
                         {t('tutorial.tasksToComplete')}
                         <div className="pull-right integr8ly-task-dashboard-time-to-completion">
-                          <Icon type="fa" name="clock" style={{ marginRight: 5 }} />
+                          <Icon type="fa" name="clock" className="pf-u-mr-xs" />
                           <span>
                             {parsedThread.time}
                             <span className="integr8ly-task-dashboard-time-to-completion_minutes">
@@ -156,7 +156,7 @@ class TutorialPage extends React.Component {
                             description={task.shortDescription}
                             actions={
                               <div className="integr8ly-task-dashboard-estimated-time">
-                                <Icon type="fa" name="clock-o" style={{ marginRight: 5 }} />
+                                <Icon type="fa" name="clock" className="pf-u-mr-xs" />
                                 <span>
                                   {task.time}
                                   <span className="integr8ly-task-dashboard-estimated-time_minutes">

--- a/src/styles/application/_variables.scss
+++ b/src/styles/application/_variables.scss
@@ -15,5 +15,6 @@ $img-path: "~patternfly/dist/img/";
 
 // PatternFly 4 Global Variables
 $pf-global--enable-font-overpass-cdn: false !default;
+$pf-global--enable-fontawesome-cdn: false !default;
 $pf-global--load-pf-3: true !default;
 $pf-global--enable-reset: true !default;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -76,9 +76,10 @@
 
 // Font Awesome 5 icons
 // Import Font Awesome 5, but ignore any inherited stylelint issues
-@import "@fortawesome/fontawesome-free/scss/fontawesome.scss";
-@import "@fortawesome/fontawesome-free/scss/regular.scss";
-@import "@fortawesome/fontawesome-free/scss/solid.scss";
+@import "../node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss";
+@import "../node_modules/@fortawesome/fontawesome-free/scss/regular.scss";
+@import "../node_modules/@fortawesome/fontawesome-free/scss/solid.scss";
+@import "../node_modules/@fortawesome/fontawesome-free/scss/v4-shims.scss";
 /* stylelint-enable */
 
 // Utilities

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,7 +877,6 @@
 "@emotion/cache@^10.0.7":
   version "10.0.7"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.7.tgz#6221de2e939f62022c04b4df2c165ce577809f23"
-  integrity sha512-wscXuawG+nQhSNbDpJdAqvv5d2g1O+fpwf/wD/CAmW/wsuN8hNzahWh2ldSVakqO9sINewyQNFl74IeDeTkRZg==
   dependencies:
     "@emotion/sheet" "0.9.2"
     "@emotion/stylis" "0.8.3"
@@ -887,7 +886,6 @@
 "@emotion/hash@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
-  integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
 
 "@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
   version "0.6.6"
@@ -896,7 +894,6 @@
 "@emotion/memoize@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
-  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
 
 "@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
   version "0.6.6"
@@ -905,7 +902,6 @@
 "@emotion/serialize@^0.11.4":
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.4.tgz#691e615184a23cd3b9ae9b1eaa79eb8798e52379"
-  integrity sha512-JKmn+Qnc8f6OZKSHmNq1RpO27raIi6Kj0uqBaSOUVMW6NI0M3wLpV4pK5hZO4I+1WuCC39hOBPgQ/GcgoHbDeg==
   dependencies:
     "@emotion/hash" "0.7.1"
     "@emotion/memoize" "0.7.1"
@@ -925,12 +921,10 @@
 "@emotion/sheet@0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.2.tgz#74e5c6b5e489a1ba30ab246ab5eedd96916487c4"
-  integrity sha512-pVBLzIbC/QCHDKJF2E82V2H/W/B004mDFQZiyo/MSR+VC4pV5JLG0TF/zgQDFvP3fZL/5RTPGEmXlYJBMUuJ+A==
 
 "@emotion/stylis@0.8.3":
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.3.tgz#3ca7e9bcb31b3cb4afbaeb66156d86ee85e23246"
-  integrity sha512-M3nMfJ6ndJMYloSIbYEBq6G3eqoYD41BpDOxreE8j0cb4fzz/5qvmqU9Mb2hzsXcCnIlGlWhS03PCzVGvTAe0Q==
 
 "@emotion/stylis@^0.7.0":
   version "0.7.1"
@@ -939,7 +933,6 @@
 "@emotion/unitless@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
-  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
 
 "@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.7":
   version "0.6.7"
@@ -948,7 +941,6 @@
 "@emotion/utils@0.11.1":
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.1.tgz#8529b7412a6eb4b48bdf6e720cc1b8e6e1e17628"
-  integrity sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg==
 
 "@emotion/utils@^0.8.2":
   version "0.8.2"
@@ -957,7 +949,6 @@
 "@emotion/weak-memoize@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
-  integrity sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
 
 "@fortawesome/fontawesome-free@5.7.1":
   version "5.7.1"
@@ -974,15 +965,13 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@patternfly/patternfly@1.0.200":
-  version "1.0.200"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.200.tgz#7c5ed392529b9faeaf559c777f5a9448c87cbb3f"
-  integrity sha512-eyJyLRqB/b0Vhwf5WGWQkIQYmBkC02dV5Zm7/Z+rBBdCdc9QJngMUWrznfztqayheAdDbbNQdCXCTxFTmPA91A==
+"@patternfly/patternfly@1.0.203":
+  version "1.0.203"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.203.tgz#2cd6be9bbbe1da2d94b8046ef6d1103bf0c7154b"
 
 "@patternfly/react-core@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-2.1.4.tgz#be16ae1928d694eb1408f585542471abf3c147f9"
-  integrity sha512-A7TpS4r4p/poPQNgUfNb4jJoaGMC394jLTX0w/ZKzPkkIsdbZaxLdQRD7hxgaLS4YAyT1//ZHuieaaZGBzVQiQ==
   dependencies:
     "@patternfly/react-icons" "^3.0.0"
     "@patternfly/react-styles" "^2.3.2"
@@ -996,12 +985,10 @@
 "@patternfly/react-icons@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.0.2.tgz#259ca46374b7558addb36f72e9a66a4c8f93259a"
-  integrity sha512-VJQWugCosecct5CUKNbgez1bbA4bnKpTE7BH5CGfe66Z6/UT71VhPnOGixJao2qpH7de2LYB5IPXJgRmDRzMOg==
 
 "@patternfly/react-styles@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-2.3.2.tgz#b2dd4d0e202bbdda7ceaceb6beced9c1419d2d87"
-  integrity sha512-2WJZUgF79Bc5hTKGkifRrl3rR+uU1GS7xtGQwsVpL1tEEV1GgcDxNGV1sh0eU4Nk54G1p6P48OMeKsgeI4U21w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -1019,7 +1006,6 @@
 "@patternfly/react-tokens@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.0.0.tgz#db44313e884bf2a3eb78aba64f084f0a9dd93625"
-  integrity sha512-buDc/zTC0C/zULLL+RqCNgLXmN7jV3lRX9VyELSVWiTWE5G9TB59G8/ccVqx1GSxYFF/kybEioMRnbQrVhB2hg==
 
 "@svgr/core@^2.4.1":
   version "2.4.1"
@@ -2012,7 +1998,6 @@ babel-plugin-dynamic-import-node@2.2.0:
 babel-plugin-emotion@^10.0.7:
   version "10.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.7.tgz#3634ada6dee762140f27db07387feaec8d2cb619"
-  integrity sha512-5PdLJYme3tFN97M3tBbEUS/rJVkS9EMbo7rs7/7BAUEUVMWehm1kb5DEbp16Rs+UsI3rTXRan1iqpL022T8XxA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@emotion/hash" "0.7.1"
@@ -3474,7 +3459,6 @@ create-emotion-server@^9.2.12:
 create-emotion@^10.0.7:
   version "10.0.7"
   resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.7.tgz#608d69c550e2f57827383762d416a9ddf75d8bed"
-  integrity sha512-2T6vvvh7XN/MvI3far2SXeQ5s7wti/dae6jKuHxkK4IA1IKdYocKTujZ+r56azZ8fguq3Qj4ua1AJ2vHCq7VTg==
   dependencies:
     "@emotion/cache" "^10.0.7"
     "@emotion/serialize" "^0.11.4"
@@ -3811,7 +3795,6 @@ csstype@^2.5.2:
 csstype@^2.5.7:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.2.tgz#3043d5e065454579afc7478a18de41909c8a2f01"
-  integrity sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -4302,7 +4285,6 @@ emotion-server@^9.2.6:
 emotion@^10.0.6:
   version "10.0.7"
   resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.7.tgz#74ea432c7004c2bd5452d017d52e307a7a31a835"
-  integrity sha512-k1gGBoel9rlHvHIUVHyk4iJPsRaDsrpr7vKivOmdJAH2Va+smxIYvsjjzXnxTeqJt5IwcVBareuoAJMxeShG/w==
   dependencies:
     babel-plugin-emotion "^10.0.7"
     create-emotion "^10.0.7"
@@ -9077,7 +9059,6 @@ patternfly-bootstrap-treeview@~2.1.0:
 patternfly-react@2.29.13:
   version "2.29.13"
   resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.29.13.tgz#ceafd9ebd8a4e8143d167d4a25c25a9fd442273e"
-  integrity sha512-6ebQ3fcpUFhrxNN+pSX3/pLlst19YGzBzFY3uxaQ2C1iuRv9XytXrZmHsrH85O+jjDwHNP5yFXf+Ley2Mt4VKg==
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
@@ -9103,7 +9084,6 @@ patternfly-react@2.29.13:
 patternfly@^3.58.0:
   version "3.59.1"
   resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.59.1.tgz#4adea89223e7386551bc9560ad5bed99e37df904"
-  integrity sha512-0Q/P58yaxcQXwnXo/OssiXaZmuX0g9QvWdpsYHyml4ihqnN2lL/yGdadFarA6UAQb//15XtNjKHZocoJXCkWYg==
   dependencies:
     bootstrap "~3.4.0"
     font-awesome "^4.7.0"
@@ -12520,7 +12500,6 @@ tippy.js@^3.2.0:
 tippy.js@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-3.4.1.tgz#f0eb3081824ad6c5d364336451ad77ae2f543da8"
-  integrity sha512-ZiyGP9WZyCCcjxKM4G88cm4U1r1ytjeMDGa5FSKPaPzwc/3yZJVZsb1ffcmqUMCpryRp5LNxRNGKLzbs11sb/Q==
   dependencies:
     popper.js "^1.14.6"
 


### PR DESCRIPTION
## Motivation
Fix issues INTLY-1074 and INTLY-1077.

## What
Update Font Awesome usage to utilize both the FA5 shim (for using Font Awesome 4 icons) and include the Regular icon set. Update the various icons to use the correct ones (according to visual designs) and verify that all are using the proper weight and classes. Update icons to use the PatternFly-React icon components where possible.

## Why
As part of fixing PatternFly 4 implementation bugs.

## Verification Steps

Navigate to any page that uses an icon, inspect the code, and verify that they are using Font Awesome 5 as the font-family.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task