### PR TITLE
Changes to allow automated browsers testing. Fixes for console errors…

### DIFF
--- a/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
+++ b/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
@@ -27,7 +27,8 @@ exports[`CopyField Component should render a multi-line copy component: multi-li
     </span>
     <input
       class="integr8ly-copy-input expanded form-control"
-      id="copyField_null"
+      copyfieldid="copyField_null"
+      id="test"
       readonly=""
       type="text"
       value="{\\"hello\\":\\"world\\"}"
@@ -69,7 +70,8 @@ exports[`CopyField Component should render a single-line copy component: single-
   >
     <input
       class="integr8ly-copy-input false form-control"
-      id="copyField_null"
+      copyfieldid="copyField_null"
+      id="test"
       readonly=""
       type="text"
       value="{\\"hello\\":\\"world\\"}"

--- a/src/components/copyField/copyField.js
+++ b/src/components/copyField/copyField.js
@@ -173,7 +173,7 @@ class CopyField extends React.Component {
             </InputGroup.Button>
           )}
           <Form.FormControl
-            id={`copyField_${this.props.copySequenceId}`}
+            copyfieldid={`copyField_${this.props.copySequenceId}`}
             type="text"
             value={value}
             className={`integr8ly-copy-input ${expanded && 'expanded'}`}

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -49,7 +49,11 @@ class TaskPage extends React.Component {
       let sequenceNumber = 1;
       codeBlocks.forEach(block => {
         ReactDOM.render(
-          <CopyField copySequenceId={sequenceNumber} value={block.innerText} multiline={block.clientHeight > 40} />,
+          <CopyField
+            copySequenceId={sequenceNumber.toString()}
+            value={block.innerText}
+            multiline={block.clientHeight > 40}
+          />,
           block.parentNode
         );
         sequenceNumber++;
@@ -365,7 +369,6 @@ class TaskPage extends React.Component {
     } = this.props;
     const attrs = this.getDocsAttributes(id);
     const { t, thread, manifest } = this.props;
-
     if (thread.error || manifest.error) {
       return (
         <div>
@@ -434,6 +437,8 @@ class TaskPage extends React.Component {
                   <WalkthroughResources resources={combinedResources} />
                 </GridItem>
               </Grid>
+              {/* The div below is needed for automated testing with Nightwatch.js */}
+              <div id="pushIntoView" />
             </PageSection>
             <PageSection>
               {/* Bottom footer */}
@@ -521,7 +526,7 @@ class TaskPage extends React.Component {
                     )}
                     {taskNum + 1 === totalTasks && (
                       <Button
-                        id="exitButton"
+                        id="nextPartWalkthrough"
                         variant={taskVerificationComplete ? 'primary' : 'secondary'}
                         type="button"
                         onClick={e => this.exitTutorial(e)}


### PR DESCRIPTION
… regarding IDs

## Motivation
INTLY-1661

## What
Addition of an empty div to be used as a target for nightwatch.  This will bring the last verification box on each page into clickable view.  Also some minor corrections for IDs which were causing console errors.

## Why
To enable automated browser testing for walkthroughs on integreatly tutorial-web-app.

## Verification Steps

1. Clone this fork
2. CD into tutorial-web-app
3. yarn install
4. yarn start:dev
5. On each page of the walkthrough there should be a div below the Grid element with id="pushIntoView"
6. On the last page of each walkthrough the 'Next' button should have an id="nextPartWalkthrough"
7. All copyfields for all walkthroughs should have a custom property 'copyfieldid=*'
8. There should be no console errors relating to IDs.


## Checklist:

- [x ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

