### PR TITLE
fix(provisioning): fix alignment of content

### DIFF
--- a/src/components/provisioning/provisioning.js
+++ b/src/components/provisioning/provisioning.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'patternfly-react';
 import {
-  Bullseye,
   EmptyState,
   EmptyStateIcon,
   DataList,
@@ -166,14 +165,16 @@ function buildProvisioningScreen(WrappedComponent) {
     static renderLoadingScreen(services) {
       return (
         <Page className="pf-u-h-100vh">
-          <PageSection variant={PageSectionVariants.default}>
-            <Bullseye>
-              <EmptyState>
-                <EmptyStateIcon icon={BoxesIcon} />
-                <Title size="lg">Provisioning services for your new environment.</Title>
-              </EmptyState>
-            </Bullseye>
-            <DataList className="integr8ly-provisioning-datalist" aria-label="Simple data list example">
+          <PageSection
+            variant={PageSectionVariants.default}
+            className="pf-u-display-flex pf-l-flex pf-m-column-tablet-plus pf-m-justify-content-space-between"
+          >
+            <div />
+            <EmptyState className="pf-m-align-self-center">
+              <EmptyStateIcon icon={BoxesIcon} />
+              <Title size="lg">Provisioning services for your new environment.</Title>
+            </EmptyState>
+            <DataList className="pf-u-w-100" aria-label="Provisioned services datalist">
               {services.map(Provisioning.renderServiceStatusBar)}
             </DataList>
           </PageSection>

--- a/src/styles/application/pages/_provisioning.scss
+++ b/src/styles/application/pages/_provisioning.scss
@@ -1,9 +1,6 @@
 .integr8ly-provisioning {
-  &-datalist {
-    position: fixed;
-    right: 0;
-    bottom: 0;
-    left: 0;
+  &-empty-state {
+    margin: 0 auto;
   }
 
   &-check {


### PR DESCRIPTION
## Motivation
Fix alignment and layout of provisioning screen elements, broken with previous provisioning screen work.

## What
Remove Bullseye component and replace with PF4 layouts utilities.

## Why
Text was hidden behind the provisioning datalist.

## Verification Steps

1. Navigate to the Provisioning screen
2. View on large and small screen (viewports)
3. Verify that the icon and text do not flow behind the datalist.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

