### PR TITLE
fix: query string for walkthrough folders  in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -198,7 +198,7 @@ WALKTHROUGH_LOCATIONS="https://github.com/user/repo?walkthroughsFolder=/custom/l
 You can specify multiple walkthrough folders in same repo if you want:
 
 ----
-WALKTHROUGH_LOCATIONS="https://github.com/user/repo?walkthroughsFolder=/custom/location?walkthroughsFolder=/another/custom/location#branch-or-tag"
+WALKTHROUGH_LOCATIONS="https://github.com/user/repo?walkthroughsFolder=/custom/location&walkthroughsFolder=/another/custom/location#branch-or-tag"
 ----
 ====
 


### PR DESCRIPTION
## Motivation
The current querystring has a second `?` instead of an `&`

## What
Changed the second `?` to `&`

## Why
Prevents confusion/frustration for users that need to use multiple walkthroughs from a single repo and copy/paste without spotting the mistake.

## How
N/A

## Verification Steps
N/A