### PR TITLE
INTLY-5251: Order of Solution Patterns keeps changing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/tutorialDashboard/tutorialDashboard.js
+++ b/src/components/tutorialDashboard/tutorialDashboard.js
@@ -10,6 +10,12 @@ import { connect, reduxActions } from '../../redux';
 const TutorialDashboard = props => {
   const { walkthroughs, userProgress } = props;
 
+  function walkthroughSorter(w1, w2) {
+    const a = `${w1.id} ${w1.title}`;
+    const b = `${w2.id} ${w2.title}`;
+    return a < b ? -1 : 1;
+  }
+
   function filterWalkthroughs(walkthrus, filter) {
     let result = [];
     if (walkthrus[0]) {
@@ -56,7 +62,7 @@ const TutorialDashboard = props => {
     for (let i = 0; i < allRepos.length; i++) {
       const filteredWalkthroughs = filterWalkthroughs(walkthrus, allRepos[i]);
 
-      const cards = filteredWalkthroughs.map(walkthrough => {
+      const cards = filteredWalkthroughs.sort(walkthroughSorter).map(walkthrough => {
         const currentProgress = userProgress[walkthrough.id];
         let startedText;
         if (currentProgress === undefined) startedText = 'Get Started';


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-5251

## What
The order of solution patterns seems to change, and/or is not consistent with the order that is desired. 

## Why
When we added the sort by % complete, the sort order by 'id' was removed. When we removed the sort by % complete, we did not add a new sort back. So there was no sort at all, which could lead to inconsistent display of the solution patterns.

## How
Added a sort by ID as it was originally - keep in mind that 'ID' as it stands now means the name of the directory in which the walkthrough resides. It sort by this name, alphabetically, and then by walkthrough name, alphabetically. So if you name your prepend the names of your directories 1, 2, 3, etc you can force a repeatable order.

## Verification Steps
Go to the 'All Solution Patterns' tab and verify that the order of the SPs are in the same alphabetical order as the directories in which they are contained. Also, add your own test walkthrough repo using the **Settings > Git URLs for subscribed content** and verify that the SPs appear in the desired order.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
You can use my cluster to test if you want:
https://tutorial-web-app-webapp.apps.uxddev-90fa.open.redhat.com/

Or point to my solution explore image on your own cluster:
docker.io/mfrances17/dev-tutorial-web-app:latest

**Screen caps:**
**Red Hat default walkthrough dir names:**
![default-repo](https://user-images.githubusercontent.com/39063664/74684349-a8ad5780-5199-11ea-8cb2-b020b94d4d88.png)

**Red Hat default walkthrough display order:**
![default-display](https://user-images.githubusercontent.com/39063664/74684354-ac40de80-5199-11ea-8151-d2e8f3825bdd.png)

**Tiffany's walkthrough repo dir names:**
![tiff-repo](https://user-images.githubusercontent.com/39063664/74684365-b236bf80-5199-11ea-9b0a-5ea79ff6c2f3.png)

**Tiffany's walkthrough display order:**
![tiff-display](https://user-images.githubusercontent.com/39063664/74684375-b531b000-5199-11ea-8caa-88db0dccadd8.png)

