### PR TITLE
INTLY-3307: Revert PF4 clipboardCopy component to old custom component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.4",
+  "version": "2.18.5",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/asciiDocTemplate/asciiDocTemplate.js
+++ b/src/components/asciiDocTemplate/asciiDocTemplate.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Asciidoctor from 'asciidoctor.js';
 import { translate } from 'react-i18next';
-import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
+import CopyField from '../copyField/copyField';
 
 class AsciiDocTemplate extends React.Component {
   state = { loaded: false, docContent: null };
@@ -32,12 +32,7 @@ class AsciiDocTemplate extends React.Component {
     if (this.rootDiv.current) {
       const codeBlocks = this.rootDiv.current.querySelectorAll('pre');
       codeBlocks.forEach(block => {
-        ReactDOM.render(
-          <ClipboardCopy isReadOnly variant={block.clientHeight > 40 ? ClipboardCopyVariant.expansion : null}>
-            {block.innerText}
-          </ClipboardCopy>,
-          block.parentNode
-        );
+        ReactDOM.render(<CopyField value={block.innerText} multiline={block.clientHeight > 40} />, block.parentNode);
       });
     }
   }

--- a/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
+++ b/src/components/copyField/__tests__/__snapshots__/copyField.test.js.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CopyField Component should default expanded on multiline and collapse on blur: expanded 1`] = `null`;
+
+exports[`CopyField Component should render a multi-line copy component: multi-line 1`] = `
+<div
+  aria-live="polite"
+  class="integr8ly-copy form-group"
+>
+  <span
+    class="pf-u-display-flex input-group"
+  >
+    <span
+      class="input-group-btn"
+    >
+      <button
+        aria-hidden="true"
+        class="integr8ly-copy-display-button btn btn-default"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="fa fa-angle-down"
+        />
+      </button>
+    </span>
+    <input
+      class="integr8ly-copy-input expanded form-control"
+      copyfieldid="copyField_null"
+      id="test"
+      readonly=""
+      type="text"
+      value="{\\"hello\\":\\"world\\"}"
+    />
+    <span
+      class="input-group-btn"
+    >
+      <button
+        aria-label="Copy to Clipboard"
+        class="btn btn-default"
+        id="copyButton_null"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="fa fa-paste"
+        />
+      </button>
+    </span>
+  </span>
+  <textarea
+    aria-hidden="true"
+    class="integr8ly-copy-display pf-u-p-md pf-u-w-100"
+    disabled=""
+    rows="5"
+  >
+    {"hello":"world"}
+  </textarea>
+</div>
+`;
+
+exports[`CopyField Component should render a single-line copy component: single-line 1`] = `
+<div
+  aria-live="polite"
+  class="integr8ly-copy form-group"
+>
+  <span
+    class="pf-u-display-flex input-group"
+  >
+    <input
+      class="integr8ly-copy-input false form-control"
+      copyfieldid="copyField_null"
+      id="test"
+      readonly=""
+      type="text"
+      value="{\\"hello\\":\\"world\\"}"
+    />
+    <span
+      class="input-group-btn"
+    >
+      <button
+        aria-label="Copy to Clipboard"
+        class="btn btn-default"
+        id="copyButton_null"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="fa fa-paste"
+        />
+      </button>
+    </span>
+  </span>
+</div>
+`;

--- a/src/components/copyField/__tests__/copyField.test.js
+++ b/src/components/copyField/__tests__/copyField.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { CopyField } from '../copyField';
+
+describe('CopyField Component', () => {
+  it('should render a single-line copy component', () => {
+    const props = {
+      id: 'test',
+      value: JSON.stringify({ hello: 'world' })
+    };
+    const component = mount(<CopyField {...props} />);
+
+    expect(component.render()).toMatchSnapshot('single-line');
+  });
+
+  it('should render a multi-line copy component', () => {
+    const props = {
+      id: 'test',
+      multiline: true,
+      value: JSON.stringify({ hello: 'world' })
+    };
+    const component = mount(<CopyField {...props} />);
+
+    expect(component.render()).toMatchSnapshot('multi-line');
+  });
+
+  it('should default expanded on multiline and collapse on blur', () => {
+    const props = {
+      id: 'test',
+      multiline: true,
+      value: JSON.stringify({ hello: 'world' })
+    };
+    const component = mount(<CopyField {...props} />);
+    const componentInstance = component.instance();
+    const mockEvent = { target: { blur: () => {} } };
+
+    componentInstance.onExpand(mockEvent);
+    expect(component.state().expanded).toEqual(false);
+    expect(component.render().find('textarea.integr8ly-copy-display')).toMatchSnapshot('expanded');
+  });
+});

--- a/src/components/copyField/copyField.js
+++ b/src/components/copyField/copyField.js
@@ -1,0 +1,228 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form, Icon, InputGroup, Button, OverlayTrigger, Tooltip as PFTooltip } from 'patternfly-react';
+import { generateId } from '../../common/helpers';
+
+class CopyField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      copied: false,
+      expanded: !!props.multiline,
+      timer: null
+    };
+  }
+  state = {
+    copied: false,
+    expanded: false,
+    timer: null
+  };
+
+  onCopy = event => {
+    const { timer } = this.state;
+    const { value } = this.props;
+    const success = this.copyClipboard(value);
+
+    event.target.blur();
+    clearTimeout(timer);
+
+    this.setState(
+      {
+        copied: success
+      },
+      () => this.resetStateTimer()
+    );
+  };
+
+  copyClipboard = text => {
+    let successful;
+
+    try {
+      window.getSelection().removeAllRanges();
+
+      const newTextarea = document.createElement('pre');
+      newTextarea.appendChild(document.createTextNode(text));
+
+      newTextarea.style.position = 'absolute';
+      newTextarea.style.top = '-9999px';
+      newTextarea.style.left = '-9999px';
+
+      const range = document.createRange();
+      window.document.body.appendChild(newTextarea);
+
+      range.selectNode(newTextarea);
+
+      window.getSelection().addRange(range);
+
+      successful = window.document.execCommand('copy');
+
+      window.document.body.removeChild(newTextarea);
+      window.getSelection().removeAllRanges();
+    } catch (e) {
+      successful = false;
+      console.warn('Copy to clipboard failed.', e.message);
+    }
+
+    return successful;
+  };
+
+  onExpand = event => {
+    const { expanded } = this.state;
+    event.target.blur();
+
+    this.setState({
+      expanded: !expanded
+    });
+  };
+
+  onSelect = event => {
+    event.target.select();
+  };
+
+  resetStateTimer() {
+    const { resetTimer } = this.props;
+
+    const timer = setTimeout(
+      () =>
+        this.setState({
+          copied: false
+        }),
+      resetTimer
+    );
+
+    this.setState({ timer });
+  }
+
+  renderButton() {
+    const { copied } = this.state;
+    const { label, labelClicked, labelDescription, labelClickedDescription, tooltipPlacement } = this.props;
+
+    if (labelDescription && labelClickedDescription && label && labelClicked) {
+      const setToolTipId = generateId();
+
+      return (
+        <React.Fragment>
+          {copied && (
+            <OverlayTrigger
+              overlay={<PFTooltip id={setToolTipId}>{labelClickedDescription}</PFTooltip>}
+              placement={tooltipPlacement}
+            >
+              <Button
+                id={`copyButton_${this.props.copySequenceId}`}
+                onClick={this.onCopy}
+                aria-label={labelClickedDescription}
+              >
+                {labelClicked}
+              </Button>
+            </OverlayTrigger>
+          )}
+          {!copied && (
+            <OverlayTrigger
+              overlay={<PFTooltip id={setToolTipId}>{labelDescription}</PFTooltip>}
+              placement={tooltipPlacement}
+            >
+              <Button
+                id={`copyButton_${this.props.copySequenceId}`}
+                onClick={this.onCopy}
+                aria-label={labelDescription}
+              >
+                {label}
+              </Button>
+            </OverlayTrigger>
+          )}
+        </React.Fragment>
+      );
+    }
+
+    if (label && labelClicked) {
+      return (
+        <Button onClick={this.onCopy} aria-label={labelDescription}>
+          {copied && label}
+          {!copied && labelClicked}
+        </Button>
+      );
+    }
+
+    return (
+      <Button onClick={this.onCopy} aria-label={labelDescription}>
+        {copied && (
+          <React.Fragment>
+            <Icon type="fa" name="check" /> Copied
+          </React.Fragment>
+        )}
+        {!copied && 'Copy'}
+      </Button>
+    );
+  }
+
+  render() {
+    const { expanded } = this.state;
+    const { id, multiline, expandDescription, value } = this.props;
+
+    const setId = id || generateId();
+
+    return (
+      <Form.FormGroup className="integr8ly-copy" controlId={setId} aria-live="polite">
+        <InputGroup className="pf-u-display-flex">
+          {multiline && (
+            <InputGroup.Button>
+              <Button onClick={this.onExpand} className="integr8ly-copy-display-button" aria-hidden tabIndex={-1}>
+                {!expanded && <Icon type="fa" name="angle-right" />}
+                {expanded && <Icon type="fa" name="angle-down" />}
+              </Button>
+            </InputGroup.Button>
+          )}
+          <Form.FormControl
+            copyfieldid={`copyField_${this.props.copySequenceId}`}
+            type="text"
+            value={value}
+            className={`integr8ly-copy-input ${expanded && 'expanded'}`}
+            readOnly
+            aria-label={expandDescription}
+            onClick={this.onSelect}
+          />
+          <InputGroup.Button>{this.renderButton()}</InputGroup.Button>
+        </InputGroup>
+        {expanded && (
+          <textarea
+            className="integr8ly-copy-display pf-u-p-md pf-u-w-100"
+            rows={5}
+            aria-label={expandDescription}
+            disabled
+            value={value}
+            aria-hidden
+          />
+        )}
+      </Form.FormGroup>
+    );
+  }
+}
+
+CopyField.propTypes = {
+  id: PropTypes.string,
+  copySequenceId: PropTypes.string,
+  expandDescription: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  labelClicked: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  labelDescription: PropTypes.string,
+  labelClickedDescription: PropTypes.string,
+  multiline: PropTypes.bool,
+  resetTimer: PropTypes.number,
+  tooltipPlacement: PropTypes.string,
+  value: PropTypes.string.isRequired
+};
+
+CopyField.defaultProps = {
+  id: null,
+  copySequenceId: null,
+  expandDescription: null,
+  label: <Icon type="fa" name="paste" />,
+  labelClicked: <Icon type="fa" name="check" />,
+  labelDescription: 'Copy to Clipboard',
+  labelClickedDescription: 'Copied',
+  multiline: false,
+  resetTimer: 8000,
+  tooltipPlacement: 'top'
+};
+
+export { CopyField as default, CopyField };

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -7,8 +7,6 @@ import { noop, Icon, Form, FormGroup, Radio } from 'patternfly-react';
 import {
   Button,
   Card,
-  ClipboardCopy,
-  ClipboardCopyVariant,
   Grid,
   GridItem,
   Page,
@@ -34,6 +32,7 @@ import {
   WalkthroughStep
 } from '../../../common/walkthroughHelpers';
 import ProvisioningScreen from '../../../components/provisioning/provisioningScreen';
+import CopyField from '../../../components/copyField/copyField';
 import { findServices } from '../../../common/serviceInstanceHelpers';
 import { isOpenShift4 } from '../../../common/openshiftHelpers';
 
@@ -49,13 +48,11 @@ class TaskPage extends React.Component {
       let sequenceNumber = 1;
       codeBlocks.forEach(block => {
         ReactDOM.render(
-          <ClipboardCopy
-            id={sequenceNumber.toString()}
-            isReadOnly
-            variant={block.clientHeight > 40 ? ClipboardCopyVariant.expansion : null}
-          >
-            {block.innerText}
-          </ClipboardCopy>,
+          <CopyField
+            copySequenceId={sequenceNumber.toString()}
+            value={block.innerText}
+            multiline={block.clientHeight > 40}
+          />,
           block.parentNode
         );
         sequenceNumber++;

--- a/src/styles/application/_components.scss
+++ b/src/styles/application/_components.scss
@@ -3,6 +3,7 @@
 @import "./components/about-modal";
 @import "./components/alerts";
 @import "./components/cards";
+@import "./components/copyField";
 @import "./components/errorScreen";
 @import "./components/installedAppsView";
 @import "./components/lists";

--- a/src/styles/application/components/_copyField.scss
+++ b/src/styles/application/components/_copyField.scss
@@ -1,0 +1,43 @@
+.integr8ly-copy {
+  button {
+    height: 32px;
+  }
+
+  input {
+    height: 32px;
+  }
+
+  &-input {
+    &.false { /* stylelint-disable-line selector-class-pattern */
+      width: 200px;
+      text-overflow: ellipsis;
+    }
+
+    @media (min-width: 768px) {
+      &.false { /* stylelint-disable-line selector-class-pattern */
+        width: 400px;
+      }
+    }
+
+    &.expanded { /* stylelint-disable-line selector-class-pattern */
+      background-color: var(--pf-global--BackgroundColor--light-300);
+    }
+  }
+
+  &-display {
+    border: var(--pf-global--BorderWidth--sm) solid;
+    border-color: var(--pf-global--BorderColor--light);
+    border-top-width: 0;
+    word-wrap: break-word;
+    resize: none;
+  }
+
+  /* stylelint-disable selector-class-pattern */
+  & > .input-group {
+    .input-group-addon,
+    .input-group-btn {
+      width: auto;
+    }
+  }
+  /* stylelint-enable */
+}


### PR DESCRIPTION
## Motivation
INTLY-3307 - the PF4 clipboardCopy component is not rendering indentation correctly, which makes formatted text like code examples very difficult to read/follow.

## What
Reverted the clipboardCopy component to the old custom component that Integreatly was using prior to updating to the PF4 component.

## Why
It will fix the code examples and multiline copyable text so that line indents are preserved.

## Verification Steps
1. Proceed through a walkthrough until you get to a multiline formatted code example.
2. Verify that the line indents now appear correctly. 

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**Before:**
![clipCopy_before](https://user-images.githubusercontent.com/39063664/64547008-b95bc680-d2f9-11e9-85e4-def254e51ce6.png)

**After:**
![clipCopy_after](https://user-images.githubusercontent.com/39063664/64547023-bfea3e00-d2f9-11e9-9c2a-f7fc90b83218.png)
