### PR TITLE
INTLY-1918: Add Help menu and commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -6,12 +6,13 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
+  DropdownSeparator,
   PageHeader,
   Toolbar,
   ToolbarGroup,
   ToolbarItem
 } from '@patternfly/react-core';
-import { CogIcon } from '@patternfly/react-icons';
+import { CogIcon, HelpIcon } from '@patternfly/react-icons';
 import accessibleStyles from '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
 import { css } from '@patternfly/react-styles';
 import { noop } from 'patternfly-react';
@@ -105,6 +106,12 @@ class Masthead extends React.Component {
       onClick: () => this.onTitleClick()
     };
 
+    const gsUrl =
+      'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/getting_started/';
+    const riUrl =
+      'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/release_notes/';
+    const csUrl = 'https://access.redhat.com/support/';
+
     const MastheadToolbar = (
       <React.Fragment>
         <Toolbar>
@@ -126,27 +133,21 @@ class Masthead extends React.Component {
                 onSelect={this.onHelpDropdownSelect}
                 isOpen={isHelpDropdownOpen}
                 toggle={
-                  <DropdownToggle onToggle={this.onHelpDropdownToggle}>
-                    <i className="fas fa-question-circle" aria-hidden="true" />
+                  <DropdownToggle iconComponent={null} onToggle={this.onHelpDropdownToggle}>
+                    <HelpIcon />
                   </DropdownToggle>
                 }
                 dropdownItems={[
-                  <DropdownItem
-                    key="help-cmd-1"
-                    component="button"
-                    href="#helpcmd1"
-                    onClick={() => console.log('Help menu command 1 clicked!')}
-                  >
-                    Help Command 1
+                  <DropdownItem key="help-getting-started" href={gsUrl} target="_blank">
+                    Getting started
                   </DropdownItem>,
-                  <DropdownItem
-                    key="help-cmd-2"
-                    component="button"
-                    href="#helpcmd2"
-                    onClick={() => console.log('Help menu command 2 clicked!')}
-                  >
-                    Help Command 2
+                  <DropdownItem key="help-release-info" href={riUrl} target="_blank">
+                    Release information
                   </DropdownItem>,
+                  <DropdownItem key="help-customer-support" href={csUrl} target="_blank">
+                    Customer support
+                  </DropdownItem>,
+                  <DropdownSeparator key="help-separator" />,
                   <DropdownItem key="about" component="button" href="#about" onClick={this.onAboutModal}>
                     About
                   </DropdownItem>

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -26,6 +26,7 @@ class Masthead extends React.Component {
     super(props);
 
     this.state = {
+      isHelpDropdownOpen: false,
       isUserDropdownOpen: false,
       showAboutModal: false
     };
@@ -35,6 +36,9 @@ class Masthead extends React.Component {
 
     this.onUserDropdownToggle = this.onUserDropdownToggle.bind(this);
     this.onUserDropdownSelect = this.onUserDropdownSelect.bind(this);
+
+    this.onHelpDropdownToggle = this.onHelpDropdownToggle.bind(this);
+    this.onHelpDropdownSelect = this.onHelpDropdownSelect.bind(this);
 
     this.onAboutModal = this.onAboutModal.bind(this);
     this.closeAboutModal = this.closeAboutModal.bind(this);
@@ -82,8 +86,20 @@ class Masthead extends React.Component {
     history.push(`/settings`);
   };
 
+  onHelpDropdownToggle(isHelpDropdownOpen) {
+    this.setState({
+      isHelpDropdownOpen
+    });
+  }
+
+  onHelpDropdownSelect = () => {
+    this.setState({
+      isHelpDropdownOpen: !this.state.isHelpDropdownOpen
+    });
+  };
+
   render() {
-    const { isUserDropdownOpen, showAboutModal } = this.state;
+    const { isUserDropdownOpen, isHelpDropdownOpen, showAboutModal } = this.state;
 
     const logoProps = {
       onClick: () => this.onTitleClick()
@@ -103,6 +119,47 @@ class Masthead extends React.Component {
                 <CogIcon />
               </Button>
             </ToolbarItem>
+            <ToolbarItem className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnMd)}>
+              <Dropdown
+                isPlain
+                position="right"
+                onSelect={this.onHelpDropdownSelect}
+                isOpen={isHelpDropdownOpen}
+                toggle={
+                  <DropdownToggle onToggle={this.onHelpDropdownToggle}>
+                    <Button
+                      className="pf-c-button pf-m-plain"
+                      aria-label="Help"
+                      variant="plain"
+                      onClick={this.onSettingsClick}
+                    >
+                      <i className="fas fa-question-circle" aria-hidden="true" />
+                    </Button>
+                  </DropdownToggle>
+                }
+                dropdownItems={[
+                  <DropdownItem
+                    key="help-cmd-1"
+                    component="button"
+                    href="#helpcmd1"
+                    onClick={() => console.log('Help menu command 1 clicked!')}
+                  >
+                    Help Command 1
+                  </DropdownItem>,
+                  <DropdownItem
+                    key="help-cmd-2"
+                    component="button"
+                    href="#helpcmd2"
+                    onClick={() => console.log('Help menu command 2 clicked!')}
+                  >
+                    Help Command 2
+                  </DropdownItem>,
+                  <DropdownItem key="about" component="button" href="#about" onClick={this.onAboutModal}>
+                    About
+                  </DropdownItem>
+                ]}
+              />
+            </ToolbarItem>
           </ToolbarGroup>
           <ToolbarGroup className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnSm)}>
             <ToolbarItem className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnSm)}>
@@ -119,9 +176,6 @@ class Masthead extends React.Component {
                 dropdownItems={[
                   <DropdownItem key="logout" component="button" href="#logout" onClick={this.onLogoutUser}>
                     Log out
-                  </DropdownItem>,
-                  <DropdownItem key="about" component="button" href="#about" onClick={this.onAboutModal}>
-                    About
                   </DropdownItem>
                 ]}
               />

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -127,14 +127,7 @@ class Masthead extends React.Component {
                 isOpen={isHelpDropdownOpen}
                 toggle={
                   <DropdownToggle onToggle={this.onHelpDropdownToggle}>
-                    <Button
-                      className="pf-c-button pf-m-plain"
-                      aria-label="Help"
-                      variant="plain"
-                      onClick={this.onSettingsClick}
-                    >
-                      <i className="fas fa-question-circle" aria-hidden="true" />
-                    </Button>
+                    <i className="fas fa-question-circle" aria-hidden="true" />
                   </DropdownToggle>
                 }
                 dropdownItems={[


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1918

## What
Added new help menu to the Solution Explorer toolbar, added 3 new drop-down menu commands (Getting started, Release information, and Customer support) which link to URLs, and moved the About command from the user menu to the new help menu.

## Why
Compliance with other Red Hat product UIs.

## Verification Steps
1. Go to the Solution Explorer home page.
2. Verify that there is a help icon in the toolbar to the right of the Settings cog icon.
3. Verify that 4 commands are present in drop-down when the help menu is clicked:
        Getting started
        Release information
        Customer support
        About
4. Verify that there is a separator between the Customer support and About commands.
5. Verify that each of the three help command links navigate to the appropriate web URL.
6. Verify that the About command opens the About modal.
7. Verify that the user menu no longer has an About menu command (should just be a Log out command).

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**Screencap of new masthead:**
![help-masthead](https://user-images.githubusercontent.com/39063664/60912561-9eb29600-a253-11e9-857b-72fd124d8393.png)

**Screencap of expanded help menu:**
![help-expanded](https://user-images.githubusercontent.com/39063664/60912587-b12ccf80-a253-11e9-8b04-a584233bd120.png)

You can use my server to verify, if you wish:
https://tutorial-web-app-webapp.apps.uxddev-d503.openshiftworkshop.com/

Or install a docker image of these changes on your own server:
docker.io/mfrances17/dev-tutorial-web-app:latest




