### PR TITLE
switch to ns

### DIFF
--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -44,7 +44,7 @@ class EnMasseServiceInstanceTransform {
     const defaultTransform = new DefaultServiceInstanceTransform().transform(siInfo);
     defaultTransform.spec.parameters = {
       name: siInfo.username,
-      namespace: siInfo.username
+      namespace: siInfo.namespace
     };
     defaultTransform.spec.clusterServicePlanExternalName = 'standard-unlimited';
     return defaultTransform;


### PR DESCRIPTION
uses openshift namespace an enmasse provisioning services "namespace" param