### PR TITLE
INTLY-4959 - fix sorting service crashes on login on os4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -101,7 +101,7 @@ const getProductDetailsForServiceClass = serviceClassName => {
 };
 
 const getServiceSortOrder = svc => {
-  const serviceClassName = svc.spec.clusterServiceClassExternalName;
+  const serviceClassName = isOpenShift4() ? svc.name : svc.spec.clusterServiceClassExternalName;
   const keys = Object.keys(productDetails);
   const serviceOrder = keys.indexOf(serviceClassName);
 


### PR DESCRIPTION
## Motivation
On OS4, login is broken due to the object returned when calling `getServiceSortOrder()` does not contain a spec object causing an undefined error and crashing the webapp on login

Jira:
* https://issues.redhat.com/browse/INTLY-4959

## What
* If cluster is OS4, get the service name from `svc.name` instead of `svc.spec.clusterServiceClassExternalName`

## Verification Steps
1. Install integreatly on a OS4 cluster
2. Scale down the web app operator to prevent it reconciling back to specified image
* `oc edit deployment tutorial-web-app-operator -n rhmi-solution-explorer`
3. Change image to ` quay.io/kevfan/tutorial-web-app:2.21.1` on tutoiral web app deployment config
* `oc edit deploymentconfig tutorial-web-app -n rhmi-solution-explorer`
4. Run the `./scripts/setup-htpass-idp.sh` to create sample users
5. Visit solution explorer and ensure you can sign in and sign out without errors with the created users
**Note: There is an known issue where logging out using kubeadmin would sign the user back in. Just testing the users created from the script should be fine**

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
