### PR TITLE
fix(progress): convert progress bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/tutorialCard/tutorialCard.js
+++ b/src/components/tutorialCard/tutorialCard.js
@@ -1,6 +1,14 @@
 import React from 'react';
-import { ProgressBar, noop } from 'patternfly-react';
-import { Button, Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
+import { noop } from 'patternfly-react';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Progress,
+  ProgressMeasureLocation
+} from '@patternfly/react-core';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
@@ -45,8 +53,13 @@ const TutorialCard = props => (
           </div>
         ) : (
           <div className="progress-bar-table">
-            <ProgressBar now={props.progress} />
-            <span className="progress-label pf-u-ml-sm">{`${props.progress}%`} </span>
+            <Progress
+              value={props.progress}
+              measureLocation={ProgressMeasureLocation.outside}
+              min={0}
+              max={100}
+              size="lg"
+            />
           </div>
         )}
       </div>

--- a/src/styles/application/components/_cards.scss
+++ b/src/styles/application/components/_cards.scss
@@ -8,39 +8,8 @@
   }
 
   /* stylelint-disable selector-class-pattern */
-  .pf-c-card__footer {
-    .progress {
-      width: 70%;
-      margin-top: -2px;
-      margin-bottom: 0;
-      vertical-align: middle;
-      background-color: rgba(0, 102, 204, .2);
-
-      .progress-bar {
-        background-color: var(--pf-global--primary-color--100);
-      }
-
-      .progress-bar[aria-valuenow="100"] {
-        background-color: var(--pf-global--success-color--100);
-      }
-    }
-
-    .progress-label-completed {
-      color: var(--pf-global--success-color--100);
-    }
-
-    .progress-bar-table {
-      display: flex;
-      align-items: center;
-
-      .progress {
-        margin-bottom: 0;
-      }
-
-      .progress-label {
-        text-align: right;
-      }
-    }
+  .pf-c-progress__bar[aria-valuenow="100"] .pf-c-progress__indicator {
+    background-color: var(--pf-global--success-color--100);
   }
   /* stylelint-enable */
 }


### PR DESCRIPTION
## Motivation
Convert the progress bar component from PF3 to PF4.

## What
Convert the progress bar component from PF3 to PF4.

## Why
Remove another PatternFly 3 component in order to remove the PatternFly 3 dependency.

## How
Replace Progress Bar component.

## Verification Steps

1. Run `yarn install` to get the latest packages.
2. Start the webapp
3. Check that the Cards still display the clock icon and time in the footer.
4. Start a Walkthrough and return to Dashboard - you should see a blue progress bar with the percentage listed.
5. Start and complete a Walkthrough - you should now see a completed green progress bar with the percentage listed.

## Checklist:

- [X] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

![Screen Shot 2019-07-16 at 10 07 44 AM](https://user-images.githubusercontent.com/4032718/61301273-99a09a00-a7b1-11e9-8aa8-0c4b94522dde.png)

