### PR TITLE
fix(congrats): update congratulations page

### DIFF
--- a/src/pages/congratulations/congratulations.js
+++ b/src/pages/congratulations/congratulations.js
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
 import { noop } from 'patternfly-react';
-import { FlagCheckeredIcon } from '@patternfly/react-icons';
+import { AwardIcon } from '@patternfly/react-icons';
 import RoutedConnectedMasthead from '../../components/masthead/masthead';
 import { connect, reduxActions } from '../../redux';
 
@@ -29,10 +29,10 @@ class CongratulationsPage extends React.Component {
       <React.Fragment>
         <Page className="pf-u-h-100vh">
           <RoutedConnectedMasthead />
-          <PageSection variant={PageSectionVariants.darker}>
+          <PageSection variant={PageSectionVariants.default}>
             <Bullseye>
               <EmptyState>
-                <EmptyStateIcon icon={FlagCheckeredIcon} />
+                <EmptyStateIcon icon={AwardIcon} />
                 <Title size="lg">Congratulations, you completed the walkthrough!</Title>
                 <EmptyStateBody>
                   Return to your homepage to explore more walkthroughs or go to your OpenShift console to utilize what


### PR DESCRIPTION
## Motivation
Fix issue https://issues.jboss.org/browse/INTLY-1136 and replace background color with default grey.

## What
Replace icon and update background color.

## Why
UXD review session results.

## How
Update icon component and background variant.

## Verification Steps

1. Visit the Congratulations screen
2. Background should be grey
3. Icon should be a ribbon

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

<img width="1920" alt="screen shot 2019-02-26 at 1 59 49 pm" src="https://user-images.githubusercontent.com/4032718/53439314-c5bca980-39cf-11e9-8c34-219dbb6c600c.png">
