### PR TITLE
INTLY-5026: Align pretty names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/styles/application/components/_installedAppsView.scss
+++ b/src/styles/application/components/_installedAppsView.scss
@@ -72,8 +72,8 @@
   }
 }
 
-.pf-c-data-list__item-action {
-  display: block !important;
+.pf-c-data-list__item-action { /* stylelint-disable-line selector-class-pattern */
+  display: block !important; /* stylelint-disable-line declaration-no-important */
   min-width: 30%;
 
   > * {

--- a/src/styles/application/components/_installedAppsView.scss
+++ b/src/styles/application/components/_installedAppsView.scss
@@ -71,3 +71,16 @@
     padding-top: 1px !important; /* stylelint-disable-line declaration-no-important */
   }
 }
+
+.pf-c-data-list__item-action {
+  display: block !important;
+  min-width: 30%;
+
+  > * {
+    text-align: right;
+  }
+
+  @media (max-width: 600px) {
+    min-width: initial;
+  }
+}


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-5026

## What
Fixes an issue on the dashboard in which the pretty names were no longer left-aligned if the size of the 'Open console' buttons became larger, as is the case when they display 'Start Service' with icon. 

## Why
Pretty names did not align properly if there was a mixed size of launch buttons on the right.

## Verification Steps
Verify that the pretty names are always left-aligned despite the size of the 'open console' buttons. 

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
**Before:**
![before-lg-btn](https://user-images.githubusercontent.com/39063664/73295178-3ae2c100-41d5-11ea-94a1-a432bd15e2a8.png)

**After:**
![after-lg-btn](https://user-images.githubusercontent.com/39063664/73295184-3d451b00-41d5-11ea-9785-cd6d3b2f3661.png)
