### PR TITLE
INTLY-1241 Allow for a new env var for the threescale wildcard domain

### DIFF
--- a/server.js
+++ b/server.js
@@ -380,6 +380,7 @@ function getCustomConfigData(configPath) {
 function getMockConfigData() {
   return `window.OPENSHIFT_CONFIG = {
     masterUri: 'mock-openshift-console-url',
+    threescaleWildcardDomain: '${process.env.THREESCALE_WILDCARD_DOMAIN || ''}',
     mockData: {
       serviceInstances: [
         {
@@ -474,7 +475,8 @@ function getConfigData(req) {
     wssMasterUri: 'wss://${process.env.OPENSHIFT_HOST}',
     ssoLogoutUri: 'https://${
       process.env.SSO_ROUTE
-    }/auth/realms/openshift/protocol/openid-connect/logout?redirect_uri=${logoutRedirectUri}'
+    }/auth/realms/openshift/protocol/openid-connect/logout?redirect_uri=${logoutRedirectUri}',
+    threescaleWildcardDomain: '${process.env.THREESCALE_WILDCARD_DOMAIN || ''}'
   };`;
 }
 

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -44,7 +44,12 @@ const retrieveRouteAttributes = (resourceId, route) => {
 };
 
 const getMiddlewareServiceAttrs = middlewareServices => {
-  const threescaleUrl = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE);
+  let threescaleUrl;
+  if (window.OPENSHIFT_CONFIG.threescaleWildcardDomain && window.OPENSHIFT_CONFIG.threescaleWildcardDomain.length > 0) {
+    threescaleUrl = window.OPENSHIFT_CONFIG.threescaleWildcardDomain;
+  } else {
+    threescaleUrl = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE);
+  }
 
   return {
     'openshift-app-host': threescaleUrl ? threescaleUrl.replace('https://3scale-admin.', '') : threescaleUrl,


### PR DESCRIPTION
If THREESCALE_WILDCARD_DOMAIN is set, it will be made available in the
ui as window.OPENSHIFT_CONFIG.threescaleWildcardDomain.

This in turn will be used to set the openshift-app-host property for
walkthroughs to indicate the wildcard suffix/domain, which is useful in
a cluster where 3scale has the wildcard proxy setup.
This is used in walkthrough 2 for the staging base url.

*Verification*

* Start the webapp as normal in development, with the OPENSHIFT_HOST env var set e.g. `OPENSHIFT_HOST=master.waterford-62a5.openshiftworkshop.com WALKTHROUGH_LOCATIONS=../tutorial-web-app-walkthroughs/walkthroughs yarn start:dev`
* Go to walkthrough 2 step `3.2. Adding the Fuse Aggregation App Endpoint to Red Hat 3scale`
* Verify the Staging Base URL has the suffix of the OPENSHIFT_HOST e.g. `https://wt2-admin-3scale.apps.waterford-62a5.openshiftworkshop.com`
* Stop the webapp

* Start the webapp again, also setting the THREESCALE_WILDCARD_DOMAIN env var to some value e.g. `THREESCALE_WILDCARD_DOMAIN=example.com OPENSHIFT_HOST=master.waterford-62a5.openshiftworkshop.com WALKTHROUGH_LOCATIONS=../tutorial-web-app-walkthroughs/walkthroughs yarn start:dev`
* Go to walkthrough 2 step `3.2. Adding the Fuse Aggregation App Endpoint to Red Hat 3scale`
* Verify the Staging Base URL has the suffix of the THREESCALE_WILDCARD_DOMAIN e.g. `https://wt2-admin-3scale.example.com`

