### PR TITLE
Ensure thread success action is dispatched si's are undefined

### DIFF
--- a/src/services/walkthroughServices.js
+++ b/src/services/walkthroughServices.js
@@ -83,6 +83,7 @@ const prepareCustomWalkthroughNamespace = (dispatch, walkthoughName, attrs = {})
           .then(additionalAttrs => {
             const mergedAttrs = Object.assign({}, attrs, ...additionalAttrs);
             if (!manifest || !manifest.dependencies || !manifest.dependencies.serviceInstances) {
+              dispatch(initCustomThreadSuccess(manifest));
               return Promise.resolve([]);
             }
             const siObjs = manifest.dependencies.serviceInstances.map(siPartial => {


### PR DESCRIPTION
Currently, if depenendencies.serviceInstances is undefined in a walkthroughs
walkthrough.json file then a thread init success action will not be
dispatched. This results in the loading screen on the walkthrough never
becoming hidden.

This change ensures this action is dispatched, even when the serviceInstances
value is undefined.

Verification:
- From master, ensure WALKTHROUGH_LOCATIONS=https://github.com/evanshortiss/tutorial-web-app-walkthroughs#INTLY-2308
- Try to open walkthrough 3, confirm the loading screen is never hidden
- From this commit, ensure WALKTHROUGH_LOCATIONS=https://github.com/evanshortiss/tutorial-web-app-walkthroughs#INTLY-2308
- Try to open walkthrough 3, confirm the loading screen becomes hidden

