### PR TITLE
add walkthrough-locations attribute

### DIFF
--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -25,7 +25,8 @@ const getUserAttrs = (walkthroughId, username) => ({
     walkthroughId || buildValidProjectNamespaceName(username, 'shared')
   ),
   'user-username': username,
-  'user-sanitized-username': cleanUsername(username)
+  'user-sanitized-username': cleanUsername(username),
+  'walkthrough-locations': process.env.WALKTHROUGH_LOCATIONS
 });
 
 const getWalkthroughSpecificAttrs = (walkthroughId, walkthroughResources) =>


### PR DESCRIPTION
To support 'Publishing' walkthrough, user needs to understand the current configuration before changing it. This PR allows us to include the current config in walkthrough