### PR TITLE
fix(provisioning): remove duplicate status identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/provisioning/provisioningScreen.js
+++ b/src/components/provisioning/provisioningScreen.js
@@ -58,19 +58,6 @@ class ProvisioningScreen extends React.Component {
     return null;
   }
 
-  static renderServiceLoadingText(svc) {
-    if (isServiceProvisioned(svc)) {
-      return <div className="list-group-item-heading">Ready to use</div>;
-    }
-    if (isServiceProvisioning(svc)) {
-      return <div className="list-group-item-heading">Provisioning</div>;
-    }
-    if (isServiceProvisionFailed(svc)) {
-      return <div className="list-group-item-heading integr8ly-status-error">Error</div>;
-    }
-    return null;
-  }
-
   static renderServiceLoadingBar(svc) {
     if (isServiceProvisioned(svc)) {
       return (
@@ -115,10 +102,7 @@ class ProvisioningScreen extends React.Component {
                 {ProvisioningScreen.renderServiceLoadingIcon(svc)}
               </DataListCell>,
               <DataListCell key="secondary content" className="pf-u-py-md">
-                {ProvisioningScreen.renderServiceLoadingText(svc)}
-                <div className={` ${isProvisionFailed ? 'integr8ly-status-error' : null}`}>
-                  {getProductDetails(svc).prettyName}
-                </div>
+                {getProductDetails(svc).prettyName}
               </DataListCell>,
               <DataListCell key="tertiary content" className="pf-u-py-md">
                 {ProvisioningScreen.renderServiceLoadingBar(svc)}


### PR DESCRIPTION
## Motivation
Remove duplicate status identifiers (Ready to use, Provisioning, Error, etc). from the datalist. Per the design, it should only appear on the left of the datalist, next to the  status icon.

fixes https://issues.jboss.org/browse/INTLY-1289

## What
Remove duplicate status identifiers (Ready to use, Provisioning, Error, etc). from the datalist. Per the design, it should only appear on the left of the datalist, next to the  status icon.

## Why
Match design

## How
Remove the reference to the provisioning check

## Verification Steps

1. Start the webapp
2. Look at the text on the provisioning screen

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task