### PR TITLE
INTLY-1128: Replace home icon with text in breadcrumb

### DIFF
--- a/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
@@ -12,15 +12,9 @@ exports[`Breadcrumb component should handle home clicked 1`] = `
     isActive={false}
     onClick={[Function]}
     target={null}
-    to={null}
+    to="#"
   >
-    <HomeIcon
-      aria-label="Back to the Dashboard"
-      className="fa-lg"
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
+    Home
   </BreadcrumbItem>
   <BreadcrumbItem
     className=""
@@ -56,15 +50,9 @@ exports[`Breadcrumb component should render breadcrumb with props 1`] = `
     isActive={false}
     onClick={[Function]}
     target={null}
-    to={null}
+    to="#"
   >
-    <HomeIcon
-      aria-label="Back to the Dashboard"
-      className="fa-lg"
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
+    Home
   </BreadcrumbItem>
   <BreadcrumbItem
     className=""
@@ -100,15 +88,9 @@ exports[`Breadcrumb component should render default breadcrumb 1`] = `
     isActive={false}
     onClick={[Function]}
     target={null}
-    to={null}
+    to="#"
   >
-    <HomeIcon
-      aria-label="Back to the Dashboard"
-      className="fa-lg"
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
+    Home
   </BreadcrumbItem>
 </Breadcrumb>
 `;

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
 import { BreadcrumbItem, Breadcrumb as PfBreadcrumb } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
-import { HomeIcon } from '@patternfly/react-icons';
 
 class Breadcrumb extends React.Component {
   homeClicked = () => {
@@ -17,8 +16,8 @@ class Breadcrumb extends React.Component {
     const { t, threadName, threadId, totalTasks, taskPosition } = this.props;
     return (
       <PfBreadcrumb>
-        <BreadcrumbItem onClick={this.homeClicked} id="breadcrumb-home">
-          <HomeIcon className="fa-lg" aria-label="Back to the Dashboard" />
+        <BreadcrumbItem to="#" onClick={this.homeClicked} id="breadcrumb-home">
+          Home
         </BreadcrumbItem>
         {threadName && !taskPosition && <BreadcrumbItem isActive>{threadName}</BreadcrumbItem>}
         {threadName &&


### PR DESCRIPTION
## Motivation
INTLY-1128

## What
Removed the home icon in the breadcrumb and replaced it with the text 'Home'.

## Why
Request from UXD design.

## How
Simple change, the only small gotcha was that needed to add a to="#" in order for the text to render as a link instead of static text (either way, the onClick still worked).

## Verification Steps
1. Go to any web app page that contains a breadcrumb at the top.
2. Hover over the Home text and verify that it behaves as a link like the others in the breadcrumb sequence.
3. Click Home to verify that it traverses to the home screen.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
![home_breadcrumb](https://user-images.githubusercontent.com/39063664/53442530-7da18500-39d7-11e9-9404-a77873282995.png)
