### PR TITLE
INTLY-473: Walkthrough progress can be more than 100 percent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.9",
+  "version": "2.18.10",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -76,8 +76,10 @@ const TutorialDashboard = props => {
         const currentProgress = userProgress[walkthrough.id];
         let startedText;
         if (currentProgress === undefined) startedText = 'Get Started';
-        else if (currentProgress.progress === 100) startedText = 'Completed';
-        else startedText = 'Resume';
+        else if (currentProgress.progress >= 100) {
+          currentProgress.progress = 100;
+          startedText = 'Completed';
+        } else startedText = 'Resume';
 
         return (
           <GalleryItem id={walkthrough.id} key={walkthrough.id}>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -140,7 +140,7 @@ class TaskPage extends React.Component {
     const totalSteps = this.getTotalSteps(data);
     if (totalSteps > 0) {
       const completedSteps = this.getCompletedSteps(oldProgress[id]);
-      oldProgress[id].progress = Math.floor((completedSteps / totalSteps) * 100);
+      oldProgress[id].progress = Math.min(Math.floor((completedSteps / totalSteps) * 100), 100);
       oldProgress[id].task = task;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,11 +4127,6 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
-  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
-
 decamelize-keys@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -7993,14 +7988,6 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-<<<<<<< HEAD
-=======
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
->>>>>>> update yarn.lock
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,6 +4127,11 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debuglog@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
+  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
+
 decamelize-keys@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -7988,6 +7993,14 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+<<<<<<< HEAD
+=======
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
+>>>>>>> update yarn.lock
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
## Motivation
[INTLY-473](https://issues.jboss.org/browse/INTLY-473)

## What
In some scenarios, the walkthrough progress show more than 100% done. I've added code so that if the scenario is complete, aka there are no steps left, then it forces to 100.

## Why
We should not be showing a percent complete higher than 100%.

## Verification Steps
Note that I could not reproduce this issue. But I did test to make sure that there were no regressions. Basically:
1. Select a walkthroughs from the main page.
2. Mark several checkboxes as done, and go back and forth in the wizard, keeping an eye on the % done.
3. Finish at least two of the walkthroughs and verify that you see a value of 100% for the percent complete on the card. 

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
Screen cap of finished walkthroughs:
![100_percents](https://user-images.githubusercontent.com/39063664/66765766-997c6d00-ee7a-11e9-948d-29b20c3ff0ac.png)

