### PR TITLE
INTLY-1159: Implement dashboard organization designs

### DIFF
--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -37,12 +37,21 @@ const TutorialDashboard = props => {
     return a < b ? -1 : 1;
   }
 
+  // this needs to check for the json file
   function addCategory(walkthroughs) {
-    const repo = walkthroughs[0].walkthroughLocationInfo.remote;
-    const repoParts = repo.split('/');
-    const repoLastPart = repoParts.length - 1;
-    const repoCategory = repoParts[repoLastPart];
-    const htmlCategory = <h3 className="pf-c-title pf-m-2xl pf-u-mt-sm">{repoCategory} Solution Patterns</h3>;
+    const repoInfo = walkthroughs[0].walkthroughLocationInfo;
+    let htmlCategory = '';
+    if (repoInfo.type === 'path') {
+      htmlCategory = <h3 className="pf-c-title pf-m-2xl pf-u-mt-sm">Locally Installed Solution Patterns</h3>;
+    } else if (repoInfo.header === null) {
+      const repo = walkthroughs[0].walkthroughLocationInfo.remote;
+      const repoParts = repo.split('/');
+      const repoLastPart = repoParts.length - 1;
+      const repoCategory = repoParts[repoLastPart];
+      htmlCategory = <h3 className="pf-c-title pf-m-2xl pf-u-mt-sm">{repoCategory} Solution Patterns</h3>;
+    } else {
+      htmlCategory = <h3 className="pf-c-title pf-m-2xl pf-u-mt-sm">{repoInfo.header}</h3>;
+    }
     return htmlCategory;
   }
 

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -30,14 +30,24 @@ const TutorialDashboard = props => {
     return repos;
   }
 
-  function walkthroughSorter(w1, w2) {
-    const a = `${w1.id} ${w1.title}`;
-    const b = `${w2.id} ${w2.title}`;
+  function wtSortByProgress(w1, w2) {
+    const a = [userProgress[w1.id], w1.title];
+    const b = [userProgress[w2.id], w2.title];
 
-    return a < b ? -1 : 1;
+    if (a[0] === undefined && b[0] === undefined) {
+      return a[1] < b[1] ? -1 : 1;
+    }
+    if (a[0] !== undefined && b[0] !== undefined) {
+      return a[0].progress > b[0].progress ? -1 : 1;
+    }
+    if (a[0] === undefined && b[0] !== undefined) {
+      return a > b ? -1 : 1;
+    }
+    if (a[0] !== undefined && b[0] === undefined) {
+      return a > b ? -1 : 1;
+    }
   }
 
-  // this needs to check for the json file
   function addCategory(walkthroughs) {
     const repoInfo = walkthroughs[0].walkthroughLocationInfo;
     let htmlCategory = '';
@@ -62,7 +72,7 @@ const TutorialDashboard = props => {
     for (let i = 0; i < allRepos.length; i++) {
       const filteredWalkthroughs = filterWalkthroughs(walkthroughs, allRepos[i]);
 
-      const cards = filteredWalkthroughs.sort(walkthroughSorter).map((walkthrough, i) => {
+      const cards = filteredWalkthroughs.sort(wtSortByProgress).map((walkthrough, i) => {
         const currentProgress = userProgress[walkthrough.id];
         let startedText;
         if (currentProgress === undefined) startedText = 'Get Started';

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -8,6 +8,28 @@ import TutorialCard from '../tutorialCard/tutorialCard';
 const TutorialDashboard = props => {
   const { walkthroughs, userProgress } = props;
 
+  function filterWalkthroughs(walkthrus, filter) {
+    let result = [];
+    if (walkthrus[0]) {
+      result = walkthrus.filter(walkthru => walkthru.walkthroughLocationInfo.remote === filter);
+      return result;
+    }
+    return result;
+  }
+
+  function getRepos(walkthroughs) {
+    const repos = [];
+
+    for (let i = 0; i < walkthroughs.length; i++) {
+      const currentWalkthrough = walkthroughs[i];
+      const repo = currentWalkthrough.walkthroughLocationInfo.remote;
+      if (!repos.includes(repo)) {
+        repos.push(repo);
+      }
+    }
+    return repos;
+  }
+
   function walkthroughSorter(w1, w2) {
     const a = `${w1.id} ${w1.title}`;
     const b = `${w2.id} ${w2.title}`;
@@ -15,54 +37,75 @@ const TutorialDashboard = props => {
     return a < b ? -1 : 1;
   }
 
-  const cards = walkthroughs.sort(walkthroughSorter).map((walkthrough, i) => {
-    const currentProgress = userProgress[walkthrough.id];
-    let startedText;
-    if (currentProgress === undefined) startedText = 'Get Started';
-    else if (currentProgress.progress === 100) startedText = 'Completed';
-    else startedText = 'Resume';
+  function addCategory(walkthroughs) {
+    const repo = walkthroughs[0].walkthroughLocationInfo.remote;
+    const repoParts = repo.split('/');
+    const repoLastPart = repoParts.length - 1;
+    const repoCategory = repoParts[repoLastPart];
+    const htmlCategory = <h3 className="pf-c-title pf-m-2xl pf-u-mt-sm">{repoCategory} Solution Patterns</h3>;
+    return htmlCategory;
+  }
 
-    return (
-      <GalleryItem key={walkthrough.id}>
-        <TutorialCard
-          title={walkthrough.title}
-          getStartedLink={
-            currentProgress !== undefined && currentProgress.task + 1 === currentProgress.totalTasks
-              ? `/tutorial/${walkthrough.id}`
-              : `/tutorial/${walkthrough.id}/${currentProgress === undefined ? '' : `task/${currentProgress.task}`}`
-          }
-          getStartedText={startedText}
-          getStartedIcon={
-            <Icon
-              type="fa"
-              name={
-                currentProgress !== undefined && currentProgress.progress === 100
-                  ? 'check-circle pf-u-mr-xs integr8ly-c-card__status--complete-icon'
-                  : 'arrow-circle-right pf-u-mr-sm'
+  function addAll(walkthroughs) {
+    const allRepos = getRepos(walkthroughs);
+    const htmlSnippet = [];
+
+    for (let i = 0; i < allRepos.length; i++) {
+      const filteredWalkthroughs = filterWalkthroughs(walkthroughs, allRepos[i]);
+
+      const cards = filteredWalkthroughs.sort(walkthroughSorter).map((walkthrough, i) => {
+        const currentProgress = userProgress[walkthrough.id];
+        let startedText;
+        if (currentProgress === undefined) startedText = 'Get Started';
+        else if (currentProgress.progress === 100) startedText = 'Completed';
+        else startedText = 'Resume';
+
+        return (
+          <GalleryItem key={walkthrough.id}>
+            <TutorialCard
+              title={walkthrough.title}
+              getStartedLink={
+                currentProgress !== undefined && currentProgress.task + 1 === currentProgress.totalTasks
+                  ? `/tutorial/${walkthrough.id}`
+                  : `/tutorial/${walkthrough.id}/${currentProgress === undefined ? '' : `task/${currentProgress.task}`}`
               }
-            />
-          }
-          minsIcon={<ClockIcon className="pf-u-mr-sm" />}
-          progress={currentProgress === undefined ? 0 : currentProgress.progress}
-          mins={walkthrough.time}
-        >
-          <p>{walkthrough.shortDescription}</p>
-        </TutorialCard>
-      </GalleryItem>
-    );
-  });
-
-  return (
-    <div className="integr8ly-tutorial-dashboard pf-u-mb-0">
-      <div className="integr8ly-tutorial-dashboard-title pf-u-display-flex pf-u-py-sm">
-        <h1 className="pf-c-title pf-m-4xl pf-u-mt-sm">Start with a walkthrough</h1>
-        <div className="integr8ly-walkthrough-counter pf-u-mt-lg pf-u-mr-md pf-u-text-align-right pf-m-sm">
-          <strong>{walkthroughs.length} walkthroughs</strong>
+              getStartedText={startedText}
+              getStartedIcon={
+                <Icon
+                  type="fa"
+                  name={
+                    currentProgress !== undefined && currentProgress.progress === 100
+                      ? 'check-circle pf-u-mr-xs integr8ly-c-card__status--complete-icon'
+                      : 'arrow-circle-right pf-u-mr-sm'
+                  }
+                />
+              }
+              minsIcon={<ClockIcon className="pf-u-mr-sm" />}
+              progress={currentProgress === undefined ? 0 : currentProgress.progress}
+              mins={walkthrough.time}
+            >
+              <p>{walkthrough.shortDescription}</p>
+            </TutorialCard>
+          </GalleryItem>
+        );
+      });
+      htmlSnippet.push(
+        <div className="integr8ly-tutorial-dashboard-title pf-u-display-flex pf-u-py-sm">
+          {addCategory(filteredWalkthroughs)}
+          <div className="integr8ly-walkthrough-counter pf-u-mt-lg pf-u-mr-md pf-u-text-align-right pf-m-sm">
+            {filteredWalkthroughs.length === 1 ? (
+              <strong>{filteredWalkthroughs.length} walkthough</strong>
+            ) : (
+              <strong>{filteredWalkthroughs.length} walkthoughs</strong>
+            )}
+          </div>
         </div>
-      </div>
-      <Gallery gutter="md">{cards}</Gallery>
-    </div>
-  );
+      );
+      htmlSnippet.push(<Gallery gutter="md">{cards}</Gallery>);
+    }
+    return htmlSnippet;
+  }
+  return <div className="integr8ly-tutorial-dashboard pf-u-mb-0">{addAll(walkthroughs)}</div>;
 };
 
 TutorialDashboard.propTypes = {

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -17,11 +17,11 @@ const TutorialDashboard = props => {
     return result;
   }
 
-  function getRepos(walkthroughs) {
+  function getRepos(walkthrus) {
     const repos = [];
 
-    for (let i = 0; i < walkthroughs.length; i++) {
-      const currentWalkthrough = walkthroughs[i];
+    for (let i = 0; i < walkthrus.length; i++) {
+      const currentWalkthrough = walkthrus[i];
       const repo = currentWalkthrough.walkthroughLocationInfo.remote;
       if (!repos.includes(repo)) {
         repos.push(repo);
@@ -46,15 +46,16 @@ const TutorialDashboard = props => {
     if (a[0] !== undefined && b[0] === undefined) {
       return a > b ? -1 : 1;
     }
+    return a[1] < b[1] ? -1 : 1;
   }
 
-  function addCategory(walkthroughs) {
-    const repoInfo = walkthroughs[0].walkthroughLocationInfo;
+  function addCategory(walkthrus) {
+    const repoInfo = walkthrus[0].walkthroughLocationInfo;
     let htmlCategory = '';
     if (repoInfo.type === 'path') {
       htmlCategory = <h3 className="pf-c-title pf-m-2xl pf-u-mt-sm">Locally Installed Solution Patterns</h3>;
     } else if (repoInfo.header === null) {
-      const repo = walkthroughs[0].walkthroughLocationInfo.remote;
+      const repo = walkthrus[0].walkthroughLocationInfo.remote;
       const repoParts = repo.split('/');
       const repoLastPart = repoParts.length - 1;
       const repoCategory = repoParts[repoLastPart];
@@ -65,14 +66,14 @@ const TutorialDashboard = props => {
     return htmlCategory;
   }
 
-  function addAll(walkthroughs) {
-    const allRepos = getRepos(walkthroughs);
+  function addAll(walkthrus) {
+    const allRepos = getRepos(walkthrus);
     const htmlSnippet = [];
 
     for (let i = 0; i < allRepos.length; i++) {
-      const filteredWalkthroughs = filterWalkthroughs(walkthroughs, allRepos[i]);
+      const filteredWalkthroughs = filterWalkthroughs(walkthrus, allRepos[i]);
 
-      const cards = filteredWalkthroughs.sort(wtSortByProgress).map((walkthrough, i) => {
+      const cards = filteredWalkthroughs.sort(wtSortByProgress).map(walkthrough => {
         const currentProgress = userProgress[walkthrough.id];
         let startedText;
         if (currentProgress === undefined) startedText = 'Get Started';

--- a/src/styles/application/components/_tutorialDashboard.scss
+++ b/src/styles/application/components/_tutorialDashboard.scss
@@ -8,6 +8,10 @@
     & h1 {
       flex-basis: 50%;
     }
+
+    & h3 {
+      flex-basis: 50%;
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1159

## What

- Categorize and group walkthroughs by repository, adding each repository's walkthroughs in their own group under a specific heading. The category heading is based off the 'pretty name' defined in the repository's walkthrough-config.json file. If the json file does not exist, use the last part of the github repo's name followed by 'Solution Patterns'. For example, in the first screen shot below, the json file for the above set of walkthroughs contained a pretty name of 'Red Hat Solution Patterns'. In the below set of walkthroughs, there was no json file in the 'https://github.com/integr8ly/example-customisations' repo, so the category was named 'example-customisations Solution Patterns'.
- Create a sort in which each category of walkthroughs is first sorted by the % completed, then alphabetically.

## Why
To work with new dashboard design.

## Verification Steps
1. Go on a Integreatly cluster that is running multiple repos and use my docker image for the web app:
         docker.io/mfrances17/dev-tutorial-web-app:latest
2. Verify that all walkthroughs are grouped and categorized by heading that corresponds to the json file/repo for which they belong. 
3. Verify that all unstarted walkthroughs are listed alphabetically under each category. 
4. Start a few of the walkthroughs and return to the home page to verify that the cards are now sorted by % completed, then alphabetically.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
Link to demo (my demo starts 43 seconds in):
https://bluejeans.com/s/t3sRS/

**Screen cap: Categorized walkthroughs:**
![categories](https://user-images.githubusercontent.com/39063664/56387782-34a9c800-61f3-11e9-8ff7-3a2e4281865b.png)

**Screen cap: Sorted after one walkthrough started:**
![sorted](https://user-images.githubusercontent.com/39063664/56387830-5acf6800-61f3-11e9-978e-2eed756629e4.png)
