### PR TITLE
do not crash when a walkthrough cannot be resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.6",
+  "version": "2.18.7",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -366,10 +366,16 @@ function resolveWalkthroughLocations(locations) {
         }
 
         return reject(new Error(`${location} is neither a path nor a git repo`));
+      }).catch(err => {
+        console.error(err);
+        return undefined;
       })
   );
 
-  return Promise.all(mappedLocations).then(flattenDeep);
+  return Promise.all(mappedLocations).then(promises => {
+    // Ignore all locations that could not be resolved
+    return flattenDeep(promises.filter(p => !!p));
+  });
 }
 
 /**


### PR DESCRIPTION
Fixes [INTLY-3338](https://issues.jboss.org/browse/INTLY-3338)

Do not crash the webapp if one of the walkthrough locations can't be resolved but still log the error.

Verification steps:

1. Start the webapp and provide a list of locations with at least one invalid location, e.g. ` WALKTHROUGH_LOCATIONS=https://github.com/integr8ly/does-not-exist,https://github.com/integr8ly/tutorial-web-app-walkthroughs yarn run start:dev`
1. Make sure the error is logged but the webapp still starts and loads the other walkthroughs
1. Verify the same on a cluster