### PR TITLE
Use RHEL base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nodeshift/centos7-s2i-nodejs:10.x
+FROM registry.access.redhat.com/rhoar-nodejs/nodejs-10
 
 EXPOSE 5001
 
@@ -6,15 +6,12 @@ ENV BUILD_ENV=OCP
 ENV GIT_COMMITTER_NAME=integreatly
 ENV GIT_COMMITTER_EMAIL=integreatly@redhat.com
 ENV GIT_TERMINAL_PROMPT=0
-ENV LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64
 
 USER default
 
 COPY . ./
 
 USER root
-
-RUN yum -y install git
 
 RUN chmod g+w yarn.lock
 


### PR DESCRIPTION
The base image is for node.js, but also has git installed.
This is sufficient for the webapp to run and clone walkthroughs

@mfrances17 It looks like we don't need to install the git dependency when using this rhel base image as its already there.
This avoids the need to auth with subscription manager.