### PR TITLE
INTLY-5299: Support additional admonition styles

### DIFF
--- a/src/styles/application/utilities/_patternfly4.scss
+++ b/src/styles/application/utilities/_patternfly4.scss
@@ -39,7 +39,11 @@ button,
     }
   }
 
-  .admonitionblock.note {
+  .admonitionblock.note,
+  .admonitionblock.tip,
+  .admonitionblock.caution,
+  .admonitionblock.important,
+  .admonitionblock.warning {
     margin-bottom: var(--pf-c-content--MarginBottom);
     padding: var(--pf-global--spacer--md);
     font-weight: var(--pf-c-content--blockquote--FontWeight);


### PR DESCRIPTION
## Motivation
Support the additional admonition styles from AsciiDoc:
 - TIP
 - IMPORTANT
 - CAUTION
 - WARNING

## What
Added the following classes to `.admonitionblock`:
```
.admonitionblock.tip,
.admonitionblock.note,
.admonitionblock.important,
.admonitionblock.warning
```

## Why
Complete INTLY-5299

## How
Added classes that match AsciiDoc injections.

## Verification Steps

1. Go to a walkthrough
2. Either find an item with one of the five admonition types
3. Verify that the styles are working
4. If desired, edit the code in the inspector to use one of the other admonition types

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

<img width="633" alt="Screen Shot 2020-02-11 at 2 55 26 PM" src="https://user-images.githubusercontent.com/4032718/74275591-2842ae80-4ce2-11ea-8f71-1beef8a08432.png">
