### PR TITLE
Change red hat repo url and date format

### DIFF
--- a/src/components/walkthroughDetails/walkthroughDetails.js
+++ b/src/components/walkthroughDetails/walkthroughDetails.js
@@ -27,9 +27,7 @@ class WalkthroughDetails extends React.Component {
                   ) : (
                     <div>
                       <a href={walkthroughInfo.gitUrl} target="_blank" rel="noopener noreferrer">
-                        {walkthroughInfo.gitUrl === 'https://github.com/integr8ly/tutorial-web-app-walkthroughs'
-                          ? 'Red Hat'
-                          : 'Community'}
+                        {walkthroughInfo.gitUrl.includes('https://github.com/integr8ly/') ? 'Red Hat' : 'Community'}
                       </a>
                     </div>
                   )}

--- a/src/components/walkthroughDetails/walkthroughDetails.js
+++ b/src/components/walkthroughDetails/walkthroughDetails.js
@@ -27,7 +27,7 @@ class WalkthroughDetails extends React.Component {
                   ) : (
                     <div>
                       <a href={walkthroughInfo.gitUrl} target="_blank" rel="noopener noreferrer">
-                        {walkthroughInfo.gitUrl === 'https://github.com/integr8ly/tutorial-web-app-walkthroughs.git'
+                        {walkthroughInfo.gitUrl === 'https://github.com/integr8ly/tutorial-web-app-walkthroughs'
                           ? 'Red Hat'
                           : 'Community'}
                       </a>
@@ -41,7 +41,7 @@ class WalkthroughDetails extends React.Component {
                   {walkthroughInfo.type === 'path' ? (
                     <div>---</div>
                   ) : (
-                    <div>{new Date(walkthroughInfo.commitDate).toLocaleDateString()}</div>
+                    <div>{new Date(walkthroughInfo.commitDate).toISOString().slice(0, 10)}</div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Motivation
RH walkthroughs were displaying 'Community' instead of 'Red Hat' for the source. Also received request that date not go by locale but be formatted as 'YYYY-MM-DD".

## What
Checked the latest server and there is no longer a .git at the end of the default RH walkthroughs in the env var. Also reformatted the date as requested.

## Verification Steps
1. Select the first page of any walkthrough.
2. View that the Details section on the right.
3. Verify that the Source is listed as 'Red Hat' for our (default) walkthroughs, 'Community' otherwise.
3. Verify that the Last Updated date is now formatted as 'YYYY-MM-DD'.

## Checklist:
- [x] Code has been tested locally and on live server by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
Screen cap on live system:
![rh_and_date_format](https://user-images.githubusercontent.com/39063664/55509771-beba3400-562a-11e9-831f-55777519b3ea.png)
