### PR TITLE
INTLY-1718: Update version text in About modal

### DIFF
--- a/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
+++ b/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
@@ -17,8 +17,8 @@ exports[`AboutModal Component should render a non-connected component: hidden mo
     brandImageAlt="Red Hat logo"
     brandImageSrc="Logo_RH_RGB_Reverse.png"
     className=""
-    heroImageAlt="Red Hat Solutions Explorer background image"
-    heroImageSrc="pfbg_992.jpg"
+    heroimagealt="Red Hat Solutions Explorer background image"
+    heroimagesrc="pfbg_992.jpg"
     isOpen={false}
     logoImageAlt="Red Hat Solutions Explorer logo"
     logoImageSrc="logo-alt.svg"
@@ -35,8 +35,8 @@ exports[`AboutModal Component should render a non-connected component: hidden mo
         brandImageAlt="Red Hat logo"
         brandImageSrc="Logo_RH_RGB_Reverse.png"
         className=""
-        heroImageAlt="Red Hat Solutions Explorer background image"
-        heroImageSrc="pfbg_992.jpg"
+        heroimagealt="Red Hat Solutions Explorer background image"
+        heroimagesrc="pfbg_992.jpg"
         isOpen={false}
         logoImageAlt="Red Hat Solutions Explorer logo"
         logoImageSrc="logo-alt.svg"
@@ -66,8 +66,8 @@ exports[`AboutModal Component should render a non-connected component: show moda
     brandImageAlt="Red Hat logo"
     brandImageSrc="Logo_RH_RGB_Reverse.png"
     className=""
-    heroImageAlt="Red Hat Solutions Explorer background image"
-    heroImageSrc="pfbg_992.jpg"
+    heroimagealt="Red Hat Solutions Explorer background image"
+    heroimagesrc="pfbg_992.jpg"
     isOpen={false}
     logoImageAlt="Red Hat Solutions Explorer logo"
     logoImageSrc="logo-alt.svg"
@@ -84,8 +84,8 @@ exports[`AboutModal Component should render a non-connected component: show moda
         brandImageAlt="Red Hat logo"
         brandImageSrc="Logo_RH_RGB_Reverse.png"
         className=""
-        heroImageAlt="Red Hat Solutions Explorer background image"
-        heroImageSrc="pfbg_992.jpg"
+        heroimagealt="Red Hat Solutions Explorer background image"
+        heroimagesrc="pfbg_992.jpg"
         isOpen={false}
         logoImageAlt="Red Hat Solutions Explorer logo"
         logoImageSrc="logo-alt.svg"

--- a/src/components/aboutModal/aboutModal.js
+++ b/src/components/aboutModal/aboutModal.js
@@ -27,8 +27,8 @@ class AboutModal extends React.Component {
           isOpen={isOpen}
           onClose={closeAboutModal}
           productName="Red Hat Solution Explorer"
-          heroImageSrc={pfBackgroundImage}
-          heroImageAlt="Red Hat Solutions Explorer background image"
+          heroimagesrc={pfBackgroundImage}
+          heroimagealt="Red Hat Solutions Explorer background image"
           brandImageSrc={redHatLogo}
           brandImageAlt="Red Hat logo"
           logoImageSrc={solutionsExplorerLogo}
@@ -36,7 +36,7 @@ class AboutModal extends React.Component {
         >
           <TextContent>
             <TextList component="dl">
-              <TextListItem component="dt">Webapp version</TextListItem>
+              <TextListItem component="dt">Web App Version</TextListItem>
               <TextListItem component="dd">{pkgJson.version}</TextListItem>
               <TextListItem component="dt">User Name</TextListItem>
               <TextListItem component="dd">{window.localStorage.getItem('currentUserName')}</TextListItem>


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1718

## What
Ask was that, for consistency with the other items in the About modal, the text for the Web App version should be displayed with the label of "Web App Version" instead of "Webapp version". Also, noticed that the About modal was throwing a couple of console errors on instantiation... a couple of the props must have been renamed in PF4. So included those fixes along with this one.

## Why
Consistency with other About modal items and clean up errors.

## Verification Steps
1. In the web app, select About from the user menu.
2. Verify that no errors appear in the console.
3. Verify that the text for the web app version now appears as "Web App Version" as opposed to "Webapp version".

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
![web-app-version](https://user-images.githubusercontent.com/39063664/56697516-cebeb400-66bc-11e9-9545-ec80881b3646.png)
