### PR TITLE
INTLY-4390 Added stable IDs to tabs in landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
+++ b/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
@@ -14,7 +14,6 @@ exports[`AboutModal Component should render a non-connected component: hidden mo
   }
 >
   <AboutModal
-    appendTo={null}
     backgroundImageSrc="PF4DownstreamBG.svg"
     brandImageAlt="Red Hat logo"
     brandImageSrc="Logo-RedHat-A-Reverse-RGB.svg"
@@ -29,7 +28,6 @@ exports[`AboutModal Component should render a non-connected component: hidden mo
       containerInfo={<div />}
     >
       <AboutModalContainer
-        appendTo={null}
         ariaDescribedById="pf-about-modal-content-0"
         ariaLabelledbyId="pf-about-modal-title-0"
         backgroundImageSrc="PF4DownstreamBG.svg"
@@ -61,7 +59,6 @@ exports[`AboutModal Component should render a non-connected component: show moda
   }
 >
   <AboutModal
-    appendTo={null}
     backgroundImageSrc="PF4DownstreamBG.svg"
     brandImageAlt="Red Hat logo"
     brandImageSrc="Logo-RedHat-A-Reverse-RGB.svg"
@@ -76,7 +73,6 @@ exports[`AboutModal Component should render a non-connected component: show moda
       containerInfo={<div />}
     >
       <AboutModalContainer
-        appendTo={null}
         ariaDescribedById="pf-about-modal-content-0"
         ariaLabelledbyId="pf-about-modal-title-0"
         backgroundImageSrc="PF4DownstreamBG.svg"

--- a/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
+++ b/src/components/breadcrumb/__tests__/__snapshots__/breadcrumb.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Breadcrumb component should handle home clicked 1`] = `
-<Component
+<Breadcrumb
   aria-label="Breadcrumb"
 >
   <BreadcrumbItem
@@ -22,11 +22,11 @@ exports[`Breadcrumb component should handle home clicked 1`] = `
   >
     Task 1 of 3
   </BreadcrumbItem>
-</Component>
+</Breadcrumb>
 `;
 
 exports[`Breadcrumb component should render breadcrumb with props 1`] = `
-<Component
+<Breadcrumb
   aria-label="Breadcrumb"
 >
   <BreadcrumbItem
@@ -47,11 +47,11 @@ exports[`Breadcrumb component should render breadcrumb with props 1`] = `
   >
     Task 1 of 3
   </BreadcrumbItem>
-</Component>
+</Breadcrumb>
 `;
 
 exports[`Breadcrumb component should render default breadcrumb 1`] = `
-<Component
+<Breadcrumb
   aria-label="Breadcrumb"
 >
   <BreadcrumbItem
@@ -61,5 +61,5 @@ exports[`Breadcrumb component should render default breadcrumb 1`] = `
   >
     Home
   </BreadcrumbItem>
-</Component>
+</Breadcrumb>
 `;

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -83,12 +83,14 @@ class LandingPage extends React.Component {
             </p>
             <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
               <Tab
+                id="servicesTabSection"
                 eventKey={0}
                 title="All services"
                 tabContentId="servicesTabSection"
                 tabContentRef={this.contentRef1}
               />
               <Tab
+                id="solutionPatternsTabSection"
                 eventKey={1}
                 title="All Solution Patterns"
                 tabContentId="solutionPatternsTabSection"

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -21,10 +21,8 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
   <Page
     breadcrumb={null}
     className="pf-u-h-100vh"
-    defaultManagedSidebarIsOpen={true}
     header={null}
     isManagedSidebar={false}
-    mainContainerId={null}
     onPageResize={[Function]}
     sidebar={null}
     skipToContent={null}
@@ -61,7 +59,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
                 >
                   Example
                 </h1>
-                <Component
+                <Button
                   aria-label="Get Started"
                   id="get-started-01"
                   onClick={[Function]}
@@ -69,7 +67,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
                   variant="primary"
                 >
                   tutorial.getStarted
-                </Component>
+                </Button>
               </div>
               <div
                 dangerouslySetInnerHTML={
@@ -112,7 +110,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
               <div
                 className="integr8ly-task-dashboard-time-to-completion pf-u-mb-lg"
               >
-                <Component
+                <Button
                   aria-label="Get Started"
                   id="get-started-02"
                   onClick={[Function]}
@@ -120,7 +118,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
                   variant="primary"
                 >
                   tutorial.getStarted
-                </Component>
+                </Button>
               </div>
             </TextContent>
           </Card>


### PR DESCRIPTION
## Motivation
INTLY-4390

## What
Added stable static ID's to the tabs in the webapp landing page.

## Why
ID's are needed to allow QE browser tests to work.

## How

## Verification Steps
Clone this MR and run webapp locally against cluster installed with RHMI master branch

1.  Login to webapp as evals user   evals01/Password1
2. Inspect the tab elements in the browser and they should match the image below.

<img width="793" alt="Screenshot 2019-12-11 at 20 14 47" src="https://user-images.githubusercontent.com/10615211/70656950-ebf7c100-1c52-11ea-8f73-22b96d490526.png">


## Checklist:

- [x ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO
