### PR TITLE
INTLY-6829: Create a flag/method to determine user role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.6",
+  "version": "2.22.7",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -598,7 +598,7 @@ function getMockConfigData() {
         },
         {
           spec: {
-            clusterServiceClassExternalName: 'apicurito'
+            clusterServiceClassExternalName: 'apicurito-rhmi'
           },
           status: {
             dashboardURL:'${process.env.OPENSHIFT_URL}',

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -16,11 +16,20 @@ axios.interceptors.response.use(
 
 class OpenShiftUser {
   constructor(userRes) {
+    this.isAdmin = false;
+    console.log(`isAdmin initialized as false - isAdmin: ${this.isAdmin}`);
     if (userRes !== undefined) {
+      this.groups = userRes.groups;
       this.uid = userRes.metadata.uid;
       this.username = userRes.metadata.name;
       this.fullName = userRes.fullName;
+      this.isAdmin = this.groups.includes('cluster-admins' || 'dedicated-admins');
+      console.log(`isAdmin after check for admin group - isAdmin: ${this.isAdmin}`);
+
       window.localStorage.setItem('currentUserName', this.fullName ? this.fullName : this.username);
+      window.localStorage.setItem('currentUserIsAdmin', this.isAdmin);
+      console.log(`isAdmin after setting to local storage - isAdmin: ${this.isAdmin}`);
+      console.log(`window.localStorage.currentUserIsAdmin value: ${window.localStorage.currentUserIsAdmin}`);
     }
   }
 }

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -17,19 +17,15 @@ axios.interceptors.response.use(
 class OpenShiftUser {
   constructor(userRes) {
     this.isAdmin = false;
-    console.log(`isAdmin initialized as false - isAdmin: ${this.isAdmin}`);
     if (userRes !== undefined) {
       this.groups = userRes.groups;
       this.uid = userRes.metadata.uid;
       this.username = userRes.metadata.name;
       this.fullName = userRes.fullName;
-      this.isAdmin = this.groups.includes('cluster-admins' || 'dedicated-admins');
-      console.log(`isAdmin after check for admin group - isAdmin: ${this.isAdmin}`);
+      this.isAdmin = this.groups.includes('system:cluster-admins' || 'system:dedicated-admins');
 
       window.localStorage.setItem('currentUserName', this.fullName ? this.fullName : this.username);
       window.localStorage.setItem('currentUserIsAdmin', this.isAdmin);
-      console.log(`isAdmin after setting to local storage - isAdmin: ${this.isAdmin}`);
-      console.log(`window.localStorage.currentUserIsAdmin value: ${window.localStorage.currentUserIsAdmin}`);
     }
   }
 }


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-6829

## What
Add a localstorage value that checks if a user has admin privileges, based on if they belong to an admin group.

## Why
We need to change the UI and behavior of the solution explorer based on if the user has admin privileges.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
For testing, you can point your server to my docker image at:
docker.io/mfrances17/dev-tutorial-web-app:latest

Or check it out on this server, it's currently installed on it but will be taken down at some point:
https://tutorial-web-app-redhat-rhmi-solution-explorer.apps.uxd.cloudservices.rhmw.io/

It's not implemented anywhere just yet since this PR just covers the resource itself, but you should be able to set a breakpoint in the UI to check the value of window.localStorage.currentUserIsAdmin.