### PR TITLE
INTLY-2791: adding OPENSHIFT_OAUTH_HOST env var

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -174,7 +174,7 @@ This will start the Webapp in development mode and import your Walkthroughs. You
 
 [source,shell]
 ----
-OPENSHIFT_HOST=<openshift master url> WALKTHROUGH_LOCATIONS=<path/to/your/walkthrough/folder> yarn start:dev
+OPENSHIFT_HOST=<openshift master url> OPENSHIFT_OAUTH_HOST=<openshift oauth url> WALKTHROUGH_LOCATIONS=<path/to/your/walkthrough/folder> yarn start:dev
 ----
 
 After you've made changes to your walkthrough you can restart the webapp server by typing `rs` into the terminal where the Webapp process is running and hitting return. Refresh your browser and your changes should be reflected.

--- a/deployment/openshift-template.yml
+++ b/deployment/openshift-template.yml
@@ -12,6 +12,10 @@ parameters:
     description: The OpenShift master/api host e.g. openshift.example.com:8443. If blank, mock data (and mock service URL params) will be used.
     displayName: OpenShift Host
     required: false
+  - name: OPENSHIFT_OAUTH_HOST
+    description: The OpenShift OAuth host. OpenShift 4 example - https://oauth-openshift.apps.openshift.example.com. On OpenShift it's the same as OPENSHIFT_HOST. If blank, mock data (and mock service URL params) will be used.
+    displayName: OpenShift Host
+    required: false
   - name: WEBAPP_IMAGE
     value: quay.io/integreatly/tutorial-web-app
     required: true
@@ -67,6 +71,8 @@ objects:
             value: ${OPENSHIFT_OAUTHCLIENT_ID}
           - name: OPENSHIFT_HOST
             value: ${OPENSHIFT_HOST}
+          - name: OPENSHIFT_OAUTH_HOST
+            value: ${OPENSHIFT_OAUTH_HOST}
           - name: NODE_ENV
             value: production
           - name: SSO_ROUTE
@@ -78,9 +84,6 @@ objects:
           - containerPort: 5001
             name: http
             protocol: TCP
-      metadata:
-        labels:
-          app: tutorial-web-app
     triggers:
       - type: ConfigChange
 - apiVersion: v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -602,11 +602,15 @@ function getConfigData(req) {
   } else {
     logoutRedirectUri = 'http://localhost:3006';
   }
+  if (!process.env.OPENSHIFT_OAUTH_HOST) {
+    console.warn('OPENSHIFT_OAUTH_HOST not set, using OPENSHIFT_HOST instead. This is okay on OCP 3.11, but will not work on 4.x, see INTLY-2791.');
+    process.env.OPENSHIFT_OAUTH_HOST = process.env.OPENSHIFT_HOST;
+  }
 
   return `window.OPENSHIFT_CONFIG = {
     clientId: '${process.env.OPENSHIFT_OAUTHCLIENT_ID}',
-    accessTokenUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/token',
-    authorizationUri: 'https://${process.env.OPENSHIFT_HOST}/oauth/authorize',
+    accessTokenUri: 'https://${process.env.OPENSHIFT_OAUTH_HOST}/oauth/token',
+    authorizationUri: 'https://${process.env.OPENSHIFT_OAUTH_HOST}/oauth/authorize',
     redirectUri: '${redirectHost}/oauth/callback',
     scopes: ['user:full'],
     masterUri: 'https://${process.env.OPENSHIFT_HOST}',


### PR DESCRIPTION
## Motivation
JIRA: https://issues.jboss.org/browse/INTLY-2791
Main motivation is OpenShift 4 support

## What
New env var is added to set OpenShift auth URL.

## Why
In OpenShift 4 the url is different than master/console url.

## How
New env var has been added. When it's not set, webapp will fallback to master url - this should enable backwards compatibility.

## Verification Steps
Test backwards compatibility:

1. Get Integreatly cluster on Openshift 3.11
2. Swap image tag of tutorial-web-app deployment config for `2.15.0`
3. Once new pod is running, open it's logs
4. Open tutorial web app route in private window
5. You should be redirected to login screen, once you log in, you should see a screen that shows service provisioning progress
6. In the logs you should observe this line: `OPENSHIFT_OAUTH_HOST not set, using OPENSHIFT_HOST instead. This is okay on OCP 3.11, but will not work on 4.x, see INTLY-2791.`

Verification steps on Openshift 4 will be described in a PR for the operator.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Additional Notes
Full E2E verification is currently blocked by inability to set additional CORS domain in OpenShift 4.1. This PR will be updated once we have more info on this issue.
