### PR TITLE
add preview label to mdc

### DIFF
--- a/server.js
+++ b/server.js
@@ -600,6 +600,15 @@ function getMockConfigData() {
             dashboardURL: '${process.env.OPENSHIFT_URL}',
             conditions: [{ status: 'True' }]
           }
+        },
+        {
+          spec: {
+            clusterServiceClassExternalName: 'mdc'
+          },
+          status: {
+            dashboardURL: '${process.env.OPENSHIFT_URL}',
+            conditions: [{ status: 'True' }]
+          }
         }
       ]
     }

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -33,7 +33,7 @@ export default {
   },
   mdc: {
     prettyName: 'Mobile Developer Console',
-    gaStatus: 'LA'
+    gaStatus: 'preview'
   },
   rhsso: {
     prettyName: 'Red Hat Single Sign-On (Cluster)',


### PR DESCRIPTION
Make sure that the preview label is displayed for MDC in the application list. Also add MDC to the mock config so that we can test it locally.

Verification steps:

1. Run the webapp locally or deploy this branch to a cluster
2. Ensure that the Mobile Developer Console is in the application list and is labelled `preview`