### PR TITLE
Use Monospace font for copy field

### DIFF
--- a/src/styles/application/components/_copyField.scss
+++ b/src/styles/application/components/_copyField.scss
@@ -30,6 +30,7 @@
     border-top-width: 0;
     word-wrap: break-word;
     resize: none;
+    font-family: monospace;
   }
 
   /* stylelint-disable selector-class-pattern */


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-3393
Font used in code blocks in Solution Explorer is not monospace

## What
Add font-family: monospace; to the .integr8ly-copy-display class

## Why
So that the font will be monospace

## How
Add font-family: monospace; to the .integr8ly-copy-display class

## Verification Steps
View any code block and ensure the font is monospace
 
## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task
- [ ] TODO

## Additional Notes
Before:
![Screenshot 2019-09-11 13 31 34](https://user-images.githubusercontent.com/235734/64699062-ef38b080-d49b-11e9-9e49-73c1202425d3.png)

After:
<img width="765" alt="Screenshot 2019-09-11 13 45 44" src="https://user-images.githubusercontent.com/235734/64699155-12fbf680-d49c-11e9-9a87-d9d941bf0f53.png">
