### PR TITLE
Fix local run issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -598,7 +598,7 @@ function getMockConfigData() {
         },
         {
           spec: {
-            clusterServiceClassExternalName: 'apicurio'
+            clusterServiceClassExternalName: 'apicurito'
           },
           status: {
             dashboardURL:'${process.env.OPENSHIFT_URL}',

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -16,10 +16,12 @@ axios.interceptors.response.use(
 
 class OpenShiftUser {
   constructor(userRes) {
-    this.uid = userRes.metadata.uid;
-    this.username = userRes.metadata.name;
-    this.fullName = userRes.fullName;
-    window.localStorage.setItem('currentUserName', this.fullName ? this.fullName : this.username);
+    if (userRes !== undefined) {
+      this.uid = userRes.metadata.uid;
+      this.username = userRes.metadata.name;
+      this.fullName = userRes.fullName;
+      window.localStorage.setItem('currentUserName', this.fullName ? this.fullName : this.username);
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation
Local builds running the mock config won't run, they fail at the provisioning screen.

## What
Changed the name of apicurio in the mock config, and added a check for undefined to get around a user-related undefined error that would display in the browser.
 
## Verification Steps
1. Run yarn start:dev locally to verify that the solution explorer loads normally, e.g. makes it through the provision screen and no longer displays an undefined error on startup.
2. Run the code on a live OS4 system to verify that solution explorer loads as expected.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
You can point to the following docker image to test the changes on any live OS4 system:
docker.io/mfrances17/dev-tutorial-web-app:latest