### PR TITLE
INTLY-4336: Sort dashboard services based on product-info.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.20.8",
+  "version": "2.20.9",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -14,7 +14,7 @@ import {
   Tooltip
 } from '@patternfly/react-core';
 import { ChartPieIcon, ErrorCircleOIcon, HelpIcon, OnRunningIcon, OffIcon } from '@patternfly/react-icons';
-import { getProductDetails } from '../../services/middlewareServices';
+import { getProductDetails, getServiceSortOrder } from '../../services/middlewareServices';
 import { SERVICE_STATUSES, SERVICE_TYPES } from '../../redux/constants/middlewareConstants';
 
 class InstalledAppsView extends React.Component {
@@ -52,7 +52,7 @@ class InstalledAppsView extends React.Component {
 
   getStatusForApp = (app, prettyName) => {
     const provisioningStatus = (
-      <div className="integr8ly-state-provisioining">
+      <div className="integr8ly-state-provisioning">
         <ChartPieIcon /> &nbsp;Provisioning
       </div>
     );
@@ -200,7 +200,7 @@ class InstalledAppsView extends React.Component {
           </DataListAction>
         </DataListItemRow>
         <DataListContent
-          aria-label={`Openshit Content Details ${index}`}
+          aria-label={`Openshift Content Details ${index}`}
           className="integr8ly-app-detail-content"
           id={`openshift-expand-${index}`}
           isHidden={!this.state.expanded.includes(`openshift-toggle-${index}`)}
@@ -285,17 +285,15 @@ class InstalledAppsView extends React.Component {
       }
       return provisionedSvc;
     });
-
+    // Sort by order of products in json file
     const masterList = completeSvcList
       .sort((cur, next) => {
-        const curDetails = getProductDetails(cur);
-        const nextDetails = getProductDetails(next);
-        // Try to push any non-pretty names to the bottom. Although, all names
-        // should be pretty in this section.
-        if (!curDetails || nextDetails.prettyName > curDetails.prettyName) {
+        const curOrder = getServiceSortOrder(cur);
+        const nextOrder = getServiceSortOrder(next);
+        if (!curOrder || nextOrder > curOrder) {
           return -1;
         }
-        if (!nextDetails || curDetails.prettyName > nextDetails.prettyName) {
+        if (!nextOrder || curOrder > nextOrder) {
           return 1;
         }
         return 0;
@@ -378,7 +376,7 @@ class InstalledAppsView extends React.Component {
                   <div className="integr8ly-state-ready">{this.getStatusForApp(app, prettyName)}</div>
                   {enableLaunch && this.isServiceUnready(app) ? (
                     // <div className="pf-u-display-flex pf-u-justify-content-flex-end">
-                    <div className="integr8ly-state-provisioining">
+                    <div className="integr8ly-state-provisioning">
                       <Button onClick={() => launchHandler(app)} variant="secondary">
                         <OffIcon />
                         &nbsp; Start service

--- a/src/components/walkthroughResources/walkthroughResources.js
+++ b/src/components/walkthroughResources/walkthroughResources.js
@@ -44,7 +44,7 @@ class WalkthroughResources extends React.Component {
   }
 
   static assignSerivceIcon(app) {
-    const provisioningStatus = <ChartPieIcon className="pf-u-mr-xs integr8ly-state-provisioining" />;
+    const provisioningStatus = <ChartPieIcon className="pf-u-mr-xs integr8ly-state-provisioning" />;
     const readyStatus = <OnRunningIcon className="pf-u-mr-xs integr8ly-state-ready" />;
     const unavailableStatus = <ExclamationCircleIcon className="pf-u-mr-xs integr8ly-state-unavailable" />;
 

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -100,6 +100,14 @@ const getProductDetailsForServiceClass = serviceClassName => {
   return storedDetails;
 };
 
+const getServiceSortOrder = svc => {
+  const serviceClassName = svc.spec.clusterServiceClassExternalName;
+  const keys = Object.keys(productDetails);
+  const serviceOrder = keys.indexOf(serviceClassName);
+
+  return serviceOrder;
+};
+
 /**
  * Dispatch a mock set of user services.
  * @param {Object} dispatch Redux dispatch.
@@ -406,6 +414,7 @@ export {
   getCustomConfig,
   handleEnmasseServiceInstanceWatchEvents,
   getProductDetails,
+  getServiceSortOrder,
   getProductDetailsForServiceClass,
   getServicesToProvision,
   manageServicesV4

--- a/src/styles/application/components/_installedAppsView.scss
+++ b/src/styles/application/components/_installedAppsView.scss
@@ -35,7 +35,7 @@
   }
 }
 
-.integr8ly-state-provisioining {
+.integr8ly-state-provisioning {
   color: $pf-color-black-600 !important; /* stylelint-disable-line declaration-no-important */
 }
 


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-4336

## What
List the services on the dashboard based on the order in which they appear in the product-info.js file.

## Why
Provide the ability to change the order in which services appear on the dashboard by editing the product-info.js file.

## Verification Steps
1. In Solution Explorer, click the 'All services' tab on the dashboard.
2. Verify that the services in the Managed services section appear in the same order as they appear in product-info.js file.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**List of services before code changes:**
![old_dash_order](https://user-images.githubusercontent.com/39063664/71846051-a5518700-3097-11ea-9ca1-553bfcda1973.png)

**Contents of product-info.js:**
![product-info-js-contents](https://user-images.githubusercontent.com/39063664/71846064-ae425880-3097-11ea-81fb-1cef4bfe4f3a.png)

**List of services after code changes:**
![new_dash_order](https://user-images.githubusercontent.com/39063664/71846070-b26e7600-3097-11ea-8063-420ab5c8eca3.png)
