### PR TITLE
INTLY-4335: Remove card sort based on percent complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.20.0",
+  "version": "2.20.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -32,25 +32,6 @@ const TutorialDashboard = props => {
     return repos;
   }
 
-  function wtSortByProgress(w1, w2) {
-    const a = [userProgress[w1.id], w1.title];
-    const b = [userProgress[w2.id], w2.title];
-
-    if (a[0] === undefined && b[0] === undefined) {
-      return a[1] < b[1] ? -1 : 1;
-    }
-    if (a[0] !== undefined && b[0] !== undefined) {
-      return a[0].progress > b[0].progress ? -1 : 1;
-    }
-    if (a[0] === undefined && b[0] !== undefined) {
-      return a > b ? -1 : 1;
-    }
-    if (a[0] !== undefined && b[0] === undefined) {
-      return a > b ? -1 : 1;
-    }
-    return a[1] < b[1] ? -1 : 1;
-  }
-
   function addCategory(walkthrus) {
     const repoInfo = walkthrus[0].walkthroughLocationInfo;
     let htmlCategory = '';
@@ -75,7 +56,7 @@ const TutorialDashboard = props => {
     for (let i = 0; i < allRepos.length; i++) {
       const filteredWalkthroughs = filterWalkthroughs(walkthrus, allRepos[i]);
 
-      const cards = filteredWalkthroughs.sort(wtSortByProgress).map(walkthrough => {
+      const cards = filteredWalkthroughs.map(walkthrough => {
         const currentProgress = userProgress[walkthrough.id];
         let startedText;
         if (currentProgress === undefined) startedText = 'Get Started';


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-4335

## What
Request was to remove the sort order of the walkthrough cards based on % complete. Cards will no longer be sorted based on their % complete, and finished walkthroughs will no longer go to the end of the list.

## Why
Request from customer service to facilitate training.

## Verification Steps
1. Go to the All Solutions Patterns tab.
2. Start a solution pattern and make progress through at least one or more sections.
3. Navigate back to the home page and verify that the order of the cards has not changed.
4. Go through and completely finish at least one solution pattern.
5. Navigate back to the home page and verify that the order of the cards has not changed.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**All Solution Patterns tab default:**
![soix_default](https://user-images.githubusercontent.com/39063664/70257423-3d3a1900-1758-11ea-9682-08c2c6d8c4c1.png)

**All Solution Patterns after starting one and completing another pattern:**
![soix_started](https://user-images.githubusercontent.com/39063664/70257427-40cda000-1758-11ea-9e7b-ed81bcfdeb16.png)


