### PR TITLE
fix(alerts): update alert styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.7.2",
-    "@patternfly/patternfly": "2.20.2",
     "@patternfly/react-core": "3.73.0",
+    "@patternfly/patternfly": "2.26.0",
     "asciidoctor.js": "1.5.7",
     "axios": "0.18.0",
     "body-parser": "^1.18.3",

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -285,55 +285,65 @@ class TaskPage extends React.Component {
     const isNoChecked = currentThreadProgress[blockId] !== undefined && !currentThreadProgress[blockId];
     const isYesChecked = currentThreadProgress[blockId] !== undefined && !!currentThreadProgress[blockId];
 
-    let verificationClasses = 'alert integr8ly-alert pf-u-mt-md integr8ly-module-column--steps_alert-blue';
-    let verificationIcon = 'integr8ly-alert-icon far fa-circle fa-lg';
+    let verificationClasses = 'pf-c-alert pf-m-info pf-m-inline pf-u-mt-md integr8ly-m-alert';
+    let verificationLabel = 'Alert';
+    let verificationIcon = 'fa fa-circle-o';
     if (isYesChecked) {
-      verificationClasses = 'alert integr8ly-alert pf-u-mt-md integr8ly-module-column--steps_alert-green';
-      verificationIcon = 'integr8ly-alert-icon fa fa-check-circle fa-lg';
+      verificationClasses = 'pf-c-alert pf-m-success pf-m-inline pf-u-mt-md integr8ly-m-alert';
+      verificationIcon = 'fas fa-check-circle';
+      verificationLabel = 'Alert success';
     }
     if (isNoChecked) {
-      verificationClasses = 'alert integr8ly-alert pf-u-mt-md integr8ly-module-column--steps_alert-red';
-      verificationIcon = 'integr8ly-alert-icon fa fa-times-circle fa-lg';
+      verificationClasses = 'pf-c-alert pf-m-danger pf-m-inline pf-u-mt-md integr8ly-m-alert';
+      verificationIcon = 'fas fa-times-circle';
+      verificationLabel = 'Alert fail';
     }
     return (
-      <div className={verificationClasses} key={`verification-${blockId}`}>
-        <i className={verificationIcon} />
-        <strong>{t('task.verificationTitle')}</strong>
-        <span dangerouslySetInnerHTML={{ __html: block.html }} />
-        {
-          <React.Fragment>
-            <Form>
-              <FormGroup controlId="radio" disabled={false} bsSize="small" label="Check your work">
-                <Radio
-                  id={`${blockId}verificationYes`}
-                  name={`${blockId}Yes`}
-                  checked={isYesChecked}
-                  onChange={e => {
-                    this.handleVerificationInput(e, blockId, true);
-                  }}
-                  label="Yes"
-                >
-                  Yes
-                </Radio>
-                <Radio
-                  id={`${blockId}verificationNo`}
-                  name={`${blockId}No`}
-                  checked={isNoChecked}
-                  onChange={e => {
-                    this.handleVerificationInput(e, blockId, false);
-                  }}
-                  label="No"
-                >
-                  No
-                </Radio>
-                {isNoChecked &&
-                  block.hasFailBlock && <div dangerouslySetInnerHTML={{ __html: block.failBlock.html }} />}
-                {isYesChecked &&
-                  block.hasSuccessBlock && <div dangerouslySetInnerHTML={{ __html: block.successBlock.html }} />}
-              </FormGroup>
-            </Form>
-          </React.Fragment>
-        }
+      <div className={verificationClasses} key={`verification-${blockId}`} aria-label={verificationLabel}>
+        <div className="pf-c-alert__icon">
+          <i className={verificationIcon} aria-hidden="true" />
+        </div>
+        <h4 className="pf-c-alert__title">
+          <span className="pf-screen-reader">{t('task.verificationTitle')}</span>
+          {t('task.verificationTitle')}
+        </h4>
+        <div className="pf-c-alert__description">
+          <span dangerouslySetInnerHTML={{ __html: block.html }} />
+          {
+            <React.Fragment>
+              <Form>
+                <FormGroup controlId="radio" disabled={false} bsSize="small" label="Check your work">
+                  <Radio
+                    id={`${blockId}verificationYes`}
+                    name={`${blockId}Yes`}
+                    checked={isYesChecked}
+                    onChange={e => {
+                      this.handleVerificationInput(e, blockId, true);
+                    }}
+                    label="Yes"
+                  >
+                    Yes
+                  </Radio>
+                  <Radio
+                    id={`${blockId}verificationNo`}
+                    name={`${blockId}No`}
+                    checked={isNoChecked}
+                    onChange={e => {
+                      this.handleVerificationInput(e, blockId, false);
+                    }}
+                    label="No"
+                  >
+                    No
+                  </Radio>
+                  {isNoChecked &&
+                    block.hasFailBlock && <div dangerouslySetInnerHTML={{ __html: block.failBlock.html }} />}
+                  {isYesChecked &&
+                    block.hasSuccessBlock && <div dangerouslySetInnerHTML={{ __html: block.successBlock.html }} />}
+                </FormGroup>
+              </Form>
+            </React.Fragment>
+          }
+        </div>
       </div>
     );
   }

--- a/src/styles/application/pages/_taskLayout.scss
+++ b/src/styles/application/pages/_taskLayout.scss
@@ -29,36 +29,6 @@
       }
     }
 
-    &-column--steps_alert-blue {
-      background-color: $pf-color-blue-50;
-      border-color: $pf-color-blue-200;
-      color: $pf-color-black-1000;
-    }
-
-    &-column--steps_alert-blue i {
-      color: $pf-color-blue-400 !important; /* stylelint-disable-line declaration-no-important */
-    }
-
-    &-column--steps_alert-red {
-      background-color: lighten($pf-color-red-100, 55%);
-      border-color: var(--pf-global--danger-color--100);
-      color: $pf-color-black-1000;
-    }
-
-    &-column--steps_alert-red i {
-      color: var(--pf-global--danger-color--100) !important; /* stylelint-disable-line declaration-no-important */
-    }
-
-    &-column--steps_alert-green {
-      background-color: lighten($pf-color-green-100, 10%);
-      border-color: $pf-color-green-200;
-      color: $pf-color-black-1000;
-    }
-
-    &-column--steps_alert-green i {
-      color: $pf-color-green-400 !important; /* stylelint-disable-line declaration-no-important */
-    }
-
     &-column--footer {
       background-color: var(--pf-global--Color--light-100);
       border-top: var(--pf-global--BorderWidth--sm) solid;
@@ -79,7 +49,7 @@
 
       &_status {
         &.icon { /* stylelint-disable selector-class-pattern */
-          color: $pf-color-blue-400 !important; /* stylelint-disable-line declaration-no-important */
+          color: var(--pf-global--info-color--100) !important; /* stylelint-disable-line declaration-no-important */
         }
 
         .icon:first-child {
@@ -87,7 +57,7 @@
         }
 
         &-checked.icon {
-          color: $pf-color-green-400 !important; /* stylelint-disable-line declaration-no-important */
+          color: var(--pf-global--success-color--100) !important; /* stylelint-disable-line declaration-no-important */
         }
 
         &-unchecked.icon {
@@ -96,5 +66,16 @@
       }
       /* stylelint-enable */
     }
+  }
+}
+
+.integr8ly-m-alert {
+  .pf-c-alert__title { /* stylelint-disable selector-class-pattern */
+    margin-top: 0 !important; /* stylelint-disable-line declaration-no-important */
+    margin-bottom: 0 !important; /* stylelint-disable-line declaration-no-important */
+  }
+
+  .form-group {
+    margin-bottom: 0;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,9 +1005,10 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@patternfly/patternfly@2.20.2":
-  version "2.20.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.20.2.tgz#06c16f80a1a8f4f49e428595fb25eaef91290af4"
+"@patternfly/patternfly@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.26.0.tgz#2708a81cbf9acbdcb0999fd344d4198444382ae5"
+  integrity sha512-nK+AwcL+MAQlC2nOP5thdHlYZTq04XhV5/KR0ddYsJe+bxKK6F93I6yXfTd/AA5SWrqhlzjgPSa0i6jTNmGN0w==
 
 "@patternfly/react-core@3.73.0":
   version "3.73.0"


### PR DESCRIPTION
## Motivation
Updates Alerts to use PatternFly 4.

## What
Update the Alert component and styles to utilize the PatternFly 4 version.

## Why
In order to complete the move to PatternFly 4.

## How
Change out the classes and colors associated with the old Alert styles/component. Remove old CSS that is no longer needed.

## Verification Steps

1. Go to a Walkthrough
2. Verify that the 3 different options appear when interacting with "Check your work"
3. Verify that each status has a corresponding color
  a. nothing selected = blue
  b. Yes selected = green
  c. No selected = read
4. Colors and icons should match between the Alert dialogs and the footer.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes
![Screen Shot 2019-08-12 at 2 09 53 PM](https://user-images.githubusercontent.com/4032718/62887257-e624ba00-bd0a-11e9-8894-9a10b13763b4.png)
![Screen Shot 2019-08-12 at 2 09 42 PM](https://user-images.githubusercontent.com/4032718/62887268-e91faa80-bd0a-11e9-886e-3176376fc87d.png)
![Screen Shot 2019-08-12 at 2 09 19 PM](https://user-images.githubusercontent.com/4032718/62887272-eae96e00-bd0a-11e9-940c-d739fc34110f.png)
