### PR TITLE
ci: remove yarn install from config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: sudo npm install -g yarn
       - run: yarn install
       - run: yarn build
       - run: yarn run test


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->

It appears yarn has been included in the `circleci/node:10` image used by our circleci. 
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Remove yarn install from config

## Why
<!-- Add a short answer for: Why it was done? (E.g The feature X was deprecated.) -->

Yarn binary appears to have been added by the circleci team *not* using npm, so when we try to install it via npm it throws a conflict, as seen in CI failures [here](https://circleci.com/gh/integr8ly/tutorial-web-app/1730?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) and [here](https://circleci.com/gh/integr8ly/tutorial-web-app/1731?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)


## How
<!-- Add a short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) -->

Remove yarn install line from config

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

Check CI below passes and does not fail on any yarn steps or with the failure seen on the jobs mentioned above.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
