### PR TITLE
fix(taskpage): add masthead to task page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -41,6 +41,7 @@ import {
 import ProvisioningScreen from '../../../components/provisioning/provisioningScreen';
 import { findServices } from '../../../common/serviceInstanceHelpers';
 import { isOpenShift4 } from '../../../common/openshiftHelpers';
+import { RoutedConnectedMasthead } from '../../../components/masthead/masthead';
 
 class TaskPage extends React.Component {
   constructor(props) {
@@ -414,6 +415,7 @@ class TaskPage extends React.Component {
         <React.Fragment>
           <Page className="pf-u-h-100vh">
             <SkipToContent href="#main-content">Skip to content</SkipToContent>
+            <RoutedConnectedMasthead/>
             <PageSection variant="light">
               <Breadcrumb
                 threadName={parsedThread.title}

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -26,7 +26,7 @@ import get from 'lodash.get';
 import { connect, reduxActions } from '../../../redux';
 import Breadcrumb from '../../../components/breadcrumb/breadcrumb';
 import ErrorScreen from '../../../components/errorScreen/errorScreen';
-import { PfMasthead, RoutedConnectedMasthead } from '../../../components/masthead/masthead';
+import { RoutedConnectedMasthead } from '../../../components/masthead/masthead';
 import WalkthroughResources from '../../../components/walkthroughResources/walkthroughResources';
 import { prepareCustomWalkthroughNamespace, prepareWalkthroughV4 } from '../../../services/walkthroughServices';
 import { getThreadProgress } from '../../../services/threadServices';
@@ -392,7 +392,7 @@ class TaskPage extends React.Component {
     if (thread.error || manifest.error) {
       return (
         <div>
-          <PfMasthead />
+          <RoutedConnectedMasthead />
           <ErrorScreen errorText={thread.errorMessage || manifest.errorMessage} />
         </div>
       );

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -26,7 +26,7 @@ import get from 'lodash.get';
 import { connect, reduxActions } from '../../../redux';
 import Breadcrumb from '../../../components/breadcrumb/breadcrumb';
 import ErrorScreen from '../../../components/errorScreen/errorScreen';
-import PfMasthead from '../../../components/masthead/masthead';
+import { PfMasthead, RoutedConnectedMasthead } from '../../../components/masthead/masthead';
 import WalkthroughResources from '../../../components/walkthroughResources/walkthroughResources';
 import { prepareCustomWalkthroughNamespace, prepareWalkthroughV4 } from '../../../services/walkthroughServices';
 import { getThreadProgress } from '../../../services/threadServices';
@@ -41,7 +41,6 @@ import {
 import ProvisioningScreen from '../../../components/provisioning/provisioningScreen';
 import { findServices } from '../../../common/serviceInstanceHelpers';
 import { isOpenShift4 } from '../../../common/openshiftHelpers';
-import { RoutedConnectedMasthead } from '../../../components/masthead/masthead';
 
 class TaskPage extends React.Component {
   constructor(props) {
@@ -415,7 +414,7 @@ class TaskPage extends React.Component {
         <React.Fragment>
           <Page className="pf-u-h-100vh">
             <SkipToContent href="#main-content">Skip to content</SkipToContent>
-            <RoutedConnectedMasthead/>
+            <RoutedConnectedMasthead />
             <PageSection variant="light">
               <Breadcrumb
                 threadName={parsedThread.title}


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-116

## What
Add masthead to all remaining pages in app

## Why
Ready for the cross-console nav

## How
Adding masthead component

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to the task pages
2. Check that there is a masthead on all pages
3. Report back if there is a missing masthead on a page I didn't catch
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="920" alt="Screen Shot 2020-04-15 at 5 10 16 PM" src="https://user-images.githubusercontent.com/20118816/79462597-b890be80-7fc5-11ea-895a-011fea52a575.png">

