### PR TITLE
INTLY-3044 apicurio product info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -28,7 +28,7 @@ export default {
     gaStatus: 'GA'
   },
   apicurio: {
-    prettyName: 'Apicurito',
+    prettyName: 'API Designer',
     gaStatus: 'GA'
   },
   mdc: {


### PR DESCRIPTION
currently, for the product apicurio, we are displaying the display
name as apicurito. this is now incorrect and we should instead be
using api manager.

this change replaces the display name for apicurio with api
designer.

verification:
- run yarn start:dev
- open the main page of the solution explorer
- ensure the apicurio service is now api designer
- if running against a cluster, ensure the link still works as
  expected