### PR TITLE
INTLY-5357: New help URLs for OS4

### DIFF
--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -128,11 +128,20 @@ class Masthead extends React.Component {
       onClick: () => this.onTitleClick()
     };
 
-    const gsUrl =
-      'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/getting_started/';
-    const riUrl =
-      'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/release_notes/';
+    let gsUrl = '';
+    let riUrl = '';
     const csUrl = 'https://access.redhat.com/support/';
+
+    if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.openshiftVersion === 3) {
+      gsUrl =
+        'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/getting_started/';
+      riUrl = 'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/release_notes/';
+    } else {
+      gsUrl =
+        'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2.0/html-single/getting_started_with_red_hat_managed_integration_2.0/';
+      riUrl =
+        'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2.0/html-single/release_notes_for_red_hat_managed_integration_2.0/';
+    }
 
     const MastheadToolbar = (
       <React.Fragment>


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-5357

## What
Add new help URLs for getting started and release notes links.

## Why
They are different than those for OpenShift 3.

## How
Added a simple check for OS version and loaded the correct URL for OS3 and 4. The original request was to put a variable in for each URL that changes based on OS version, but the URLs provided were not consistent from one release to the other so that wouldn't work. It could be done going forward if the doc URLs for the next version of OpenShift docs are consistent with the OS4 doc URLs.

## Verification Steps
Verify that OS3 links and OS4 links both navigate to the correct URLs for getting started and release notes. 

NOTE: as of this PR, the URLs for the OS4 getting started and release notes do NOT work as provided in the above JIRA issue. I'm assuming that they are still being worked on... will need to verify.

https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2.0/html-single/getting_started_with_red_hat_managed_integration_2.0/

https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2.0/html-single/release_notes_for_red_hat_managed_integration_2.0/

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

