### PR TITLE
INTLY-4402: Update pds cluster type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.20.3",
+  "version": "2.20.4",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -225,9 +225,6 @@ class InstalledAppsView extends React.Component {
   }
 
   static createMasterList(displayServices, apps, customApps, enableLaunch, launchHandler) {
-    // MF 120219 Testing begin
-    console.log(`Apps = ${JSON.stringify(apps)}`);
-    // Testing end
     const completeSvcNames = apps
       .map(svc => {
         if (svc.type === SERVICE_TYPES.PROVISIONED_SERVICE) {
@@ -261,9 +258,6 @@ class InstalledAppsView extends React.Component {
       }
       return provisionedSvc;
     });
-    // MF 120219 Testing begin
-    console.log(`completeSvcList is: ${JSON.stringify(completeSvcList)}`);
-    // Testing end
     const masterList = completeSvcList
       .sort((cur, next) => {
         const curDetails = getProductDetails(cur);
@@ -279,9 +273,6 @@ class InstalledAppsView extends React.Component {
         return 0;
       })
       .map((app, index) => {
-        // MF 120219 Testing begin
-        console.log(`App is: ${JSON.stringify(app)}`);
-        // Testing end
         const { description, gaStatus, hidden, prettyName, primaryTask } = getProductDetails(app);
         const uniqKey = InstalledAppsView.genUniqueKeyForService(app);
         return hidden ? null : (
@@ -378,11 +369,6 @@ class InstalledAppsView extends React.Component {
     );
     const managedTooltip = 'Managed services are delivered as a hosted service and supported by Red Hat.';
     // const selfManagedTooltip = 'Self-managed services are available for use, but not managed by Red Hat.';
-
-    // MF 120219 Testing begin
-    console.log(appList);
-    console.log(this.props.apps);
-    // Testing end
 
     return (
       <div>

--- a/src/pages/devResources/devResources.js
+++ b/src/pages/devResources/devResources.js
@@ -37,7 +37,7 @@ class DevResourcesPage extends React.Component {
       clusterType = window.OPENSHIFT_CONFIG.mockData ? 'localhost' : window.OPENSHIFT_CONFIG.clusterType;
     }
     switch (clusterType) {
-      case 'rhpds':
+      case 'pds':
         urls.loggingUrl = `https://kibana.apps.${clusterId}.open.redhat.com`;
         urls.apiUrl = `https://master.apps.${clusterId}.open.redhat.com`;
         urls.registryUrl = `https://registry-console-default.apps.${clusterId}.open.redhat.com`;


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-4402

## What
Fixes an issue in which the Developer resources page was not displaying valid information for all 3 values: Logging, API and Registry. This was because the back end cluster type for RHPDS clusters was renamed from 'rhpds' to 'pds', and we key off that cluster type name, so it broke.
 
## Verification Steps
1. In Solution Explorer running on an RHPDS cluster, select Help btn > Developer resources.
2. Verify that the three URLs are populated correctly, as opposed to displaying 'Unknown X URL'.

You can use my server running the latest changes if you wish:
https://tutorial-web-app-webapp.apps.uxddev-6263.open.redhat.com/

Or if you want to use your own system, you can point Solution Explorer to my docker image:
docker.io/mfrances17/dev-tutorial-web-app:latest

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**Screen cap of fix:**
![dev-resources](https://user-images.githubusercontent.com/39063664/70645607-4ffa9500-1c13-11ea-8d20-0f67367437f1.png)

