### PR TITLE
fix(dropdown): fix autofocus on dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "proxy": "http://localhost:5001/",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.7.2",
-    "@patternfly/react-core": "3.58.1",
+    "@patternfly/react-core": "3.73.0",
     "@patternfly/patternfly": "2.17.3",
     "asciidoctor.js": "1.5.7",
     "axios": "0.18.0",

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -137,6 +137,7 @@ class Masthead extends React.Component {
                     <HelpIcon />
                   </DropdownToggle>
                 }
+                autoFocus={false}
                 dropdownItems={[
                   <DropdownItem key="help-getting-started" href={gsUrl} target="_blank">
                     Getting started
@@ -167,6 +168,7 @@ class Masthead extends React.Component {
                     {window.localStorage.getItem('currentUserName')}
                   </DropdownToggle>
                 }
+                autoFocus={false}
                 dropdownItems={[
                   <DropdownItem key="logout" component="button" href="#logout" onClick={this.onLogoutUser}>
                     Log out

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -32,35 +32,12 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
       className="integr8ly-landing-page-tutorial-dashboard-section"
     >
       <Grid
-        className=""
         gutter="md"
-        lg={null}
-        md={null}
-        sm={null}
-        span={null}
-        xl={null}
-        xl2={null}
       >
         <GridItem
           className="integr8ly-task-container"
-          lg={null}
-          lgOffset={null}
-          lgRowSpan={null}
           md={9}
-          mdOffset={null}
-          mdRowSpan={null}
-          offset={null}
-          rowSpan={null}
           sm={12}
-          smOffset={null}
-          smRowSpan={null}
-          span={null}
-          xl={null}
-          xl2={null}
-          xl2Offset={null}
-          xl2RowSpan={null}
-          xlOffset={null}
-          xlRowSpan={null}
         >
           <Card
             className="integr8ly-c-card--content pf-u-p-lg pf-u-mb-xl"
@@ -137,24 +114,8 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
         </GridItem>
         <GridItem
           className="integr8ly-module-frame pf-u-display-none pf-u-display-block-on-md"
-          lg={null}
-          lgOffset={null}
-          lgRowSpan={null}
           md={3}
-          mdOffset={null}
-          mdRowSpan={null}
-          offset={null}
           rowSpan={2}
-          sm={null}
-          smOffset={null}
-          smRowSpan={null}
-          span={null}
-          xl={null}
-          xl2={null}
-          xl2Offset={null}
-          xl2RowSpan={null}
-          xlOffset={null}
-          xlRowSpan={null}
         >
           <Connect(WalkthroughDetails)
             className="integr8ly-landing-page-tutorial-dashboard-section-right"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,30 +1018,30 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.17.3.tgz#ee8de7081f3cc4cbcb1a54de41204e53f3f5ac54"
   integrity sha512-AN5onFap7jduhOUi/Qe/i+b7d8bsIHFU4Miss3gt16NNCWx5vyhS9jqlg/0eR41NHtebVm1RIAar/z319Mmjhw==
 
-"@patternfly/react-core@3.58.1":
-  version "3.58.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.58.1.tgz#3b9ea3a8cabe8c49f1df7f4b5e8ea16938f7a3f1"
-  integrity sha512-ahb7cbWsLWZu69sHnn3ZdB5tcpXAbgHcUbAttWuG01KVpleK50qkwZMWW0JzuDlUfnelpW3kbaVfNE14HZo+Eg==
+"@patternfly/react-core@3.73.0":
+  version "3.73.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.73.0.tgz#7991d8a0dab250517d6b38e96c54ba932d3f5b60"
+  integrity sha512-bLjy2O7aEbHpJCinDmp3qw+3pg63AWertZg2bbGH4M7cMJx4Ewbh1To8gROlmfHXiy6aVEuJ0jee4vI4VWiHOQ==
   dependencies:
-    "@patternfly/react-icons" "^3.10.6"
-    "@patternfly/react-styles" "^3.4.6"
-    "@patternfly/react-tokens" "^2.6.5"
+    "@patternfly/react-icons" "^3.10.12"
+    "@patternfly/react-styles" "^3.5.5"
+    "@patternfly/react-tokens" "^2.6.11"
     "@tippy.js/react" "^1.1.1"
     emotion "^9.2.9"
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
 
-"@patternfly/react-icons@^3.10.6":
-  version "3.10.10"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.10.10.tgz#a16451896ed720967c85dd7c236fa8d6a044e28e"
-  integrity sha512-UbTJxGtaaruFG0QhdJi3QlTzRWjK/dBbg35gdGe5EReUVHM4X1hJ1cOID/6ntEna45yCpeb43fpLRUYY5daMiw==
+"@patternfly/react-icons@^3.10.12":
+  version "3.10.12"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.10.12.tgz#76b5805face55c0a7b63f3e7ae51b509ed967746"
+  integrity sha512-ZuAUzHOV8y4d31YuOKh4SzNg9o6vBECxoEdFuVWO3LxkNCUAg+XN7IBe7SG7FDQ/Cn/DErpB/QDxlx8jZE86Ww==
   dependencies:
     "@fortawesome/free-brands-svg-icons" "^5.8.1"
 
-"@patternfly/react-styles@^3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.4.6.tgz#03c645adfa3f6b8b7113232e90326547a39c6322"
-  integrity sha512-m9ynr85EMmBAxGhCguwRiGgpLDA9+YKtwF83ORK7ylHHsrK9JC/RFPvTj8d/80oUMmlzcL765ZwG7sT9qR3ybA==
+"@patternfly/react-styles@^3.5.5":
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.5.5.tgz#a1bf02584a08ad24a61dc3626d0361e1b285d8e6"
+  integrity sha512-9PpHkl2mNiDwu0cl3JMx0qqaQjJvY/DZST5lnE+zU0KHNgXTHOlF+RNWyC7ebid/Ti5BIsOVsS3U8sB/bR4b7g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -1057,10 +1057,10 @@
     resolve-from "^4.0.0"
     typescript "3.4.5"
 
-"@patternfly/react-tokens@^2.6.5":
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.5.tgz#94907bbf1182855ceb69a44a0e351f7775842f19"
-  integrity sha512-HZ0LLAOugMmnD9n5T5Hp6vDnZ86ikm+MXu7kbfNqK9dTOVmEroPai0rUN6hnnPP4mCzFrLXmh4rzecDr2273yg==
+"@patternfly/react-tokens@^2.6.11":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.11.tgz#e73bcb160e583f4c012b515dc65e8b6fe7e8a0a9"
+  integrity sha512-8pkMIYtgM4tijoch/4FA0zbuwVBT0vbeLiMkrYZfBuJs5bBfdiGcBrFKNWjx2fn/vugNLBMp0GGz2rI5BIV6+Q==
 
 "@svgr/core@^2.4.1":
   version "2.4.1"


### PR DESCRIPTION
## Motivation
With the last PatternFly Core update (5d988eedd5678654416f4550ddaffbdf8d8f92ad), `autoFocus` was automatically applied to all dropdown menus for accessibility purposes. This causes issues visually, and created an awkward experience with our dropdown menus.

## What
Remove `autoFocus` from the dropdown menus.

## Why
`autoFocus` was automatically applied by the default dropdown properties provided by PatternFly React.

## How
Update dependency to a minimum of `3.67.1` (actually updated to `3.73.0`) and add `autoFocus={false}` to the `<Dropdown>` Prop.

## Verification Steps

1. Run `yarn install && yarn build && yarn start:dev`
2. Click on the Help dropdown and verify that no menu item is automatically highlighted/focused on.
3. Click on the User dropdown and verify that no menu item is automatically highlighted/focused on.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task