### PR TITLE
Add 2.1 help urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -175,9 +175,9 @@ class Masthead extends React.Component {
       riUrl = 'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/release_notes/';
     } else {
       gsUrl =
-        'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2.0/html-single/getting_started_with_red_hat_managed_integration_2.0/';
+        'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2/html-single/getting_started_with_red_hat_managed_integration_2/';
       riUrl =
-        'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2.0/html-single/release_notes_for_red_hat_managed_integration_2.0/';
+        'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2/html-single/release_notes_for_red_hat_managed_integration_2/';
     }
 
     const MastheadToolbar = (


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-6524

## What
Change the help URLs for the getting started and release notes to the URLs provided by doc for the LA 2.1 release.

## Why
Help URLs have changed for 2.1.

## Verification Steps
1. On an OpenShift 3 or local system, select the Getting Started and Release Notes help commands and verify that they open the corresponding document. 
2. On an OpenShift 4 system, select the Getting Started and Release Notes help commands and verify that they open a 404 page (docs have not been updated on the web yet). Best you can do for now is just verify that the URLs appear in the browser address field as coded, with the 2's. 

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
If needed, you can use this docker image to test:
docker.io/mfrances17/dev-tutorial-web-app:latest
