### PR TITLE
fix: user showing undefined on first login

### DIFF
--- a/src/components/masthead/__tests__/__snapshots__/masthead.test.js.snap
+++ b/src/components/masthead/__tests__/__snapshots__/masthead.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Masthead Component should render a basic component: basic 1`] = `
 <Masthead
+  currentUserName={null}
   history={
     Object {
       "push": [Function],

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -216,7 +216,7 @@ class Masthead extends React.Component {
                 isOpen={isUserDropdownOpen}
                 toggle={
                   <DropdownToggle onToggle={this.onUserDropdownToggle}>
-                    {window.localStorage.getItem('currentUserName')}
+                    {this.props.currentUserName || window.localStorage.getItem('currentUserName')}
                   </DropdownToggle>
                 }
                 autoFocus={false}
@@ -250,12 +250,14 @@ class Masthead extends React.Component {
 }
 
 Masthead.propTypes = {
+  currentUserName: PropTypes.string,
   history: PropTypes.shape({
     push: PropTypes.func.isRequired
   })
 };
 
 Masthead.defaultProps = {
+  currentUserName: null,
   history: {
     push: noop
   }

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -20,7 +20,8 @@ class LandingPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      activeTabKey: 0
+      activeTabKey: 0,
+      currentUserName: null
     };
 
     this.contentRef1 = React.createRef();
@@ -39,6 +40,11 @@ class LandingPage extends React.Component {
     getCustomWalkthroughs();
     resetCurrentWalkthrough();
     getProgress();
+    currentUser().then(user => {
+      if (user) {
+        this.setState({ currentUserName: user.fullName ? user.fullName : user.username });
+      }
+    });
   }
 
   handleServiceLaunchV4(svcName) {
@@ -74,7 +80,7 @@ class LandingPage extends React.Component {
     return (
       <React.Fragment>
         <Page className="pf-u-h-100vh">
-          <RoutedConnectedMasthead />
+          <RoutedConnectedMasthead currentUserName={this.state.currentUserName} />
           <PageSection variant={PageSectionVariants.light} className="pf-u-py-0 pf-u-pl-lg pf-u-pr-0">
             <h1 className="pf-c-title pf-m-4xl pf-c-landing__heading">Welcome to the Solution Explorer</h1>
             <p className="pf-c-landing__content">


### PR DESCRIPTION
Fixes the issue where on first login the username is showing `undefined`:

![login_undefined](https://user-images.githubusercontent.com/1851198/75775404-353b4680-5d52-11ea-8bdf-d5cdb065427b.png)

This only happens on the landing page because the masthead is rendered before the user is set in the localStorage. The fix is to make the current user a part of the LandingPage state and update it once the user becomes available. This triggers the user dropdown to rerender automatically and show the correct user name.