### PR TITLE
feat: Add mdc url helper

### DIFF
--- a/server.js
+++ b/server.js
@@ -620,8 +620,28 @@ function getConfigData(req) {
     }/auth/realms/openshift/protocol/openid-connect/logout?redirect_uri=${logoutRedirectUri}',
     threescaleWildcardDomain: '${process.env.THREESCALE_WILDCARD_DOMAIN || ''}',
     integreatlyVersion: '${process.env.INTEGREATLY_VERSION || ''}',
-    clusterType: '${process.env.CLUSTER_TYPE || ''}'
+    clusterType: '${process.env.CLUSTER_TYPE || ''}',
+    optionalWatchServices: ${arrayFromString(process.env.OPTIONAL_WATCH_SERVICES, ',')},
+    optionalProvisionServices: ${arrayFromString(process.env.OPTIONAL_PROVISION_SERVICES, ',')}
   };`;
+}
+
+function arrayFromString(data, sep) {
+  if (!data) {
+    return '[]';
+  }
+
+  let parts = ['['];
+  data.split(sep).forEach(function(v, idx, arr) {
+    if (idx === arr.length -1) {
+        parts.push(`"${v}"`);    
+    } else {
+        parts.push(`"${v}",`);
+    }
+  });
+  parts.push(']');
+
+  return parts.join('');
 }
 
 function getWalkthroughInfoFromAdoc(parentId, id, dirName, doc) {

--- a/server.js
+++ b/server.js
@@ -621,28 +621,12 @@ function getConfigData(req) {
     threescaleWildcardDomain: '${process.env.THREESCALE_WILDCARD_DOMAIN || ''}',
     integreatlyVersion: '${process.env.INTEGREATLY_VERSION || ''}',
     clusterType: '${process.env.CLUSTER_TYPE || ''}',
-    optionalWatchServices: ${arrayFromString(process.env.OPTIONAL_WATCH_SERVICES, ',')},
-    optionalProvisionServices: ${arrayFromString(process.env.OPTIONAL_PROVISION_SERVICES, ',')}
+    optionalWatchServices: ${JSON.stringify(arrayFromString(process.env.OPTIONAL_WATCH_SERVICES || '', ','))},
+    optionalProvisionServices: ${JSON.stringify(arrayFromString(process.env.OPTIONAL_PROVISION_SERVICES || '', ','))}
   };`;
 }
 
-function arrayFromString(data, sep) {
-  if (!data) {
-    return '[]';
-  }
-
-  let parts = ['['];
-  data.split(sep).forEach(function(v, idx, arr) {
-    if (idx === arr.length -1) {
-        parts.push(`"${v}"`);    
-    } else {
-        parts.push(`"${v}",`);
-    }
-  });
-  parts.push(']');
-
-  return parts.join('');
-}
+const arrayFromString = (data, sep) => data.split(sep).filter(item => item !== '');
 
 function getWalkthroughInfoFromAdoc(parentId, id, dirName, doc) {
   // Retrieve the short description. There must be a gap between the document title and the short description.

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -67,7 +67,8 @@ const getMiddlewareServiceAttrs = middlewareServices => {
     'amq-broker-amqp-url': middlewareServices.amqCredentials.url,
     'amq-credentials-username': middlewareServices.amqCredentials.username,
     'amq-credentials-password': middlewareServices.amqCredentials.password,
-    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO)
+    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO),
+    'mdc-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.MDC)
   };
 };
 

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -51,7 +51,7 @@ const getMiddlewareServiceAttrs = middlewareServices => {
     threescaleUrl = getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.THREESCALE);
   }
 
-  return {
+  const output = {
     'openshift-app-host': threescaleUrl ? threescaleUrl.replace('https://3scale-admin.', '') : threescaleUrl,
     'fuse-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.FUSE),
     'launcher-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.LAUNCHER),
@@ -67,9 +67,16 @@ const getMiddlewareServiceAttrs = middlewareServices => {
     'amq-broker-amqp-url': middlewareServices.amqCredentials.url,
     'amq-credentials-username': middlewareServices.amqCredentials.username,
     'amq-credentials-password': middlewareServices.amqCredentials.password,
-    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO),
-    'mdc-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.MDC)
+    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO)
   };
+
+  if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.optionalProvisionServices.length > 0) {
+    window.OPENSHIFT_CONFIG.optionalProvisionServices.forEach(v => {
+      output[`${v}-url`] = getUrlFromMiddlewareServices(middlewareServices, v);
+    });
+  }
+
+  return output;
 };
 
 const getUrlFromMiddlewareServices = (middlewareServices, serviceName) => {

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -31,6 +31,10 @@ export default {
     prettyName: 'Apicurito',
     gaStatus: 'GA'
   },
+  mdc: {
+    prettyName: 'Mobile Developer Console',
+    gaStatus: 'LA'
+  },
   rhsso: {
     prettyName: 'Red Hat Single Sign-On (Cluster)',
     gaStatus: 'GA'

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -26,7 +26,7 @@ import { SERVICE_TYPES } from '../redux/constants/middlewareConstants';
 import { watchAMQOnline } from './amqOnlineServices';
 
 // The default services to watch.
-const WATCH_SERVICES = [
+let defaultWatchServices = [
   DEFAULT_SERVICES.CHE,
   DEFAULT_SERVICES.LAUNCHER,
   DEFAULT_SERVICES.THREESCALE,
@@ -37,13 +37,17 @@ const WATCH_SERVICES = [
   DEFAULT_SERVICES.RHSSO,
   DEFAULT_SERVICES.USER_RHSSO
 ];
+if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.optionalWatchServices.length > 0) {
+  defaultWatchServices = defaultWatchServices.concat(window.OPENSHIFT_CONFIG.optionalWatchServices);
+}
+const WATCH_SERVICES = defaultWatchServices;
 
 // The default services to show in any user-facing manner, even if they aren't
 // available. This is the opposite of the "hidden" flag in product info.
 const DISPLAY_SERVICES = [DEFAULT_SERVICES.ENMASSE];
 
 // The default services to provision.
-const PROVISION_SERVICES = [
+let provisionServices = [
   DEFAULT_SERVICES.CHE,
   DEFAULT_SERVICES.LAUNCHER,
   DEFAULT_SERVICES.APICURIO,
@@ -52,6 +56,10 @@ const PROVISION_SERVICES = [
   DEFAULT_SERVICES.RHSSO,
   DEFAULT_SERVICES.USER_RHSSO
 ];
+if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.optionalProvisionServices.length > 0) {
+  provisionServices = provisionServices.concat(window.OPENSHIFT_CONFIG.optionalProvisionServices);
+}
+const PROVISION_SERVICES = provisionServices;
 
 /**
  * Lookup product details (name and GA status) and add them to the


### PR DESCRIPTION
So I have been trying to add MDC (mobile developer console) URL into the tutorial-web-app.

I see service available in config map

<img width="895" alt="Screenshot 2019-08-02 at 13 19 38" src="https://user-images.githubusercontent.com/981838/62369680-44da7e80-b528-11e9-8c99-5275f2546ade.png">

SO I have created new type in DEFAULT_SERVICES and added new helper `mdc-url`.
Looking to verify that now but positing for early feedback.


## Verification

* Build an image with this pr or use `docker.io/odranoel/webapp:dev`
* Change the webapp deployment config to use this image
* Set both env vars `OPTIONAL_WATCH_SERVICES` and `OPTIONAL_PROVISION_SERVICES` to "mdc" and wait for the pod to be ready