### PR TITLE
Fixes missing key console error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -131,7 +131,7 @@ class InstalledAppsView extends React.Component {
   };
 
   getOpenshiftConsole = index => (
-    <li>
+    <li key="openshift_console_list">
       <DataList
         aria-label="OpenShift console datalist"
         key="openshift_console"
@@ -304,7 +304,7 @@ class InstalledAppsView extends React.Component {
         const { description, gaStatus, hidden, prettyName, primaryTask } = getProductDetails(app);
         const uniqKey = this.genUniqueKeyForService(app);
         return hidden ? null : (
-          <li>
+          <li key={uniqKey}>
             <DataList
               aria-label="Cluster service datalist"
               key={`${


### PR DESCRIPTION
## Motivation
Console errors starting appearing after accessibility changes, a list item without a specific key was added to a couple arrays: 
```
Warning: Each child in an array or iterator should have a unique "key" prop.
Check the render method of `InstalledAppsView`. See https://fb.me/react-warning-keys for more information.
    in li (at InstalledAppsView.js:134)
    in InstalledAppsView (at landingPage.js:106)
.
.
.

```
## What
Added a key for the openshift li and a unique key for the other services based on server name.

## Verification Steps
1. Go to the default dashboard page of the Solution Explorer and open the console window.
2. Verify that the specific error noted above no longer appears.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task
