### PR TITLE
update apicurito for OpenShift 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.5",
+  "version": "2.22.6",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -59,8 +59,7 @@ const DEFAULT_SERVICES = {
   CHE: 'codeready',
   LAUNCHER: 'launcher',
   THREESCALE: '3scale',
-  APICURIO:
-    window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.openshiftVersion === 4 ? 'apicurito' : 'apicurito-rhmi',
+  APICURIO: window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.openshiftVersion === 4 ? 'apicurito' : 'apicurito-rhmi',
   FUSE_MANAGED: 'fuse-managed',
   RHSSO: 'rhsso',
   USER_RHSSO: 'user-rhsso'

--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -59,7 +59,8 @@ const DEFAULT_SERVICES = {
   CHE: 'codeready',
   LAUNCHER: 'launcher',
   THREESCALE: '3scale',
-  APICURIO: 'apicurito',
+  APICURIO:
+    window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.openshiftVersion === 4 ? 'apicurito' : 'apicurito-rhmi',
   FUSE_MANAGED: 'fuse-managed',
   RHSSO: 'rhsso',
   USER_RHSSO: 'user-rhsso'

--- a/src/product-info.js
+++ b/src/product-info.js
@@ -12,6 +12,12 @@ export default {
     primaryTask: 'Design APIs',
     description: 'Quickly design your own REST APIs without writing any code.'
   },
+  'apicurito-rhmi': {
+    prettyName: 'API Designer',
+    gaStatus: 'GA',
+    primaryTask: 'Design APIs',
+    description: 'Quickly design your own REST APIs without writing any code.'
+  },
   '3scale': {
     prettyName: 'Red Hat 3scale API Management',
     gaStatus: 'GA',


### PR DESCRIPTION
On OpenShift 3 there is already a service plan named `apicurito` preinstalled. To avoid conflicts, the RHMI service plan is renamed to `apicurito-rhmi`.