### PR TITLE
INTLY-1063: Use a supported base container image for the webapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . ./
 
 USER root
 
-RUN yum -y install git
+RUN yum -y install git httpd24-libcurl
 
 RUN chmod g+w yarn.lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV BUILD_ENV=OCP
 ENV GIT_COMMITTER_NAME=integreatly
 ENV GIT_COMMITTER_EMAIL=integreatly@redhat.com
 ENV GIT_TERMINAL_PROMPT=0
+ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64
 
 USER default
 
@@ -13,7 +14,7 @@ COPY . ./
 
 USER root
 
-RUN yum -y install git httpd24-libcurl
+RUN yum -y install git
 
 RUN chmod g+w yarn.lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bucharestgold/centos7-s2i-nodejs:10.x
+FROM docker.io/nodeshift/centos7-s2i-nodejs:10.x
 
 EXPOSE 5001
 


### PR DESCRIPTION
## Motivation
INTLY-1063 - Use a supported base container image for the webapp

## What
Replaced the node.js version in the FROM with a supported rh version. Needed to specify a new path LD_LIBRARY_PATH to fix docker build issues.

## Why
So the webapp is running on a supported node.js & rhel version, and can take advantage of CVE notifications.

## Verification Steps
1. Verify that the docker build of the webapp succeeds without errors.
2. Verify that when you point the webapp to the docker build image, it looks and behaves as expected.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task
