### PR TITLE
INTLY-3658: Regex change to support github urls without www

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.7",
+  "version": "2.18.8",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -60,18 +60,17 @@ class SettingsPage extends React.Component {
     this.setState(
       {
         value,
-        isValid: /^(?:https:\/\/)+([w.-]+)+github.com\/[\w\-._~:/?#[\]@!$&/'()*+,;=.]+$/.test(value)
+        isValid: /^(?:https:\/\/)+(www.)?github.com\/[\w\-._~:/?#[\]@!$&/'()*+,;=.]+$/.test(value)
       },
       () => {
         if (this.state.value === '') {
           this.setState({ isValid: true });
         }
-
         if (this.state.value.includes('\n')) {
           const repoArray = this.state.value.split('\n');
 
           for (let i = 0; i < repoArray.length; i++) {
-            if (/^(?:https:\/\/)+([w.-]+)+github.com\/[\w\-._~:/?#[\]@!$&/'()*+,;=.]+$/.test(repoArray[i])) {
+            if (/^(?:https:\/\/)+(www.)?github.com\/[\w\-._~:/?#[\]@!$&/'()*+,;=.]+$/.test(repoArray[i])) {
               this.setState({
                 isValid: true
               });
@@ -89,7 +88,7 @@ class SettingsPage extends React.Component {
           this.setState({ isValid: true });
         } else {
           this.setState({
-            isValid: /^(?:https:\/\/)+([w.-]+)+github.com\/[\w\-._~:/?#[\]@!$&/'()*+,;=.]+$/.test(value)
+            isValid: /^(?:https:\/\/)+(www.)?github.com\/[\w\-._~:/?#[\]@!$&/'()*+,;=.]+$/.test(value)
           });
         }
       }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-3658
https://issues.jboss.org/browse/INTLY-2720

## What
Changed the regex for the url syntax checker so that it supports github URLs with and without "www." in the address, and discovered and fixed another issue in which invalid URLs would go unflagged if there were < or > 3 w's in the address (e.g. 'ww.github.com' 'wwwwww.github.com' etc).

## Why
Allows for typing or copy/pasting of completely valid github URLs that don't specify the optional www in the URL.

## Verification Steps
1. In Solution Explorer, click the Settings (gear) icon in the masthead to open the Settings page.
2. Type in a valid github URL containing www. in the field, such as:
https://www.github.com/mySolution
3. Verify that the syntax is correctly verified as you type. It should become valid as soon as you type the m in mySolution.
4. Cut the URL from the field and paste it back in to verify that it is still verifying as valid.
5. Repeat the above steps with a valid github URL without a www. in the URL, such as:
https://github.com/mySolution

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**Screen shot before fix:**
![settings-before](https://user-images.githubusercontent.com/39063664/66059975-e1aa9f80-e50a-11e9-9a74-0e18acb21735.png)

**Screen shot after fix:**
![settings-after](https://user-images.githubusercontent.com/39063664/66059965-deafaf00-e50a-11e9-9be5-6e147191097e.png)
