### PR TITLE
INTLY-1661 Added radio button ID's and footer nav button ID's

### DIFF
--- a/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
+++ b/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
@@ -27,7 +27,7 @@ exports[`CopyField Component should render a multi-line copy component: multi-li
     </span>
     <input
       class="integr8ly-copy-input expanded form-control"
-      id="test"
+      id="copyField_null"
       readonly=""
       type="text"
       value="{\\"hello\\":\\"world\\"}"
@@ -38,6 +38,7 @@ exports[`CopyField Component should render a multi-line copy component: multi-li
       <button
         aria-label="Copy to Clipboard"
         class="btn btn-default"
+        id="copyButton_null"
         type="button"
       >
         <span
@@ -68,7 +69,7 @@ exports[`CopyField Component should render a single-line copy component: single-
   >
     <input
       class="integr8ly-copy-input false form-control"
-      id="test"
+      id="copyField_null"
       readonly=""
       type="text"
       value="{\\"hello\\":\\"world\\"}"
@@ -79,6 +80,7 @@ exports[`CopyField Component should render a single-line copy component: single-
       <button
         aria-label="Copy to Clipboard"
         class="btn btn-default"
+        id="copyButton_null"
         type="button"
       >
         <span

--- a/src/components/copyField/copyField.js
+++ b/src/components/copyField/copyField.js
@@ -107,7 +107,11 @@ class CopyField extends React.Component {
               overlay={<PFTooltip id={setToolTipId}>{labelClickedDescription}</PFTooltip>}
               placement={tooltipPlacement}
             >
-              <Button onClick={this.onCopy} aria-label={labelClickedDescription}>
+              <Button
+                id={`copyButton_${this.props.copySequenceId}`}
+                onClick={this.onCopy}
+                aria-label={labelClickedDescription}
+              >
                 {labelClicked}
               </Button>
             </OverlayTrigger>
@@ -117,7 +121,11 @@ class CopyField extends React.Component {
               overlay={<PFTooltip id={setToolTipId}>{labelDescription}</PFTooltip>}
               placement={tooltipPlacement}
             >
-              <Button onClick={this.onCopy} aria-label={labelDescription}>
+              <Button
+                id={`copyButton_${this.props.copySequenceId}`}
+                onClick={this.onCopy}
+                aria-label={labelDescription}
+              >
                 {label}
               </Button>
             </OverlayTrigger>
@@ -165,6 +173,7 @@ class CopyField extends React.Component {
             </InputGroup.Button>
           )}
           <Form.FormControl
+            id={`copyField_${this.props.copySequenceId}`}
             type="text"
             value={value}
             className={`integr8ly-copy-input ${expanded && 'expanded'}`}
@@ -191,6 +200,7 @@ class CopyField extends React.Component {
 
 CopyField.propTypes = {
   id: PropTypes.string,
+  copySequenceId: PropTypes.string,
   expandDescription: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   labelClicked: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -204,6 +214,7 @@ CopyField.propTypes = {
 
 CopyField.defaultProps = {
   id: null,
+  copySequenceId: null,
   expandDescription: null,
   label: <Icon type="fa" name="paste" />,
   labelClicked: <Icon type="fa" name="check" />,

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -21,9 +21,9 @@ const TutorialDashboard = props => {
     if (currentProgress === undefined) startedText = 'Get Started';
     else if (currentProgress.progress === 100) startedText = 'Completed';
     else startedText = 'Resume';
-
+    console.log(walkthrough.id);
     return (
-      <GalleryItem key={walkthrough.id}>
+      <GalleryItem id={walkthrough.id} key={walkthrough.id}>
         <TutorialCard
           title={walkthrough.title}
           getStartedLink={

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -21,7 +21,6 @@ const TutorialDashboard = props => {
     if (currentProgress === undefined) startedText = 'Get Started';
     else if (currentProgress.progress === 100) startedText = 'Completed';
     else startedText = 'Resume';
-    console.log(walkthrough.id);
     return (
       <GalleryItem id={walkthrough.id} key={walkthrough.id}>
         <TutorialCard

--- a/src/pages/congratulations/congratulations.js
+++ b/src/pages/congratulations/congratulations.js
@@ -38,7 +38,7 @@ class CongratulationsPage extends React.Component {
                   Return to your homepage to explore more walkthroughs or go to your OpenShift console to utilize what
                   you just built!
                 </EmptyStateBody>
-                <Button variant="primary" type="button" onClick={e => this.exitTutorial(e)}>
+                <Button id="congratulations-button" variant="primary" type="button" onClick={e => this.exitTutorial(e)}>
                   Return to Home Page
                 </Button>{' '}
               </EmptyState>

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -88,6 +88,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
                   aria-label={null}
                   className=""
                   component="button"
+                  id="get-started-01"
                   isActive={false}
                   isBlock={false}
                   isDisabled={false}
@@ -148,6 +149,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
                   aria-label={null}
                   className=""
                   component="button"
+                  id="get-started-02"
                   isActive={false}
                   isBlock={false}
                   isDisabled={false}

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -46,8 +46,13 @@ class TaskPage extends React.Component {
   componentDidUpdate() {
     if (this.rootDiv.current) {
       const codeBlocks = this.rootDiv.current.querySelectorAll('pre');
+      let sequenceNumber = 1;
       codeBlocks.forEach(block => {
-        ReactDOM.render(<CopyField value={block.innerText} multiline={block.clientHeight > 40} />, block.parentNode);
+        ReactDOM.render(
+          <CopyField copySequenceId={sequenceNumber} value={block.innerText} multiline={block.clientHeight > 40} />,
+          block.parentNode
+        );
+        sequenceNumber++;
       });
     }
   }
@@ -289,6 +294,7 @@ class TaskPage extends React.Component {
             <Form>
               <FormGroup controlId="radio" disabled={false} bsSize="small">
                 <Radio
+                  id={`${blockId}verificationYes`}
                   name={blockId}
                   checked={isYesChecked}
                   onChange={e => {
@@ -300,6 +306,7 @@ class TaskPage extends React.Component {
                   Yes
                 </Radio>
                 <Radio
+                  id={`${blockId}verificationNo`}
                   name={blockId}
                   checked={isNoChecked}
                   onChange={e => {
@@ -437,12 +444,17 @@ class TaskPage extends React.Component {
                   </Text>
                   <div className="pf-u-mb-lg">
                     {taskNum === 0 && (
-                      <Button variant="secondary" type="button" onClick={e => this.backToIntro(e)}>
+                      <Button id="introReturn" variant="secondary" type="button" onClick={e => this.backToIntro(e)}>
                         {t('task.backToIntro')}
                       </Button>
                     )}
                     {taskNum > 0 && (
-                      <Button variant="secondary" type="button" onClick={e => this.goToTask(e, taskNum - 1)}>
+                      <Button
+                        id="previousPartWalkthrough"
+                        variant="secondary"
+                        type="button"
+                        onClick={e => this.goToTask(e, taskNum - 1)}
+                      >
                         {t('task.previousTask')}
                       </Button>
                     )}
@@ -498,6 +510,7 @@ class TaskPage extends React.Component {
                     </span>
                     {taskNum + 1 < totalTasks && (
                       <Button
+                        id="nextPartWalkthrough"
                         variant={taskVerificationComplete ? 'primary' : 'secondary'}
                         type="button"
                         onClick={e => this.goToTask(e, taskNum + 1)}
@@ -508,6 +521,7 @@ class TaskPage extends React.Component {
                     )}
                     {taskNum + 1 === totalTasks && (
                       <Button
+                        id="exitButton"
                         variant={taskVerificationComplete ? 'primary' : 'secondary'}
                         type="button"
                         onClick={e => this.exitTutorial(e)}

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -117,7 +117,12 @@ class TutorialPage extends React.Component {
                     <CardBody>
                       <div className="integr8ly-task-dashboard-header">
                         <h1>{parsedThread.title}</h1>
-                        <Button variant="primary" type="button" onClick={e => this.getStarted(e, id)}>
+                        <Button
+                          id="get-started-01"
+                          variant="primary"
+                          type="button"
+                          onClick={e => this.getStarted(e, id)}
+                        >
                           {t('tutorial.getStarted')}
                         </Button>
                       </div>
@@ -152,7 +157,12 @@ class TutorialPage extends React.Component {
                         ))}
                       </DataList>
                       <div className="pull-right integr8ly-task-dashboard-time-to-completion pf-u-mb-lg">
-                        <Button variant="primary" type="button" onClick={e => this.getStarted(e, id)}>
+                        <Button
+                          id="get-started-02"
+                          variant="primary"
+                          type="button"
+                          onClick={e => this.getStarted(e, id)}
+                        >
                           {t('tutorial.getStarted')}
                         </Button>
                       </div>


### PR DESCRIPTION
INTLY-1661 Added id's to copy fields and to copy field buttons

## Motivation
[https://issues.jboss.org/browse/INTLY-1661](url)

## What
ID's added to elements to aid UI-Browser testing

## Why
Using ID's will stabilise any browser test and lead to more consistent passing of tests .

## How
The ID's were added via a combination of update to this repo and to Tutorial-Web-App-Walkthrough

## Verification Steps
1. Clone repo
2. Follow README for setup to run locally.
3. Goto your cluster
4. Login to Openshift in your cluster
5. Set up your cluster to hit tutorial-web-app-walkthroughs branch with adoc changes using the following command.

`oc patch webapp tutorial-web-app-operator -n rhpds-webapp --type=merge -p '{ "spec": { "template": { "parameters": { "WALKTHROUGH_LOCATIONS": "https://github.com/tonyxrmdavidson/tutorial-web-app-walkthroughs.git#INTLY-1689" }}}}'`

6. Goto your local repo
7. yarn start:dev
8. After review you can revert back to default walkthroughs by using the following command.

`oc patch webapp tutorial-web-app-operator -n rhpds-webapp --type=merge -p '{ "spec": { "template": { "parameters": { "WALKTHROUGH_LOCATIONS": "https://github.com/integr8ly/tutorial-web-app-walkthroughs.git" }}}}'`

## Checklist:

- [x] Code has been tested locally by PR requester
- [] Changes have been successfully verified by another team member

## Progress

- [] Finished task
- [] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
