### PR TITLE
INTLY-3512: fix manifest template handling os4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {


### PR DESCRIPTION
## Motivation
The walkthrough fails to proceed from the loading page and throws the following error if the walkthrough does not have any dependencies specified in its manifest.

```TypeError: Cannot read property 'metadata' of undefined``` (on [walkthroughServices.js:119](https://github.com/integr8ly/tutorial-web-app/blob/master/src/services/walkthroughServices.js#L119))


## What
- [x] Ensure that `initCustomThreadSuccess` is dispatched when there's no dependencies specified in the walkthrough's manifest.
- [x] Ensure that `initCustomThreadFailure` is dispatched when an error occurs during the walkthrough preparation.
- [x] Bump version of the webapp to `2.19.2`

NOTE: This change is specific to OpenShift 4 only

## Verification Steps
1. Run the webapp locally (point to an OpenShift cluster) or update your webapp deployment to use the image `quay.io/jameelb/tutorial-web-app:2.19.2`
2. Ensure that walkthrough 1 is accessible
3. Ensure that walkthrough 2 is accessible

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member