### PR TITLE
"INTLY-5257: Fixed local development mock user error message."

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -19,4 +19,4 @@ REACT_APP_FUSE_URL=http://localhost:3006
 REACT_APP_LAUNCHER_URL=http://localhost:3006
 REACT_APP_CHE_URL=http://localhost:3006
 REACT_APP_ENMASSE_URL=http://localhost:3006
-REACT_APP_APICURIO_URL=http://localhost:3006
+REACT_APP_APICURITO_URL=http://localhost:3006

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -48,9 +48,9 @@ parameters:
     displayName: Che URL (used when mocking the services list)
     value: http://localhost:3006
     required: false
-  - name: REACT_APP_APICURIO_URL
-    description: Apicurio URL (used when mocking the services list)
-    displayName: Apicurio URL (used when mocking the services list)
+  - name: REACT_APP_APICURITO_URL
+    description: Apicurito URL (used when mocking the services list)
+    displayName: Apicurito URL (used when mocking the services list)
     value: http://localhost:3006
     required: false
   - name: REACT_APP_ENMASSE_URL
@@ -119,8 +119,8 @@ objects:
             value: ${REACT_APP_CHE_URL}
           - name: REACT_APP_ENMASSE_URL
             value: ${REACT_APP_ENMASSE_URL}
-          - name: REACT_APP_APICURIO_URL
-            value: ${REACT_APP_APICURIO_URL}
+          - name: REACT_APP_APICURITO_URL
+            value: ${REACT_APP_APICURITO_URL}
           - name: OUTPUT_DIR
             value: ${OUTPUT_DIR}
           - name: YARN_ENABLED

--- a/deployment/openshift-template.yml
+++ b/deployment/openshift-template.yml
@@ -31,8 +31,8 @@ parameters:
   - name: CHE_URL
     description: Mock URL for Che. Only used if OPENSHIFT_HOST is empty
     required: false
-  - name: APICURIO_URL
-    description: Mock URL for Apicurio. Only used if OPENSHIFT_HOST is empty
+  - name: APICURITO_URL
+    description: Mock URL for Apicurito. Only used if OPENSHIFT_HOST is empty
     required: false
   - name: ENMASSE_URL
     description: Mock URL for EnMasse. Only used if OPENSHIFT_HOST is empty

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "watch:css": "yarn build:css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/styles/index.scss -o src/styles/.css --watch --recursive",
     "build:js": "react-scripts build",
     "start": "node server.js",
-    "start:dev": "FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 APICURIO_URL=http://localhost:3006 run-p -l watch:css start:local start:server",
+    "start:dev": "FUSE_URL=http://localhost:3006 LAUNCHER_URL=http://localhost:3006 ENMASSE_URL=http://localhost:3006 CHE_URL=http://localhost:3006 APICURITO_URL=http://localhost:3006 run-p -l watch:css start:local start:server",
     "start:local": "react-scripts start",
     "start:server": "nodemon --watch server.js --exec 'node server.js'",
     "commit:hash": "echo REACT_APP_UI_COMMIT_HASH=$(git rev-list -1 --all) > .env",

--- a/server.js
+++ b/server.js
@@ -516,6 +516,13 @@ function getMockConfigData() {
     optionalWatchServices: [],
     optionalProvisionServices: [],
     mockData: {
+      mockUser: {
+        metadata: {
+          uid: '_mock_usr_1',
+          name: 'mockUser'
+        },
+        fullName: 'Mock User'
+      },
       serviceInstances: [
         {
           spec: {
@@ -591,7 +598,7 @@ function getMockConfigData() {
         },
         {
           spec: {
-            clusterServiceClassExternalName: 'apicurio'
+            clusterServiceClassExternalName: 'apicurito'
           },
           status: {
             dashboardURL:'${process.env.OPENSHIFT_URL}',

--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -82,7 +82,7 @@ const getMiddlewareServiceAttrs = middlewareServices => {
     'amq-broker-amqp-url': middlewareServices.amqCredentials.url,
     'amq-credentials-username': middlewareServices.amqCredentials.username,
     'amq-credentials-password': middlewareServices.amqCredentials.password,
-    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO)
+    'apicurito-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURITO)
   };
 
   if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.optionalProvisionServices.length > 0) {

--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -59,7 +59,7 @@ const DEFAULT_SERVICES = {
   CHE: 'codeready',
   LAUNCHER: 'launcher',
   THREESCALE: '3scale',
-  APICURIO: 'apicurito',
+  APICURITO: 'apicurito',
   FUSE_MANAGED: 'fuse-managed',
   RHSSO: 'rhsso',
   USER_RHSSO: 'user-rhsso'

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -32,7 +32,7 @@ let defaultWatchServices = [
   DEFAULT_SERVICES.CHE,
   DEFAULT_SERVICES.LAUNCHER,
   DEFAULT_SERVICES.THREESCALE,
-  DEFAULT_SERVICES.APICURIO,
+  DEFAULT_SERVICES.APICURITO,
   DEFAULT_SERVICES.FUSE_MANAGED,
   DEFAULT_SERVICES.FUSE,
   DEFAULT_SERVICES.ENMASSE,
@@ -52,7 +52,7 @@ const DISPLAY_SERVICES = [DEFAULT_SERVICES.ENMASSE];
 const PROVISION_SERVICES_OPENSHIFT_3 = [
   DEFAULT_SERVICES.CHE,
   DEFAULT_SERVICES.LAUNCHER,
-  DEFAULT_SERVICES.APICURIO,
+  DEFAULT_SERVICES.APICURITO,
   DEFAULT_SERVICES.THREESCALE,
   DEFAULT_SERVICES.FUSE_MANAGED,
   DEFAULT_SERVICES.RHSSO,
@@ -117,8 +117,6 @@ const mockMiddlewareServices = (dispatch, mockData) => {
   if (!mockData || !mockData.serviceInstances) {
     return;
   }
-  const mockUsername = 'mockuser';
-  window.localStorage.setItem('currentUserName', mockUsername);
   mockData.serviceInstances.forEach(si => {
     dispatch({
       type: FULFILLED_ACTION(middlewareTypes.CREATE_WALKTHROUGH),

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -108,7 +108,7 @@ class OpenShiftPollEventListener {
 const getUser = () => {
   // Don't start the OAuth flow when in mock mode. Just resolve an empty user
   if (window.OPENSHIFT_CONFIG.mockData) {
-    return new Promise(resolve => resolve({}));
+    return new Promise(resolve => resolve(window.OPENSHIFT_CONFIG.mockData.mockUser));
   }
   let user;
   try {
@@ -218,14 +218,18 @@ const currentUser = () => {
   const url = isOpenShift4()
     ? `${getMasterUri()}/apis/user.openshift.io/v1/users/~`
     : `${getMasterUri()}/oapi/v1/users/~`;
-  return getUser().then(user =>
-    axios({
-      url,
-      headers: {
-        authorization: `Bearer ${user.access_token}`
-      }
-    }).then(response => new OpenShiftUser(response.data))
-  );
+  return getUser().then(user => {
+    if (window.OPENSHIFT_CONFIG.mockData) {
+      Promise.resolve(new OpenShiftUser(user));
+    } else {
+      axios({
+        url,
+        headers: {
+          authorization: `Bearer ${user.access_token}`
+        }
+      }).then(response => new OpenShiftUser(response.data));
+    }
+  });
 };
 
 const get = (res, name) =>


### PR DESCRIPTION
This fixes the errors that are seen when running the local development environment.  Errors where related to Apicurito URL and an empty mock user object that was being returned.  We now have mock user that is being created as part of mock data in server.js