### PR TITLE
Fix local build and run issues

### DIFF
--- a/server.js
+++ b/server.js
@@ -523,6 +523,13 @@ function getMockConfigData() {
     optionalWatchServices: [],
     optionalProvisionServices: [],
     mockData: {
+      mockUser: {
+        metadata: {
+          uid: '_mock_usr_1',
+          name: 'mockUser'
+        },
+        fullName: 'Mock User'
+      },
       serviceInstances: [
         {
           spec: {
@@ -598,7 +605,7 @@ function getMockConfigData() {
         },
         {
           spec: {
-            clusterServiceClassExternalName: 'apicurio'
+            clusterServiceClassExternalName: 'apicurito'
           },
           status: {
             dashboardURL:'${process.env.OPENSHIFT_URL}',

--- a/src/services/middlewareServices.js
+++ b/src/services/middlewareServices.js
@@ -117,8 +117,6 @@ const mockMiddlewareServices = (dispatch, mockData) => {
   if (!mockData || !mockData.serviceInstances) {
     return;
   }
-  const mockUsername = 'mockuser';
-  window.localStorage.setItem('currentUserName', mockUsername);
   mockData.serviceInstances.forEach(si => {
     dispatch({
       type: FULFILLED_ACTION(middlewareTypes.CREATE_WALKTHROUGH),

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -108,7 +108,8 @@ class OpenShiftPollEventListener {
 const getUser = () => {
   // Don't start the OAuth flow when in mock mode. Just resolve an empty user
   if (window.OPENSHIFT_CONFIG.mockData) {
-    return new Promise(resolve => resolve({}));
+    // return new Promise(resolve => resolve({}));
+    return new Promise(resolve => resolve(window.OPENSHIFT_CONFIG.mockData.mockUser));
   }
   let user;
   try {
@@ -218,14 +219,18 @@ const currentUser = () => {
   const url = isOpenShift4()
     ? `${getMasterUri()}/apis/user.openshift.io/v1/users/~`
     : `${getMasterUri()}/oapi/v1/users/~`;
-  return getUser().then(user =>
-    axios({
-      url,
-      headers: {
-        authorization: `Bearer ${user.access_token}`
-      }
-    }).then(response => new OpenShiftUser(response.data))
-  );
+  return getUser().then(user => {
+    if (window.OPENSHIFT_CONFIG.mockData) {
+      Promise.resolve(new OpenShiftUser(user));
+    } else {
+      axios({
+        url,
+        headers: {
+          authorization: `Bearer ${user.access_token}`
+        }
+      }).then(response => new OpenShiftUser(response.data));
+    }
+  });
 };
 
 const get = (res, name) =>

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -108,7 +108,6 @@ class OpenShiftPollEventListener {
 const getUser = () => {
   // Don't start the OAuth flow when in mock mode. Just resolve an empty user
   if (window.OPENSHIFT_CONFIG.mockData) {
-    // return new Promise(resolve => resolve({}));
     return new Promise(resolve => resolve(window.OPENSHIFT_CONFIG.mockData.mockUser));
   }
   let user;


### PR DESCRIPTION
## Motivation
The mock data needed to be changed to handle the name change to Apicurito as well as mock user.

## What
Added mock data to handle the above.

## Why
Solution explorer would run fine on a live cluster but the UI would not run locally, which is critical for UI development.

## Verification Steps
1. Run the solution explorer UI locally using 'yarn start:dev'.
2. Verify that the UI displays without freezing on the provisioning screen, or displaying an undefined error regarding the user (which halted progress when running on Chrome.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task
