### PR TITLE
fix(build): simplify PatternFly 4 import

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.7.2",
     "@patternfly/react-core": "2.1.4",
-    "@patternfly/patternfly": "1.0.203",
+    "@patternfly/patternfly": "1.0.208",
     "asciidoctor.js": "1.5.7",
     "axios": "0.18.0",
     "body-parser": "^1.18.3",

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -9,67 +9,8 @@
 /* stylelint-disable */
 // Prevent stylelint from checking imported code
 
-// PatternFly 4 Imports
-// Import PatternFly 4, but ignore any inherited stylelint issues
-// individual imports will be simplified once
-// https://github.com/patternfly/patternfly-next/issues/1370
-// is addressed (related to missing .scss extension on import
-
-// PatternFly 4 Base
-@import '../node_modules/@patternfly/patternfly/patternfly-base.scss';
-
-// PatternFly 4 Components
-@import "../node_modules/@patternfly/patternfly/components/AboutModalBox/about-modal-box.scss";
-@import "../node_modules/@patternfly/patternfly/components/Alert/alert.scss";
-@import "../node_modules/@patternfly/patternfly/components/AlertGroup/alert-group.scss";
-@import "../node_modules/@patternfly/patternfly/components/AppLauncher/app-launcher.scss";
-@import "../node_modules/@patternfly/patternfly/components/Avatar/avatar.scss";
-@import "../node_modules/@patternfly/patternfly/components/Backdrop/backdrop.scss";
-@import "../node_modules/@patternfly/patternfly/components/BackgroundImage/background-image.scss";
-@import "../node_modules/@patternfly/patternfly/components/Badge/badge.scss";
-@import "../node_modules/@patternfly/patternfly/components/Breadcrumb/breadcrumb.scss";
-@import "../node_modules/@patternfly/patternfly/components/Button/button.scss";
-@import "../node_modules/@patternfly/patternfly/components/Card/card.scss";
-@import "../node_modules/@patternfly/patternfly/components/Check/check.scss";
-@import "../node_modules/@patternfly/patternfly/components/Chip/chip.scss";
-@import "../node_modules/@patternfly/patternfly/components/ChipGroup/chip-group.scss";
-@import "../node_modules/@patternfly/patternfly/components/Content/content.scss";
-@import "../node_modules/@patternfly/patternfly/components/ContextSelector/context-selector.scss";
-@import "../node_modules/@patternfly/patternfly/components/DataList/data-list.scss";
-@import "../node_modules/@patternfly/patternfly/components/Dropdown/dropdown.scss";
-@import "../node_modules/@patternfly/patternfly/components/EmptyState/empty-state.scss";
-@import "../node_modules/@patternfly/patternfly/components/Form/form.scss";
-@import "../node_modules/@patternfly/patternfly/components/FormControl/form-control.scss";
-@import "../node_modules/@patternfly/patternfly/components/InputGroup/input-group.scss";
-@import "../node_modules/@patternfly/patternfly/components/Label/label.scss";
-@import "../node_modules/@patternfly/patternfly/components/List/list.scss";
-@import "../node_modules/@patternfly/patternfly/components/Login/login.scss";
-@import "../node_modules/@patternfly/patternfly/components/ModalBox/modal-box.scss";
-@import "../node_modules/@patternfly/patternfly/components/Nav/nav.scss";
-@import "../node_modules/@patternfly/patternfly/components/OptionsMenu/options-menu.scss";
-@import "../node_modules/@patternfly/patternfly/components/Page/page.scss";
-@import "../node_modules/@patternfly/patternfly/components/Pagination/pagination.scss";
-@import "../node_modules/@patternfly/patternfly/components/Popover/popover.scss";
-@import "../node_modules/@patternfly/patternfly/components/Progress/progress.scss";
-@import "../node_modules/@patternfly/patternfly/components/Radio/radio.scss";
-@import "../node_modules/@patternfly/patternfly/components/Select/select.scss";
-@import "../node_modules/@patternfly/patternfly/components/Switch/switch.scss";
-@import "../node_modules/@patternfly/patternfly/components/Table/table-grid.scss";
-@import "../node_modules/@patternfly/patternfly/components/Table/table.scss";
-@import "../node_modules/@patternfly/patternfly/components/Tabs/tabs.scss";
-@import "../node_modules/@patternfly/patternfly/components/Title/title.scss";
-@import "../node_modules/@patternfly/patternfly/components/Toolbar/toolbar.scss";
-@import "../node_modules/@patternfly/patternfly/components/Tooltip/tooltip.scss";
-
-// PatternFly 4 Layouts
-@import "../node_modules/@patternfly/patternfly/layouts/Bullseye/bullseye.scss";
-@import "../node_modules/@patternfly/patternfly/layouts/Flex/flex-ba.scss";
-@import "../node_modules/@patternfly/patternfly/layouts/Flex/flex.scss";
-@import "../node_modules/@patternfly/patternfly/layouts/Gallery/gallery.scss";
-@import "../node_modules/@patternfly/patternfly/layouts/Grid/grid.scss";
-@import "../node_modules/@patternfly/patternfly/layouts/Level/level.scss";
-@import "../node_modules/@patternfly/patternfly/layouts/Split/split.scss";
-@import "../node_modules/@patternfly/patternfly/layouts/Stack/stack.scss";
+// PatternFly 4 Base & Components
+@import '../node_modules/@patternfly/patternfly/patternfly.scss';
 
 // PatternFly 4 Add-ons
 @import '../node_modules/@patternfly/patternfly/patternfly-addons.scss';

--- a/yarn.lock
+++ b/yarn.lock
@@ -965,9 +965,9 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@patternfly/patternfly@1.0.203":
-  version "1.0.203"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.203.tgz#2cd6be9bbbe1da2d94b8046ef6d1103bf0c7154b"
+"@patternfly/patternfly@1.0.208":
+  version "1.0.208"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.208.tgz#df0783657e9def112822e395c8e9189204144337"
 
 "@patternfly/react-core@2.1.4":
   version "2.1.4"


### PR DESCRIPTION
## Motivation
Simplify the PatternFly 4 imports.

## What
Remove individual component, layout, and functional imports and replace with a single import from the main `patternfly.scss` file.

## Why
PatternFly fixed an issue where the build could not distinguish the `patternfly.css` file from the `patternfly.scss` file, causing build errors for unknown/missing files.

## How
Replace multiple lines of imports with a single line.

## Verification Steps
Run the build.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task