### PR TITLE
INTLY-1809: Fix web app startup console errors

### DIFF
--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -76,12 +76,13 @@ class InstalledAppsView extends React.Component {
 
   static getOpenshiftConsole(index) {
     return (
-      <DataList>
+      <DataList aria-label="openshift-console-datalist" key="openshift_console">
         <DataListItem
           className="pf-u-p-md integr8ly-installed-apps-view-list-item-enabled"
           onClick={() => window.open(`${window.OPENSHIFT_CONFIG.masterUri}/console`, '_blank')}
           key={`openshift_console_${index}`}
           value={index}
+          aria-labelledby={`openshift-console-datalistitem-${index}`}
         >
           <div className="pf-u-display-flex pf-u-flex-direction-column">
             <p>Red Hat OpenShift</p>
@@ -166,7 +167,7 @@ class InstalledAppsView extends React.Component {
       .map((app, index) => {
         const { prettyName, gaStatus, hidden } = getProductDetails(app);
         return hidden ? null : (
-          <DataList>
+          <DataList aria-label="cluster-services-datalist" key={`${app.spec.clusterServiceClassExternalName}`}>
             <DataListItem
               className={
                 InstalledAppsView.isServiceProvisioned(app)
@@ -183,6 +184,7 @@ class InstalledAppsView extends React.Component {
               }}
               key={`${app.spec.clusterServiceClassExternalName}_${index}`}
               value={index}
+              aria-labelledby={`cluster-service-datalistitem-${index}`}
             >
               {' '}
               <div className="pf-u-display-flex pf-u-justify-content-space-between" style={{ width: '100%' }}>

--- a/src/components/provisioning/provisioningScreen.js
+++ b/src/components/provisioning/provisioningScreen.js
@@ -103,6 +103,7 @@ class ProvisioningScreen extends React.Component {
       <DataListItem
         className={`${isProvisionFailed ? 'list-group-error-item' : null}`}
         key={svc.spec.clusterServiceClassExternalName}
+        aria-labelledby={`service-statusbar-datalistitem-${svc.spec.clusterServiceClassExternalName}`}
       >
         <DataListCell className="pf-u-py-md">{ProvisioningScreen.renderServiceLoadingIcon(svc)}</DataListCell>
         <DataListCell className="pf-u-py-md">

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -138,7 +138,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
                 </div>
               </h3>
               <DataList
-                aria-label="Task breakdown by time"
+                aria-label="task-breakdowns-by-time"
                 className=""
               />
               <div

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -135,9 +135,9 @@ class TutorialPage extends React.Component {
                           </span>
                         </div>
                       </h3>
-                      <DataList aria-label="Task breakdown by time">
+                      <DataList aria-label="task-breakdowns-by-time">
                         {parsedThread.tasks.map((task, i) => (
-                          <DataListItem key={i}>
+                          <DataListItem key={i} aria-labelledby={`task-breakdown-by-time-${i}`}>
                             <DataListCell width={5}>{`${task.title}`}</DataListCell>
                             <DataListCell width={1}>
                               <div className="integr8ly-task-dashboard-estimated-time">


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1809

## What
There were 4 console errors that were being thrown on startup of the web app. About half of these were due to required props in components that were left undefined. The other half were array mappings to components that did not define unique keys for each component.

## Why
Clean up the web app so there are no errors thrown on startup, which were clogging up the console but also could have potentially become issues during UI refresh. Also clicked around the UI to verify that other console errors were not being generated.

## How
Added missing props and keys.

## Verification Steps
1. Start the web app with these changes.
2. Verify that the console is clean of errors on startup.
3. Traverse the various pages within the webapp/walkthroughs.
4. Verify that there are still no errors in the console (note - there still are 'warnings', mostly adoc related).

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task
