### PR TITLE
fix(tutorial): add breadcrumb component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.4",
+  "version": "2.22.5",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -19,7 +19,7 @@ class Breadcrumb extends React.Component {
         <BreadcrumbItem to="#" onClick={this.homeClicked} id="breadcrumb-home">
           Home
         </BreadcrumbItem>
-        {isAllSolutionPattern && <BreadcrumbItem>Solution Pattern</BreadcrumbItem>}
+        {isAllSolutionPattern && <BreadcrumbItem>Solution Patterns</BreadcrumbItem>}
         {threadName && !taskPosition && <BreadcrumbItem isActive>{threadName}</BreadcrumbItem>}
         {threadName &&
           taskPosition && (

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -13,12 +13,13 @@ class Breadcrumb extends React.Component {
     }
   };
   render() {
-    const { t, threadName, threadId, totalTasks, taskPosition } = this.props;
+    const { t, threadName, threadId, totalTasks, taskPosition, isAllSolutionPattern } = this.props;
     return (
       <PfBreadcrumb aria-label="Breadcrumb">
         <BreadcrumbItem to="#" onClick={this.homeClicked} id="breadcrumb-home">
           Home
         </BreadcrumbItem>
+        { isAllSolutionPattern && <BreadcrumbItem>Solution Pattern</BreadcrumbItem> }
         {threadName && !taskPosition && <BreadcrumbItem isActive>{threadName}</BreadcrumbItem>}
         {threadName &&
           taskPosition && (
@@ -48,7 +49,9 @@ Breadcrumb.propTypes = {
   /** The total number of tasks for this walkthrough */
   totalTasks: PropTypes.number,
   /** Called when the home button is clicked */
-  homeClickedCallback: PropTypes.func
+  homeClickedCallback: PropTypes.func,
+  /** Checks to see if all solutions pattern is in path */
+  isAllSolutionPattern: PropTypes.bool
 };
 
 Breadcrumb.defaultProps = {
@@ -57,7 +60,8 @@ Breadcrumb.defaultProps = {
   threadId: null,
   taskPosition: null,
   totalTasks: null,
-  homeClickedCallback: undefined
+  homeClickedCallback: undefined,
+  isAllSolutionPattern: false
 };
 
 const RoutedBreadcrumb = withRouter(translate()(Breadcrumb));

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -19,7 +19,7 @@ class Breadcrumb extends React.Component {
         <BreadcrumbItem to="#" onClick={this.homeClicked} id="breadcrumb-home">
           Home
         </BreadcrumbItem>
-        { isAllSolutionPattern && <BreadcrumbItem>Solution Pattern</BreadcrumbItem> }
+        {isAllSolutionPattern && <BreadcrumbItem>Solution Pattern</BreadcrumbItem>}
         {threadName && !taskPosition && <BreadcrumbItem isActive>{threadName}</BreadcrumbItem>}
         {threadName &&
           taskPosition && (

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -39,6 +39,14 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
     </SkipToContent>
     <withRouter(Connect(Masthead)) />
     <PageSection
+      variant="light"
+    >
+      <withRouter()
+        homeClickedCallback={[Function]}
+        threadName="Example"
+      />
+    </PageSection>
+    <PageSection
       className="integr8ly-landing-page-tutorial-dashboard-section"
     >
       <Grid

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -43,6 +43,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
     >
       <withRouter()
         homeClickedCallback={[Function]}
+        isAllSolutionPattern="true"
         threadName="Example"
       />
     </PageSection>

--- a/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
+++ b/src/pages/tutorial/__tests__/__snapshots__/tutorial.test.js.snap
@@ -43,7 +43,7 @@ exports[`TutorialPage Component should render the TutorialPage component fulfill
     >
       <withRouter()
         homeClickedCallback={[Function]}
-        isAllSolutionPattern="true"
+        isAllSolutionPattern={true}
         threadName="Example"
       />
     </PageSection>

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -422,6 +422,7 @@ class TaskPage extends React.Component {
                 taskPosition={taskNum + 1}
                 totalTasks={totalTasks}
                 homeClickedCallback={() => {}}
+                isAllSolutionPattern="true"
               />
             </PageSection>
             <PageSection className="integr8ly-landing-page-tutorial-dashboard-section">

--- a/src/pages/tutorial/task/task.js
+++ b/src/pages/tutorial/task/task.js
@@ -422,7 +422,7 @@ class TaskPage extends React.Component {
                 taskPosition={taskNum + 1}
                 totalTasks={totalTasks}
                 homeClickedCallback={() => {}}
-                isAllSolutionPattern="true"
+                isAllSolutionPattern
               />
             </PageSection>
             <PageSection className="integr8ly-landing-page-tutorial-dashboard-section">

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -25,6 +25,7 @@ import { noop } from '../../common/helpers';
 import { parseWalkthroughAdoc } from '../../common/walkthroughHelpers';
 import { getDocsForWalkthrough, getDefaultAdocAttrs } from '../../common/docsHelpers';
 import { RoutedConnectedMasthead } from '../../components/masthead/masthead';
+import Breadcrumb from '../../components/breadcrumb/breadcrumb';
 
 class TutorialPage extends React.Component {
   componentDidMount() {
@@ -103,6 +104,13 @@ class TutorialPage extends React.Component {
           <Page className="pf-u-h-100vh">
             <SkipToContent href="#main-content">Skip to content</SkipToContent>
             <RoutedConnectedMasthead />
+            <PageSection variant="light">
+              <Breadcrumb
+                threadName={parsedThread.title}
+                threadId={id}
+                homeClickedCallback={() => {}}
+              />
+            </PageSection>
             <PageSection className="integr8ly-landing-page-tutorial-dashboard-section">
               <Grid gutter="md">
                 <GridItem sm={12} md={9} className="integr8ly-task-container">

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -105,7 +105,12 @@ class TutorialPage extends React.Component {
             <SkipToContent href="#main-content">Skip to content</SkipToContent>
             <RoutedConnectedMasthead />
             <PageSection variant="light">
-              <Breadcrumb threadName={parsedThread.title} isAllSolutionPattern="true" threadId={id} homeClickedCallback={() => {}} />
+              <Breadcrumb
+                threadName={parsedThread.title}
+                isAllSolutionPattern="true"
+                threadId={id}
+                homeClickedCallback={() => {}}
+              />
             </PageSection>
             <PageSection className="integr8ly-landing-page-tutorial-dashboard-section">
               <Grid gutter="md">

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -107,7 +107,7 @@ class TutorialPage extends React.Component {
             <PageSection variant="light">
               <Breadcrumb
                 threadName={parsedThread.title}
-                isAllSolutionPattern="true"
+                isAllSolutionPattern
                 threadId={id}
                 homeClickedCallback={() => {}}
               />

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -105,11 +105,7 @@ class TutorialPage extends React.Component {
             <SkipToContent href="#main-content">Skip to content</SkipToContent>
             <RoutedConnectedMasthead />
             <PageSection variant="light">
-              <Breadcrumb
-                threadName={parsedThread.title}
-                threadId={id}
-                homeClickedCallback={() => {}}
-              />
+              <Breadcrumb threadName={parsedThread.title} threadId={id} homeClickedCallback={() => {}} />
             </PageSection>
             <PageSection className="integr8ly-landing-page-tutorial-dashboard-section">
               <Grid gutter="md">

--- a/src/pages/tutorial/tutorial.js
+++ b/src/pages/tutorial/tutorial.js
@@ -105,7 +105,7 @@ class TutorialPage extends React.Component {
             <SkipToContent href="#main-content">Skip to content</SkipToContent>
             <RoutedConnectedMasthead />
             <PageSection variant="light">
-              <Breadcrumb threadName={parsedThread.title} threadId={id} homeClickedCallback={() => {}} />
+              <Breadcrumb threadName={parsedThread.title} isAllSolutionPattern="true" threadId={id} homeClickedCallback={() => {}} />
             </PageSection>
             <PageSection className="integr8ly-landing-page-tutorial-dashboard-section">
               <Grid gutter="md">


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-124

## What
Add breadcrumb component to the tutorial pages. There is no link for Solution Pattern right now because that will be added once the state for the tabs is worked out (which is coming later)

## Why
So that breadcrumbs persist on each page and a user can navigate back through the pages.

## How
Adding the breadcrumb component.

## Verification Steps

1. Go to Solution Patterns
2. Click Get Started
3. The page you are taken to will have breadcrumbs at the top
4. Please let me know if there are other pages missing it!

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1255" alt="Screen Shot 2020-04-20 at 11 26 38 AM" src="https://user-images.githubusercontent.com/20118816/79769708-74b9f400-82fa-11ea-8223-c109e8301569.png">

<img width="1262" alt="Screen Shot 2020-04-20 at 11 28 43 AM" src="https://user-images.githubusercontent.com/20118816/79769715-7683b780-82fa-11ea-92ac-b79ad7971d7a.png">


