### PR TITLE
fix(cards): Update card features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/tutorialCard/tutorialCard.js
+++ b/src/components/tutorialCard/tutorialCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ProgressBar, noop } from 'patternfly-react';
-import { Button, Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
+import { Button, Card, CardHeader, CardFooter } from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
@@ -21,7 +21,7 @@ const TutorialCard = props => (
     <CardHeader>
       <h4 className="pf-c-title pf-m-lg">{props.title}</h4>
     </CardHeader>
-    <CardBody>{props.children}</CardBody>
+    <div className="integr8ly-c-card__body">{props.children}</div>
     <CardFooter>
       <div className="integr8ly-c-card__info pf-u-w-100">
         <Button

--- a/src/styles/application/components/_cards.scss
+++ b/src/styles/application/components/_cards.scss
@@ -3,6 +3,13 @@
     cursor: pointer;
   }
 
+  &__body {
+    flex: 1 1 auto;
+    padding-right: var(--pf-global--spacer--lg);
+    padding-bottom: var(--pf-global--spacer--lg);
+    padding-left: var(--pf-global--spacer--lg);
+  }
+
   &__info {
     display: contents;
   }


### PR DESCRIPTION
## Motivation
This PR fixes INTLY-2240.

## What
Update the dashboard cards to remove the `<CardBody>` element from the `<Card>` component. Replace with a custom class that mimics the flex layout and padding, but does not resize the text from 16px to 14px.

## Why
Usability test results.

## How
Remove `<CardBody>` from the `<Card>` component and replace with a custom element.

## Checklist:

- [X] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

**OLD**
<img width="901" alt="Screen Shot 2019-06-17 at 10 34 08 AM" src="https://user-images.githubusercontent.com/4032718/59615996-956d5800-90f1-11e9-9226-dc15601c9d50.png">

**NEW**
<img width="876" alt="Screen Shot 2019-06-17 at 10 34 31 AM" src="https://user-images.githubusercontent.com/4032718/59616026-a61dce00-90f1-11e9-8fb4-e7cdefa489a7.png">
