### PR TITLE
fix(spacing): adjust spacing between titles and cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -125,7 +125,7 @@ const TutorialDashboard = props => {
         </div>
       );
       htmlSnippet.push(
-        <Gallery gutter="md" key={`gallery-${allRepos[i]}`}>
+        <Gallery gutter="md" key={`gallery-${allRepos[i]}`} className="pf-u-mt-sm pf-u-mb-md">
           {cards}
         </Gallery>
       );


### PR DESCRIPTION
## Motivation
Fix the spacing between the Title and Cards of each walkthrough grouping.

## What
Adjust x-axis and y-axis spacers.

## Why
Fix https://issues.jboss.org/browse/INTLY-2981

## How
Adjust x/y-axis

## Verification Steps

1. Start the webapp and view the dashboard
2. Add multiple walkthrough repos to see additional spacing

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

<img width="1920" alt="Screen Shot 2019-08-22 at 11 04 14 AM" src="https://user-images.githubusercontent.com/4032718/63527963-0fde9d80-c4d0-11e9-80fe-e7db5539e71a.png">
