### PR TITLE
INTLY-4390: Add missing static IDs for tabs to fix browser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.20.6",
+  "version": "2.20.7",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -78,17 +78,19 @@ class LandingPage extends React.Component {
           <PageSection variant={PageSectionVariants.light} className="pf-u-py-0 pf-u-pl-lg pf-u-pr-0">
             <h1 className="pf-c-title pf-m-4xl pf-c-landing__heading">Welcome to the Solution Explorer</h1>
             <p className="pf-c-landing__content">
-              Quickly access consoles for all your Red Hat managed and self-managed services, and learn how to easily
-              implement enterprise integrations with Solution Pattern examples.
+              Quickly access consoles for all your Red Hat managed services, and learn how to easily implement
+              integrations with Solution Pattern examples.
             </p>
             <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
               <Tab
+                id="servicesTab"
                 eventKey={0}
                 title="All services"
                 tabContentId="servicesTabSection"
                 tabContentRef={this.contentRef1}
               />
               <Tab
+                id="solutionPatternsTab"
                 eventKey={1}
                 title="All Solution Patterns"
                 tabContentId="solutionPatternsTabSection"


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-4390

## What
Need to add static IDs for the new solution explorer tabs on the dashboard in order to unblock browser tests from failing. Also a text-only change, removed 'self-managed' from description on dashboard, since they are not available via the dashboard yet. Very low-risk changes.

## Verification Steps
Verify that when the tabs are inspected in the console dev window, they show id=servicesTab and id=solutionPatternsTab.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task
