### PR TITLE
ensure the openshift 4 walkthrough provisioning creates templates

### DIFF
--- a/src/common/openshiftResourceDefinitions.js
+++ b/src/common/openshiftResourceDefinitions.js
@@ -50,6 +50,12 @@ const templateDef = namespace => ({
   namespace,
   api: 'oapi'
 });
+const processedTemplateDefV4 = namespace => ({
+  name: 'processedtemplates',
+  namespace,
+  version: 'v1',
+  group: 'template.openshift.io'
+});
 const addressSpaceDef = namespace => ({
   name: 'addressspaces',
   namespace,
@@ -118,5 +124,6 @@ export {
   catalogSourceConfigDef,
   operatorGroupDef,
   subscriptionDef,
-  csvDef
+  csvDef,
+  processedTemplateDefV4
 };

--- a/src/services/fuseOnlineServices.js
+++ b/src/services/fuseOnlineServices.js
@@ -98,7 +98,7 @@ const provisionSyndesis = (username, namespace) => {
         }
       },
       integration: {
-        limit: -1
+        limit: 0
       }
     }
   };

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -237,7 +237,6 @@ const manageMiddlewareServices = (dispatch, user, config) => {
           watchListener.onEvent(handleAMQStatefulSetWatchEvents.bind(null, dispatch, userNamespace))
         );
       }
-      watchAMQOnline(dispatch, user.username, { name: userNamespace });
     });
 };
 


### PR DESCRIPTION
currently, when provisioning a walkthrough from openshift 4, any
template defined in the templates section of walkthrough.json will
be ignored.

this change ensures that the templates are created and that the
routes are watched as expected, making the functionality similar
to the openshift 3 environment.

openshift 3 verification:
- have an openshift 3 cluster with integreatly installed
- replace the webapp version with this branch
- ensure walkthrough 1a still works as expected

openshift 4 verification:
- have an openshift 4 cluster with integreatly installed
- provision this webapp version in a namespace
- for walkthrough locations, use the branch in https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/90
- ensure walkthrough 1a works as expected