### PR TITLE
change pretty name for RHSSO to match docs

### DIFF
--- a/src/product-info.js
+++ b/src/product-info.js
@@ -55,7 +55,7 @@ export default {
       'Admins can use our single sign-on solution for managing cluster users. Contact your local customer admin if you do not have access to this console. '
   },
   rhsso: {
-    prettyName: 'Red Hat Single Sign-On',
+    prettyName: 'Managed Integration Red Hat Single Sign-On',
     gaStatus: 'GA',
     primaryTask: 'Manage users (Admins only)',
     description: 'A single sign-on solution for web apps, mobile apps, and RESTful web services.'


### PR DESCRIPTION
## Motivation
Currently the screen doesn't match the documentation. This PR makes it easier for users to match the docs and the UI

## What
change pretty name to 'Managed Integration RHSSO'
![image](https://user-images.githubusercontent.com/5154224/70893266-a8021480-1fe2-11ea-9dd3-1b2a24b67097.png)

## Why
To match docs
## How
edit prettyname
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
