### PR TITLE
fix(dropdown): fix color of text on hover

### DIFF
--- a/src/styles/application/utilities/_patternfly4.scss
+++ b/src/styles/application/utilities/_patternfly4.scss
@@ -36,6 +36,10 @@ button,
   height: 32px; // accounts for increase in base font size from 12px to 16px
 }
 
+.pf-c-dropdown__menu-item:hover {
+  color: var(--pf-c-dropdown__menu-item--hover--Color);
+}
+
 .pf-c-content {
 
   .paragraph {


### PR DESCRIPTION
## Motivation
Fix issue https://issues.jboss.org/browse/INTLY-1076

## What
Fix conflict that is causing the buttons in the user dropdown to be white, rather than black.

## Why
UXD review results

## How
Add CSS update to directly target the `color` attribute, rather than using a CSS variable.

## Verification Steps

1. Go to any page and click on the user dropdown menu
2. Hover over any text to see the new color

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

![screen shot 2019-02-27 at 1 19 23 pm](https://user-images.githubusercontent.com/4032718/53513253-c0746300-3a92-11e9-8826-a4c510a73ad7.png)
