### PR TITLE
fix(steps): center steps in footer

### DIFF
--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -446,7 +446,7 @@ class TaskPage extends React.Component {
                         {t('task.previousTask')}
                       </Button>
                     )}
-                    <span className="integr8ly-module-column--footer_status pf-u-mx-lg">
+                    <span className="integr8ly-module-column--footer_status pf-u-ml-sm pf-u-mr-lg">
                       {this.getVerificationsForTask(threadTask).map((verificationId, i) => (
                         <React.Fragment key={i}>
                           {/* Bottom footer icon */}


### PR DESCRIPTION
## Motivation
Fix issue https://issues.jboss.org/browse/INTLY-1138

## What
Evenly space (center) the icons and steps between the buttons

## Why
UXD review session findings.

## How
Adjust margins on the x-axis.

## Verification Steps

1. Go to the walkthroughs
2. View the steps in the footer - should be centered between 'Previous' and 'Next' buttons

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

<img width="425" alt="screen shot 2019-02-26 at 2 15 38 pm" src="https://user-images.githubusercontent.com/4032718/53440007-842cfe00-39d1-11e9-93a7-5b1700e168f6.png">
