### PR TITLE
OS4: don't process templates, add additional WT attributes

### DIFF
--- a/server.js
+++ b/server.js
@@ -639,12 +639,13 @@ function getConfigData(req) {
     process.env.OPENSHIFT_OAUTH_HOST = process.env.OPENSHIFT_HOST;
   }
 
-  const masterUri = `https://${process.env.OPENSHIFT_HOST}`;
+  const masterUri = isOpenShift4() ? OPENSHIFT_PROXY_PATH : `https://${process.env.OPENSHIFT_HOST}`;
   const wssMasterUri = isOpenShift4() ? OPENSHIFT_PROXY_PATH : `wss://${process.env.OPENSHIFT_HOST}`;
   const ssoLogoutUri = isOpenShift4() ? '/' : `https://${process.env.SSO_ROUTE}/auth/realms/openshift/protocol/openid-connect/logout?redirect_uri=${logoutRedirectUri}`;
 
   const installedServices = process.env.INSTALLED_SERVICES || '{}';
   return `window.OPENSHIFT_CONFIG = {
+    openshiftHost: 'https://${process.env.OPENSHIFT_HOST}',
     clientId: '${process.env.OPENSHIFT_OAUTHCLIENT_ID}',
     accessTokenUri: 'https://${process.env.OPENSHIFT_OAUTH_HOST}/oauth/token',
     authorizationUri: 'https://${process.env.OPENSHIFT_OAUTH_HOST}/oauth/authorize',

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -20,7 +20,10 @@ const getDocsForWalkthrough = (walkthroughId, middlewareServices, walkthroughRes
 
 const getUserAttrs = (walkthroughId, username) => {
   let attrs = {
-    'openshift-host': window.OPENSHIFT_CONFIG.masterUri
+    'openshift-host':
+      window.OPENSHIFT_CONFIG.openshiftVersion === 4
+        ? window.OPENSHIFT_CONFIG.openshiftHost
+        : window.OPENSHIFT_CONFIG.masterUri
   };
   if (username) {
     attrs = Object.assign({}, attrs, {

--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -58,7 +58,7 @@ const DEFAULT_SERVICES = {
   CHE: 'codeready',
   LAUNCHER: 'launcher',
   THREESCALE: '3scale',
-  APICURIO: 'apicurio',
+  APICURIO: 'apicurito',
   FUSE_MANAGED: 'fuse-managed',
   RHSSO: 'rhsso',
   USER_RHSSO: 'user-rhsso'

--- a/src/components/aboutModal/aboutModal.js
+++ b/src/components/aboutModal/aboutModal.js
@@ -52,7 +52,7 @@ class AboutModal extends React.Component {
         >
           <TextContent>
             <TextList component="dl">
-              <TextListItem component="dt">Integreatly Version</TextListItem>
+              <TextListItem component="dt">RHMI Version</TextListItem>
               <TextListItem component="dd">
                 {window.OPENSHIFT_CONFIG ? window.OPENSHIFT_CONFIG.integreatlyVersion : ' '}
               </TextListItem>

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -193,8 +193,8 @@ class InstalledAppsView extends React.Component {
               <div className="integr8ly-state-ready">
                 <Button
                   onClick={() => {
-                    const suffix = window.OPENSHIFT_CONFIG.openshiftVersion === '4' ? 'dashboards' : 'console';
-                    window.open(`${window.OPENSHIFT_CONFIG.masterUri}/${suffix}`, '_blank');
+                    const suffix = window.OPENSHIFT_CONFIG.openshiftVersion === 4 ? 'dashboards' : 'console';
+                    window.open(`${window.OPENSHIFT_CONFIG.openshiftHost}/${suffix}`, '_blank');
                   }}
                   variant="secondary"
                 >

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -6,11 +6,11 @@ export default {
     primaryTask: 'Online IDE',
     description: 'A developer workspace server and cloud IDE.'
   },
-  apicurio: {
+  apicurito: {
     prettyName: 'API Designer',
     gaStatus: 'GA',
     primaryTask: 'Design APIs',
-    description: 'The Apicurito RESTful API visual designer.'
+    description: 'Quickly design your own REST APIs without writing any code.'
   },
   '3scale': {
     prettyName: 'Red Hat 3scale API Management Platform',

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import ClientOAuth2 from 'client-oauth2';
 import { isOpenShift4, getMasterUri, getWSMasterUri } from '../common/openshiftHelpers';
-import { processedTemplateDefV4 } from '../common/openshiftResourceDefinitions';
 
 const KIND_ROUTE = 'Route';
 
@@ -301,30 +300,18 @@ const create = (res, obj) =>
 
 const processV4 = (namespace, template) => {
   getUser().then(user => {
-    const requestUrl = `${_buildRequestUrl(processedTemplateDefV4(namespace))}`;
-
-    return axios({
-      url: requestUrl,
-      method: 'POST',
-      data: template,
-      headers: {
-        authorization: `Bearer ${user.access_token}`
-      }
-    }).then(resp => {
-      const items = resp.data.objects;
-
-      const processTasks = items.map(i =>
-        axios({
-          url: _buildProcessUrl(namespace, i),
-          method: 'POST',
-          data: i,
-          headers: {
-            authorization: `Bearer ${user.access_token}`
-          }
-        })
-      );
-      return Promise.all(processTasks);
-    });
+    const items = template.objects;
+    const processTasks = items.map(i =>
+      axios({
+        url: _buildProcessUrl(namespace, i),
+        method: 'POST',
+        data: i,
+        headers: {
+          authorization: `Bearer ${user.access_token}`
+        }
+      })
+    );
+    return Promise.all(processTasks);
   });
 };
 

--- a/src/services/walkthroughServices.js
+++ b/src/services/walkthroughServices.js
@@ -123,7 +123,13 @@ const prepareWalkthroughV4 = (dispatch, walkthroughName, attrs = {}) => {
         }
 
         const nsName = walkthroughNs.metadata.name;
-        const mergedAttrs = Object.assign({}, ...svcAttrs.map(a => a.additionalAttributes));
+
+        const mergedAttrs = Object.assign(
+          {
+            'user-username': user.username
+          },
+          ...svcAttrs.map(a => a.additionalAttributes)
+        );
 
         const templateTasks = manifest.dependencies.templates.map(rawTemplate => {
           const template = parseTemplate(rawTemplate, mergedAttrs);


### PR DESCRIPTION
Compatibility fixes for OS4:

1. Do not process the templates on OS4, this will fail. Instead, only create the objects inside the templates.
2. Rename `Integreatly Version` to `RHMI Version` in the about modal
3. Expose `openshiftHost` to the webapp because `masterUri` is only used for API calls on OS4
4. Expose `user-username` as an attribute to walkthroughs
5. Apirucio -> Apicurito