### PR TITLE
fix(cards): remove PF3 card group wrapper and adjust spacing

### DIFF
--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CardGrid, Icon } from 'patternfly-react';
+import { Icon } from 'patternfly-react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 import { ClockIcon } from '@patternfly/react-icons';
 import TutorialCard from '../tutorialCard/tutorialCard';
@@ -50,13 +50,11 @@ const TutorialDashboard = props => {
     <div className="integr8ly-tutorial-dashboard pf-u-mb-0">
       <div className="integr8ly-tutorial-dashboard-title pf-u-display-flex pf-u-py-sm">
         <h2 className="pf-c-title pf-m-3xl pf-u-mt-sm">Start with a walkthrough</h2>
-        <div className="integr8ly-walkthrough-counter pf-u-mt-md pf-u-mr-md pf-u-text-align-right pf-m-sm">
+        <div className="integr8ly-walkthrough-counter pf-u-mt-md pf-u-text-align-right pf-m-sm">
           <strong>{walkthroughs.length} walkthroughs</strong>
         </div>
       </div>
-      <CardGrid className="pf-u-mt-0" style={{ width: 'calc(100% - 40px)' }}>
-        <Gallery gutter="md">{cards}</Gallery>
-      </CardGrid>
+      <Gallery gutter="md">{cards}</Gallery>
     </div>
   );
 };


### PR DESCRIPTION
## Motivation
Remove PF3 padding so cards line up with titles

## Why
Match UX designs and proper PatternFly 4 layouts.

## How
Remove old PF3 card code

## Verification Steps

1. Navigate to the dashboard
2. The edge of the first card should now line up with 'Start with a walkthrough' heading.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes
<img width="1458" alt="screen shot 2019-02-25 at 5 42 04 pm" src="https://user-images.githubusercontent.com/4032718/53374024-2d69ea80-3925-11e9-950b-05d530cbbfdb.png">
