### PR TITLE
Bump version 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {


### PR DESCRIPTION
@david-martin @evanshortiss Mind taking a look? There are workshops using custom images of the webapp that include changes that are now on master. By making a versioned image available they'll be able to use an actual Integreatly image.

Although this wouldn't be in the installer until the next release of Integreatly, at least the workshops can reference an actual Integreatly image until then.