### PR TITLE
INTLY-2830 - Fix webapp logout on os4 clusters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.20.9",
+  "version": "2.20.10",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -641,6 +641,7 @@ function getConfigData(req) {
 
   const masterUri = isOpenShift4() ? OPENSHIFT_PROXY_PATH : `https://${process.env.OPENSHIFT_HOST}`;
   const wssMasterUri = isOpenShift4() ? OPENSHIFT_PROXY_PATH : `wss://${process.env.OPENSHIFT_HOST}`;
+  const ssoLogoutUri = isOpenShift4() ? '/' : `https://${process.env.SSO_ROUTE}/auth/realms/openshift/protocol/openid-connect/logout?redirect_uri=${logoutRedirectUri}`;
 
   const installedServices = process.env.INSTALLED_SERVICES || '{}';
   return `window.OPENSHIFT_CONFIG = {
@@ -651,9 +652,7 @@ function getConfigData(req) {
     scopes: ['user:full'],
     masterUri: '${masterUri}',
     wssMasterUri: '${wssMasterUri}',
-    ssoLogoutUri: 'https://${
-      process.env.SSO_ROUTE
-    }/auth/realms/openshift/protocol/openid-connect/logout?redirect_uri=${logoutRedirectUri}',
+    ssoLogoutUri: '${ssoLogoutUri}',
     threescaleWildcardDomain: '${process.env.THREESCALE_WILDCARD_DOMAIN || ''}',
     integreatlyVersion: '${process.env.INTEGREATLY_VERSION || ''}',
     clusterType: '${process.env.CLUSTER_TYPE || ''}',

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -193,7 +193,10 @@ const finishOAuth = () => {
  * logout state change in your App by navigating elsewhere
  * or reloading your App.
  */
-const logout = () => deleteCurrentSessionAuthToken().then(() => setUser(null));
+const logout = () =>
+  deleteCurrentSessionAuthToken().then(response => {
+    setUser(null);
+  });
 
 /**
  * Retrieve a single parameter value from a URL that contains a query string


### PR DESCRIPTION
## Motivation
Logout from the webapp is currently broken on OS4 cluster. This pull request fixes this bug allowing logout on OS4 clusters.

Jira:
*  https://issues.redhat.com/browse/INTLY-2830

Associated pull requests:
* https://github.com/integr8ly/tutorial-web-app-operator/pull/83
* https://github.com/integr8ly/integreatly-operator/pull/298

## What
* The `deleteCurrentSessionAuthToken` method was modified to return the promise to ensure the `OauthAccessToken` is deleted before logging out the user. 
* In addition, the SSO logout route is now configured to redirect to the root instead of to RHSSO logout as this would fail anyhow with a `invalid_indirect error`due to missing client for this (not needed for this)

## Verification Steps
### OS4
1. Install integreatly
2. Run the webapp locally (point to an OpenShift cluster) or update your webapp deployment to use the image 
* `oc edit deployment tutorial-web-app-operator -n rhmi-solution-explorer`
* Change image to ` quay.io/kevfan/tutorial-web-app-operator:v0.0.42`
3. Run the `./scripts/setup-htpass-idp.sh` to create sample users
4. Visit solution explorer and sign in / sign out ensuring there are no errors with the sign out
**Note: There is an known issue where logging out using kubeadmin would sign the user back in. Just testing the users created from the script should be fine**
### OS3
1. Edit tutorial web app deployment config and use `quay.io/kevfan/tutorial-web-app:2.20.10` as the container image.
2. Ensure user signin and signout still works as expected on an OS3 cluster
## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
