### PR TITLE
INTLY-5532: Fix drop-down arrow animation in Managed Services tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.21.4",
+  "version": "2.21.5",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -143,7 +143,7 @@ class InstalledAppsView extends React.Component {
           key={`openshift_console_${index}`}
           value={index}
           aria-labelledby={`openshift-console-datalistitem-${index}`}
-          aria-label={`Installed application list item ${index}`}
+          aria-label={`Openshift application list item ${index}`}
         >
           <DataListItemRow>
             <DataListToggle
@@ -319,12 +319,13 @@ class InstalledAppsView extends React.Component {
                 className={
                   this.isServiceProvisioned(app) ? 'integr8ly-installed-apps-view-list-item-enabled' : '&nbsp;'
                 }
-                isExpanded={this.state.expanded.includes(`list-item-${index}`)}
+                isExpanded={this.state.expanded.includes(`app-toggle-${index}`)}
                 key={`${uniqKey}_${index}`}
                 value={index}
                 id={`list-item-${index}`}
-                aria-controls={`app-expand-${index}`}
+                // aria-controls={`app-expand-${index}`}
                 aria-labelledby={`cluster-service-datalist-item-${index}`}
+                aria-label={`Installed application list item ${index}`}
               >
                 <DataListItemRow className="integr8ly-installed-apps-row">
                   <DataListToggle

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -323,7 +323,6 @@ class InstalledAppsView extends React.Component {
                 key={`${uniqKey}_${index}`}
                 value={index}
                 id={`list-item-${index}`}
-                // aria-controls={`app-expand-${index}`}
                 aria-labelledby={`cluster-service-datalist-item-${index}`}
                 aria-label={`Installed application list item ${index}`}
               >
@@ -384,7 +383,6 @@ class InstalledAppsView extends React.Component {
                   >
                     <div className="integr8ly-state-ready">{this.getStatusForApp(app, prettyName)}</div>
                     {enableLaunch && this.isServiceUnready(app) ? (
-                      // <div className="pf-u-display-flex pf-u-justify-content-flex-end">
                       <div className="integr8ly-state-provisioining">
                         <Button onClick={() => launchHandler(app)} variant="secondary">
                           <OffIcon />


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-5532

## What
Only the first service's drop-down arrow (Openshift) was animating e.g. pointing down when clicked, all others were frozen even though the hidden content was displayed correctly.

## Why
Consistency and making the arrows function as designed.

## How
The wrong ID was used for all drop downs except the first, which caused the function to expand the content to fail.

## Verification Steps
1. Go to the Managed Services tab.
2. Click the drop-down arrow for all of the services to verify that the arrow is now animated when clicked and the drop-down content is hidden/shown.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
You can pull down this repo and test the changes locally, or use my cluster to verify:
https://tutorial-web-app-webapp.apps.uxddev-90fa.open.redhat.com/

Or you can install my tutorial-web-app docker image on your own cluster:
docker.io/mfrances17/dev-tutorial-web-app:latest
