### PR TITLE
Intly 2588

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -606,7 +606,8 @@ function getConfigData(req) {
       process.env.SSO_ROUTE
     }/auth/realms/openshift/protocol/openid-connect/logout?redirect_uri=${logoutRedirectUri}',
     threescaleWildcardDomain: '${process.env.THREESCALE_WILDCARD_DOMAIN || ''}',
-    integreatlyVersion: '${process.env.INTEGREATLY_VERSION || ''}'
+    integreatlyVersion: '${process.env.INTEGREATLY_VERSION || ''}',
+    clusterType: '${process.env.CLUSTER_TYPE || ''}'
   };`;
 }
 


### PR DESCRIPTION
Make `clusterType` (RHPDS, ODS...) available to the webapp. This needs an operator and installer change to actually set the value.

Verification steps in https://github.com/integr8ly/installation/pull/766