### PR TITLE
INTLY-1814 Don't crash when walkthrough isn't found

### DIFF
--- a/server.js
+++ b/server.js
@@ -130,16 +130,17 @@ app.get('/about', (_, res) => {
 
 app.get('/about/walkthrough/:walkthroughId', (req, res) => {
   const { walkthroughId } = req.params;
+  const walkthrough = walkthroughs.find(w => w.id === walkthroughId);
+  if (!walkthrough) {
+    console.error('Could not find walkthrough with ID', walkthroughId);
+    res.sendStatus(404);
+    return;
+  }
   res.json({
     walkthroughId,
-    walkthroughLocation: getWalkthroughLocationInfoForWalkthrough(walkthroughId)
+    walkthroughLocation: walkthrough.walkthroughLocationInfo
   });
 });
-
-function getWalkthroughLocationInfoForWalkthrough(walkthroughId) {
-  const walkthrough = walkthroughs.find(w => w.id === walkthroughId);
-  return walkthrough.walkthroughLocationInfo;
-}
 
 function getUniqueWalkthroughLocationInfos(walkthroughs) {
   const infos = {};

--- a/src/redux/reducers/walkthroughServiceReducers.js
+++ b/src/redux/reducers/walkthroughServiceReducers.js
@@ -107,6 +107,9 @@ const walkthroughServiceReducers = (state = initialState, action) => {
         }
       );
     case FULFILLED_ACTION(walkthroughTypes.GET_WALKTHROUGH_INFO):
+      if (!action.payload.data || !action.payload.data.walkthroughLocation) {
+        return state;
+      }
       return setStateProp(
         'walkthroughInfo',
         {

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -163,7 +163,7 @@ const getCustomConfig = (dispatch, user) => {
   return fetch(`/customConfig?username=${parsedUsername}`)
     .then(res => res.json())
     .then(config => {
-      if (config && config.services) {
+      if (config) {
         dispatch({
           type: FULFILLED_ACTION(middlewareTypes.GET_CUSTOM_CONFIG),
           payload: config


### PR DESCRIPTION
Currently the sever will crash if a user tries to retrieve a walkthrough that doesn't exist. Although this should be rare, this resolves both the UI and server from completely failing.

@tremes I'm building an image now for testing. Verification steps are below. 

@tiffanynolan Do we have any designs for a not found screen that could be used on the UI in the future? Is this something we care too much about?

## Verification steps
- Use the image of the webapp, `docker.io/aidenkeatingrht/tutorial-web-app:INTLY-1814`
- Go to a route for a walkthrough that doesn't exist, for example `<webapp-url>/tutorial/test`
- Ensure the server doesn't crash and prints an error message instead.
- Ensure the UI doesn't completely crash, it should just be a blank screen.