### PR TITLE
INTLY-1982: Typo in walkthrough count label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -114,9 +114,9 @@ const TutorialDashboard = props => {
           {addCategory(filteredWalkthroughs)}
           <div className="integr8ly-walkthrough-counter pf-u-mt-lg pf-u-mr-md pf-u-text-align-right pf-m-sm">
             {filteredWalkthroughs.length === 1 ? (
-              <strong>{filteredWalkthroughs.length} walkthough</strong>
+              <strong>{filteredWalkthroughs.length} walkthrough</strong>
             ) : (
-              <strong>{filteredWalkthroughs.length} walkthoughs</strong>
+              <strong>{filteredWalkthroughs.length} walkthroughs</strong>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1982

## What
Typos in the 'walkthough' counter labels - added the missing 'r' to both

## Verification Steps
1. Go to the main Solutions Explorer page.
2. Verify that the counter displays '# walkthroughs' or '1 walkthrough', spelled correctly

## Checklist:
- [x] Code has been tested locally by PR requester

## Progress
- [x] Finished task

## Additional Notes
![typo-walkthrough](https://user-images.githubusercontent.com/39063664/57140856-c6363f80-6d86-11e9-8ba7-ef444113ad83.png)
