### PR TITLE
fix: replace mdc with ups

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker build -t quay.io/integreatly/tutorial-web-app:master .
+docker build -t quay.io/secondsun/tutorial-web-app:master .

--- a/server.js
+++ b/server.js
@@ -609,7 +609,7 @@ function getMockConfigData() {
         },
         {
           spec: {
-            clusterServiceClassExternalName: 'mdc'
+            clusterServiceClassExternalName: 'unifiedpush'
           },
           status: {
             dashboardURL: '${process.env.OPENSHIFT_URL}',

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -47,11 +47,11 @@ export default {
     primaryTask: 'Design APIs',
     description: 'The Apicurito RESTful API visual designer.'
   },
-  mdc: {
-    prettyName: 'Mobile Developer Console',
-    gaStatus: 'preview',
-    primaryTask: 'Create mobile apps',
-    description: 'Allows you register your mobile app and associate it with Mobile Developer Services.'
+  unifiedpush: {
+    prettyName: 'Push Notification Service',
+    gaStatus: 'GA',
+    primaryTask: 'Mobile Push Messaging',
+    description: 'Provides messaging services for Android and iOS'
   },
   rhsso: {
     prettyName: 'Red Hat Single Sign-On',


### PR DESCRIPTION
## Motivation
This PR is part of adding UPS to the solution explorer for integr8ly and removing MDC.

## What
This PR removes MDC and adds code for UPS.  It replaces it in the mock data as well as adds hooks for the UPS service to be displayed.


## Verification Steps
1. Deploy integr8ly somewhere
2. Modify the mobile-service-broker to use this image : `quay.io/secondsun/managed-service-broker:master` (a PR of msb is forthcoming) 
3. You can run this PR with the command line call `OPTIONAL_PROVISION_SERVICES=unifiedpush OPENSHIFT_HOST=$YOUR_OPENSHIFT_HOST yarn start:dev` (this will need to be added to the i8ly installer to start the solution explorer with this link)
4. Navigate to localhost:3006 and you should see the push service link.

## Checklist:

- [ x ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

