### PR TITLE
INTLY-4337: Updated the font color for the component names on Services tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -142,7 +142,7 @@ class InstalledAppsView extends React.Component {
                   </Expandable>
                 </DataListCell>,
                 <DataListCell key="primary content">
-                  <span id="Red Hat OpenShift">Red Hat OpenShift</span>
+                  <span className="integr8ly-pretty-name" id="Red Hat OpenShift">Red Hat OpenShift</span>
                 </DataListCell>,
                 <DataListCell
                   key="cell one"
@@ -310,7 +310,7 @@ class InstalledAppsView extends React.Component {
                       </span>
                     </DataListCell>,
                     <DataListCell key="primary content">
-                      <span id={`appName-${prettyName}`}>
+                      <span className="integr8ly-pretty-name" id={`appName-${prettyName}`}>
                         {' '}
                         {prettyName}{' '}
                         {gaStatus && (gaStatus === 'preview' || gaStatus === 'community') ? (

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -142,7 +142,9 @@ class InstalledAppsView extends React.Component {
                   </Expandable>
                 </DataListCell>,
                 <DataListCell key="primary content">
-                  <span className="integr8ly-pretty-name" id="Red Hat OpenShift">Red Hat OpenShift</span>
+                  <span className="integr8ly-pretty-name" id="Red Hat OpenShift">
+                    Red Hat OpenShift
+                  </span>
                 </DataListCell>,
                 <DataListCell
                   key="cell one"

--- a/src/styles/application/components/_installedAppsView.scss
+++ b/src/styles/application/components/_installedAppsView.scss
@@ -46,3 +46,7 @@
 .integr8ly-panel-title {
   background-color: $pf-color-white !important; /* stylelint-disable-line declaration-no-important */
 }
+
+.integr8ly-pretty-name {
+  color: var(--pf-global--Color--200);
+}


### PR DESCRIPTION
Updated the font color for the component names on Services tab

Screenshot:

![Screen Shot 2019-12-05 at 1 50 02 PM](https://user-images.githubusercontent.com/6126356/70264773-17684080-1767-11ea-8008-cebc0dcfd6bb.png)
