### PR TITLE
INTLY-1202 Update product info

### DIFF
--- a/src/product-info.js
+++ b/src/product-info.js
@@ -2,14 +2,14 @@
 export default {
   'amq-online-standard': {
     prettyName: 'Red Hat AMQ Online',
-    gaStatus: 'preview'
+    gaStatus: 'GA'
   },
   fuse: {
     prettyName: 'Red Hat Fuse Online',
     gaStatus: 'GA'
   },
   codeready: {
-    prettyName: 'CodeReady',
+    prettyName: 'Red Hat CodeReady Workspaces',
     gaStatus: 'GA'
   },
   launcher: {


### PR DESCRIPTION
* AMQ Online is now GA
* CodeReady should be Red Hat CodeReady Workspaces

Verification:
- Run `yarn start:dev` locally or against a cluster
- Ensure AMQ Online has no `preview` tag beside it
- Ensure the CodeReady service name is updated`