### PR TITLE
Default installed services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.18.10",
+  "version": "2.18.11",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -642,6 +642,7 @@ function getConfigData(req) {
   const masterUri = isOpenShift4() ? OPENSHIFT_PROXY_PATH : `https://${process.env.OPENSHIFT_HOST}`;
   const wssMasterUri = isOpenShift4() ? OPENSHIFT_PROXY_PATH : `wss://${process.env.OPENSHIFT_HOST}`;
 
+  const installedServices = process.env.INSTALLED_SERVICES || '{}';
   return `window.OPENSHIFT_CONFIG = {
     clientId: '${process.env.OPENSHIFT_OAUTHCLIENT_ID}',
     accessTokenUri: 'https://${process.env.OPENSHIFT_OAUTH_HOST}/oauth/token',
@@ -658,8 +659,8 @@ function getConfigData(req) {
     clusterType: '${process.env.CLUSTER_TYPE || ''}',
     optionalWatchServices: ${JSON.stringify(arrayFromString(process.env.OPTIONAL_WATCH_SERVICES || '', ','))},
     optionalProvisionServices: ${JSON.stringify(arrayFromString(process.env.OPTIONAL_PROVISION_SERVICES || '', ','))},
-    openshiftVersion: ${openshiftVersion}, 
-    provisionedServices: ${process.env.INSTALLED_SERVICES}
+    openshiftVersion: ${openshiftVersion},
+    provisionedServices: ${installedServices}
   };`;
 }
 


### PR DESCRIPTION
master on openshift 3 is failing due to the JSON returned being invalid when INSTALLED_SERVICES env isn't set.

verification steps:
- run the webapp from master, window shouldn't load
- run the webapp from this branch, window should load and provisioning screen should start

@JameelB is it correct that this value is only relevant in openshift 4, or should it be used in 3 also? are you happy with this default (an array) if nothing is set or should it be an object? i'm not overly familiar with this stuff

@tonyxrmdavidson mind taking a look, this should resolve the issue you're seeing