### PR TITLE
add functions to update and read rhmi config

### DIFF
--- a/src/common/openshiftResourceDefinitions.js
+++ b/src/common/openshiftResourceDefinitions.js
@@ -13,6 +13,16 @@ const namespaceDef = {
   version: 'v1',
   group: 'project.openshift.io'
 };
+const rhmiConfigDef = namespace => ({
+  name: 'rhmiconfigs',
+  version: 'v1alpha1',
+  group: 'integreatly.org',
+  namespace
+});
+const rhmiConfigResource = metadata => ({
+  kind: 'RHMIConfig',
+  metadata
+});
 const namespaceResource = metadata => ({
   kind: 'projects',
   metadata
@@ -125,5 +135,7 @@ export {
   operatorGroupDef,
   subscriptionDef,
   csvDef,
-  processedTemplateDefV4
+  processedTemplateDefV4,
+  rhmiConfigDef,
+  rhmiConfigResource
 };

--- a/src/services/rhmiConfigServices.js
+++ b/src/services/rhmiConfigServices.js
@@ -1,0 +1,43 @@
+import { findOpenshiftResource } from '../common/openshiftHelpers';
+import { update } from '../services/openshiftServices';
+import { rhmiConfigDef, rhmiConfigResource } from '../common/openshiftResourceDefinitions';
+
+const configName = 'rhmi-config';
+const configNamespace = 'redhat-rhmi-operator';
+
+/**
+ * Read the rhmi config and returns a promise containing
+ * the config values. The name of the config resource is
+ * always assumed to be `rhmi-config` and the namespace
+ * is assumed to be `redhat-rhmi-operator`.
+ *
+ * getCurrentRhmiConfig().then(config => {
+ *    // config represents the current rhmi config. The spec is defined
+ *    // here: https://github.com/integr8ly/integreatly-operator/blob/master/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
+ * }).catch(err => handleError);
+ *
+ * @returns {*}
+ */
+const getCurrentRhmiConfig = () => {
+  const resource = rhmiConfigResource({
+    name: configName,
+    namespace: configNamespace
+  });
+
+  const compareFn = r => r.metadata.name === configName;
+  return findOpenshiftResource(rhmiConfigDef(configNamespace), resource, compareFn);
+};
+
+/**
+ * Update rhmi config by passing a modified config object
+ *
+ * updateRhmiConfig(config).then(newConfigValues => {
+ *   // newConfigValues represents the updated config
+ * }).catch(err => handleError);
+ *
+ * @param config
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+const updateRhmiConfig = config => update(rhmiConfigDef(configNamespace), config);
+
+export { getCurrentRhmiConfig, updateRhmiConfig };


### PR DESCRIPTION
Adds a new service (rhmiConfigService) with two exported functions:

* *getCurrentRhmiConfig*: reads the current rhmi config object. This will return a promise containing an object adhering to this spec: https://github.com/integr8ly/integreatly-operator/blob/master/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml

* *updateRhmiConfig*: updates the modified rhmi config object to allow the UI to manage this configuration.