### PR TITLE
[Tony Davidson]  Fixed reference to customServerConfig.json in server…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,6 +55,9 @@ $ yarn install
 $ yarn start:dev
 ----
 
+IMPORTANT: The webapp will automatically open (http://localhost:3006) in your browser and watch for file changes.
+When running locally, the available services list is mocked, and service urls set via env vars.
+
 === Cluster configuration
 If you are running tutorial-web-app against your cluster, then you will need to configure your cluster to allow callback to your localhost:
 
@@ -72,13 +75,7 @@ redirectURIs:
 - http://localhost:3006
 
 ----
-----
-$ exit
-----
 
-
-IMPORTANT: The webapp will automatically open (http://localhost:3006) in your browser and watch for file changes.
-When running locally, the available services list is mocked, and service urls set via env vars.
 
 The webapp will also automatically load the walkthroughs from `../tutorial-web-app-walkthroughs/walkthroughs`.
 

--- a/README.adoc
+++ b/README.adoc
@@ -39,21 +39,63 @@ TIP: Use https://github.com/creationix/nvm/blob/master/README.md[nvm] to manage 
 :numbered:
 === Clone the project
 
-First you need to clone the https://github.com/integr8ly/tutorial-web-app-walkthroughs[walkthroughs repository] next to the tutorial web app
+First you need to clone the https://github.com/integr8ly/tutorial-web-app-walkthroughs[walkthroughs repository] next to the tutorial web app:
 
 [source,shell]
 ----
-$ git clone https://github.com/integr8ly/tutorial-web-app-walkthroughs.git
+home:$ git clone https://github.com/integr8ly/tutorial-web-app-walkthroughs.git
+home:$ cd tutorial-web-app-walkthroughs
+home:~/tutorial-web-app-walkthroughs$ install yarn
+home:~/tutorial-web-app-walkthroughs$ cd ..
 ----
 
 === Install dependencies
-Then change to the webapp directory, install its dependencies and run the development server:
+Then change to the webapp directory, install its dependencies and run the development server.  
+[source,shell]
+----
+home:$ cd tutorial-web-app
+home:~/tutorial-web-app$ yarn install
+home:~/tutorial-web-app$ yarn start:dev
+----
+
+=== Cluster configuration
+If you are running tutorial-web-app against your cluster, then you will need to configure your cluster to allow callback to your localhost:
+
+
 
 [source,shell]
 ----
-$ yarn install
-$ yarn start:dev
+$ ssh -i ~/.ssh/ocp-workshop.pem user@bastion.example.openshiftworkshop.com
+[user@bastion ~]# sudo -s
+[root@bastion user]# oc edit oauthclient tutorial-web-app
 ----
+This will open the file in vim for editing. The line 'http://localhost:3006' should be added to the bottom of the oauthclient tutorial-web-app and the file saved
+----
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: oauth.openshift.io/v1
+grantMethod: auto
+kind: OAuthClient
+metadata:
+  creationTimestamp: 2019-02-25T13:11:51Z
+  name: tutorial-web-app
+  resourceVersion: "23196"
+  selfLink: /apis/oauth.openshift.io/v1/oauthclients/tutorial-web-app
+  uid: ea3dc674-38fe-11e9-9ca1-0601b82a88d2
+redirectURIs:
+- https://tutorial-web-app-webapp.apps.tonydavidson-750a.openshiftworkshop.com
+- http://localhost:3006
+~                                                                                                                                                                                                                                                                                         
+~                                                                                                                                                                                                                                                                                         
+~                                                                                                                                                                                                                                                                       
+"/tmp/oc-edit-qrles.yaml" 16L, 613C
+----
+----
+[root@bastion user]# exit
+----
+
 
 IMPORTANT: The webapp will automatically open (http://localhost:3006) in your browser and watch for file changes.
 When running locally, the available services list is mocked, and service urls set via env vars.

--- a/README.adoc
+++ b/README.adoc
@@ -58,6 +58,8 @@ $ yarn start:dev
 IMPORTANT: The webapp will automatically open (http://localhost:3006) in your browser and watch for file changes.
 When running locally, the available services list is mocked, and service urls set via env vars.
 
+The webapp will also automatically load the walkthroughs from `../tutorial-web-app-walkthroughs/walkthroughs`.
+
 === Cluster configuration
 If you are running tutorial-web-app against your cluster, then you will need to configure your cluster to allow callback to your localhost:
 
@@ -76,8 +78,6 @@ redirectURIs:
 
 ----
 
-
-The webapp will also automatically load the walkthroughs from `../tutorial-web-app-walkthroughs/walkthroughs`.
 
 === Setup Local Development of Walkthroughs
 

--- a/README.adoc
+++ b/README.adoc
@@ -43,19 +43,16 @@ First you need to clone the https://github.com/integr8ly/tutorial-web-app-walkth
 
 [source,shell]
 ----
-home:$ git clone https://github.com/integr8ly/tutorial-web-app-walkthroughs.git
-home:$ cd tutorial-web-app-walkthroughs
-home:~/tutorial-web-app-walkthroughs$ install yarn
-home:~/tutorial-web-app-walkthroughs$ cd ..
+$ git clone https://github.com/integr8ly/tutorial-web-app-walkthroughs.git
 ----
 
 === Install dependencies
 Then change to the webapp directory, install its dependencies and run the development server.  
 [source,shell]
 ----
-home:$ cd tutorial-web-app
-home:~/tutorial-web-app$ yarn install
-home:~/tutorial-web-app$ yarn start:dev
+$ cd tutorial-web-app
+$ yarn install
+$ yarn start:dev
 ----
 
 === Cluster configuration
@@ -65,35 +62,18 @@ If you are running tutorial-web-app against your cluster, then you will need to 
 
 [source,shell]
 ----
-$ ssh -i ~/.ssh/ocp-workshop.pem user@bastion.example.openshiftworkshop.com
-[user@bastion ~]# sudo -s
-[root@bastion user]# oc edit oauthclient tutorial-web-app
+$ oc login <my-cluster>
+$ oc edit oauthclient tutorial-web-app
 ----
 This will open the file in vim for editing. The line 'http://localhost:3006' should be added to the bottom of the oauthclient tutorial-web-app and the file saved
 ----
-# Please edit the object below. Lines beginning with a '#' will be ignored,
-# and an empty file will abort the edit. If an error occurs while saving this file will be
-# reopened with the relevant failures.
-#
-apiVersion: oauth.openshift.io/v1
-grantMethod: auto
-kind: OAuthClient
-metadata:
-  creationTimestamp: 2019-02-25T13:11:51Z
-  name: tutorial-web-app
-  resourceVersion: "23196"
-  selfLink: /apis/oauth.openshift.io/v1/oauthclients/tutorial-web-app
-  uid: ea3dc674-38fe-11e9-9ca1-0601b82a88d2
 redirectURIs:
-- https://tutorial-web-app-webapp.apps.tonydavidson-750a.openshiftworkshop.com
+- ...
 - http://localhost:3006
-~                                                                                                                                                                                                                                                                                         
-~                                                                                                                                                                                                                                                                                         
-~                                                                                                                                                                                                                                                                       
-"/tmp/oc-edit-qrles.yaml" 16L, 613C
+
 ----
 ----
-[root@bastion user]# exit
+$ exit
 ----
 
 

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const app = express();
 app.use(bodyParser.json());
 
 const port = process.env.PORT || 5001;
-const configPath = process.env.SERVER_EXTRA_CONFIG_FILE || './etc/webapp/customServerConfig.json';
+const configPath = process.env.SERVER_EXTRA_CONFIG_FILE || '/etc/webapp/customServerConfig.json';
 
 const DEFAULT_CUSTOM_CONFIG_DATA = {
   services: []

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const app = express();
 app.use(bodyParser.json());
 
 const port = process.env.PORT || 5001;
-const configPath = process.env.SERVER_EXTRA_CONFIG_FILE || '/etc/webapp/customServerConfig.json';
+const configPath = process.env.SERVER_EXTRA_CONFIG_FILE || './etc/webapp/customServerConfig.json';
 
 const DEFAULT_CUSTOM_CONFIG_DATA = {
   services: []


### PR DESCRIPTION
….js. Updated READme to give more detail to the installation process and added a section of configuration of openshift cluster.

## Motivation
https://github.com/integr8ly/tutorial-web-app/issues/410

## What
Fixed reference to customServerConfig.json in server.js. Updated READme to give more detail to the installation process and added a section of configuration of openshift cluster.

## Why
During start up the configuration of the provisioned services can be set using an environment variable or a configuration file 'customServerConfig.json'.  This feature was not working.

## How
I changed the file reference in server.js from '/etc/webapp/customConfigFile.json' to '/etc/webapp/customConfigFile.json', which . correctly referenced to file on startup.

## Verification Steps
Verification of environment variable configuration:
create a json file with required configuration and reference it on app startup 
user:/tutorial-web-app$ OPENSHIFT_HOST=master.example.openshiftworkshop.com:443 SERVER_EXTRA_CONFIG_FILE=~/configFile.json yarn start:dev

Verification using customServerConfig.json:
create tutorial-web-app/etc/webapp/customServerConfig.json with required configuration and start app.
user:/tutorial-web-app$ OPENSHIFT_HOST=master.example.openshiftworkshop.com:443  yarn start:dev

Using either of the steps above the result should be as follows:

<img width="1652" alt="screenshot 2019-02-20 at 16 14 16" src="https://user-images.githubusercontent.com/10615211/53399054-0e11a280-39a3-11e9-90f2-19c43dd73b9d.png">


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes


