### PR TITLE
APPDUX-80: Make Settings icon inactive for non-admin users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.22.7",
+  "version": "2.22.8",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -202,7 +202,12 @@ class Masthead extends React.Component {
                   <CogIcon />
                 </Button>
               ) : (
-                <Tooltip position={TooltipPosition.bottom} distance="30" content={<div>{settingsTooltip}</div>}>
+                <Tooltip
+                  position={TooltipPosition.bottom}
+                  distance={30}
+                  entryDelay={0}
+                  content={<div>{settingsTooltip}</div>}
+                >
                   <Button isActive="false" className="pf-c-button pf-m-plain" aria-label="Settings" variant="plain">
                     <CogIcon className="integr8ly-settings-button-disabled" />
                   </Button>

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -170,16 +170,16 @@ class Masthead extends React.Component {
     let gsUrl = '';
     let riUrl = '';
     const csUrl = 'https://access.redhat.com/support/';
+    let isAdmin = window.OPENSHIFT_CONFIG.currentUserIsAdmin;
     const settingsTooltip =
       'Permissions needed. You must be logged in as an administrator to access the Settings page.';
-
-    // MF043020 TODO - local testing purposes only, remove when complete
-    window.OPENSHIFT_CONFIG.currentUserIsAdmin = true;
 
     if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.openshiftVersion === 3) {
       gsUrl =
         'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/getting_started/';
       riUrl = 'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/1/html-single/release_notes/';
+      // no admin protection for openshift 3 or for running demo/locally
+      isAdmin = true;
     } else {
       gsUrl =
         'https://access.redhat.com/documentation/en-us/red_hat_managed_integration/2/html-single/getting_started_with_red_hat_managed_integration_2/';
@@ -192,7 +192,7 @@ class Masthead extends React.Component {
         <Toolbar>
           <ToolbarGroup className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnLg)}>
             <ToolbarItem className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnMd)}>
-              {window.OPENSHIFT_CONFIG.currentUserIsAdmin ? (
+              {isAdmin ? (
                 <Button
                   className="pf-c-button pf-m-plain"
                   aria-label="Settings"

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -202,7 +202,7 @@ class Masthead extends React.Component {
                   <CogIcon />
                 </Button>
               ) : (
-                <Tooltip position={TooltipPosition.bottom} content={<div>{settingsTooltip}</div>}>
+                <Tooltip position={TooltipPosition.bottom} distance="30" content={<div>{settingsTooltip}</div>}>
                   <Button isActive="false" className="pf-c-button pf-m-plain" aria-label="Settings" variant="plain">
                     <CogIcon className="integr8ly-settings-button-disabled" />
                   </Button>

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -10,7 +10,9 @@ import {
   PageHeader,
   Toolbar,
   ToolbarGroup,
-  ToolbarItem
+  ToolbarItem,
+  Tooltip,
+  TooltipPosition
 } from '@patternfly/react-core';
 import { CogIcon, HelpIcon } from '@patternfly/react-icons';
 import accessibleStyles from '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
@@ -168,6 +170,11 @@ class Masthead extends React.Component {
     let gsUrl = '';
     let riUrl = '';
     const csUrl = 'https://access.redhat.com/support/';
+    const settingsTooltip =
+      'Permissions needed. You must be logged in as an administrator to access the Settings page.';
+
+    // MF043020 TODO - local testing purposes only, remove when complete
+    window.OPENSHIFT_CONFIG.currentUserIsAdmin = true;
 
     if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.openshiftVersion === 3) {
       gsUrl =
@@ -185,14 +192,22 @@ class Masthead extends React.Component {
         <Toolbar>
           <ToolbarGroup className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnLg)}>
             <ToolbarItem className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnMd)}>
-              <Button
-                className="pf-c-button pf-m-plain"
-                aria-label="Settings"
-                variant="plain"
-                onClick={this.onSettingsClick}
-              >
-                <CogIcon />
-              </Button>
+              {window.OPENSHIFT_CONFIG.currentUserIsAdmin ? (
+                <Button
+                  className="pf-c-button pf-m-plain"
+                  aria-label="Settings"
+                  variant="plain"
+                  onClick={this.onSettingsClick}
+                >
+                  <CogIcon />
+                </Button>
+              ) : (
+                <Tooltip position={TooltipPosition.bottom} content={<div>{settingsTooltip}</div>}>
+                  <Button isActive="false" className="pf-c-button pf-m-plain" aria-label="Settings" variant="plain">
+                    <CogIcon className="integr8ly-settings-button-disabled" />
+                  </Button>
+                </Tooltip>
+              )}
             </ToolbarItem>
             <ToolbarItem className={css(accessibleStyles.screenReader, accessibleStyles.visibleOnMd)}>
               <Dropdown

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -170,7 +170,7 @@ class Masthead extends React.Component {
     let gsUrl = '';
     let riUrl = '';
     const csUrl = 'https://access.redhat.com/support/';
-    let isAdmin = window.localStorage.currentUserIsAdmin;
+    let isAdmin = window.localStorage.currentUserIsAdmin === 'true';
     const settingsTooltip =
       'Permissions needed. You must be logged in as an administrator to access the Settings page.';
 

--- a/src/components/masthead/masthead.js
+++ b/src/components/masthead/masthead.js
@@ -170,7 +170,7 @@ class Masthead extends React.Component {
     let gsUrl = '';
     let riUrl = '';
     const csUrl = 'https://access.redhat.com/support/';
-    let isAdmin = window.OPENSHIFT_CONFIG.currentUserIsAdmin;
+    let isAdmin = window.localStorage.currentUserIsAdmin;
     const settingsTooltip =
       'Permissions needed. You must be logged in as an administrator to access the Settings page.';
 

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -22,7 +22,7 @@ class OpenShiftUser {
       this.uid = userRes.metadata.uid;
       this.username = userRes.metadata.name;
       this.fullName = userRes.fullName;
-      this.isAdmin = this.groups.includes('system:cluster-admins' || 'system:dedicated-admins');
+      this.isAdmin = this.groups.includes('system:cluster-admins' || 'system:dedicated-admins' || 'dedicated-admins');
 
       window.localStorage.setItem('currentUserName', this.fullName ? this.fullName : this.username);
       window.localStorage.setItem('currentUserIsAdmin', this.isAdmin);

--- a/src/services/openshiftServices.js
+++ b/src/services/openshiftServices.js
@@ -22,7 +22,10 @@ class OpenShiftUser {
       this.uid = userRes.metadata.uid;
       this.username = userRes.metadata.name;
       this.fullName = userRes.fullName;
-      this.isAdmin = this.groups.includes('system:cluster-admins' || 'system:dedicated-admins' || 'dedicated-admins');
+      this.isAdmin =
+        this.groups.includes('system:cluster-admins') ||
+        this.groups.includes('system:dedicated-admins') ||
+        this.groups.includes('dedicated-admins');
 
       window.localStorage.setItem('currentUserName', this.fullName ? this.fullName : this.username);
       window.localStorage.setItem('currentUserIsAdmin', this.isAdmin);

--- a/src/styles/application/_components.scss
+++ b/src/styles/application/_components.scss
@@ -8,5 +8,6 @@
 @import "./components/lists";
 @import "./components/loading";
 @import "./components/login";
-@import "./components/walkthroughResources";
+@import "./components/masthead";
 @import "./components/tutorialDashboard";
+@import "./components/walkthroughResources";

--- a/src/styles/application/components/_masthead.scss
+++ b/src/styles/application/components/_masthead.scss
@@ -1,0 +1,3 @@
+.integr8ly-settings-button-disabled {
+  color: var(--pf-global--disabled-color--100);
+}


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-80

## What
Make the Settings icon inactive for non-admin users and display a tooltip explanation.

## Why
Recent requirement to not allow non-admins access to certain areas of the Solution Explorer UI.

## Verification Steps
To test:
1. Log into Solution Explorer on an OpenShift 4 cluster as an Administrator e.g. kube:admin.
2. Verify that the Settings cog in the masthead is clickable and opens the Settings page. 
3. Close the Solution Explorer browser tab.
4. In OpenShift, log out as <admin> and click github to log in with your dev credentials. 
5. Launch Solution Explorer from the application launcher.
6. Click <admin> from the masthead and select Log out.
7. Log back into Solution Explorer with your GitHub credentials.
8. Verify that the Settings cog is now grayed out and when you hover over it, a tooltip appears and explains why.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
For testing, you can point your OpenShift cluster to my Solution Explorer docker image at: docker.io/mfrances17/dev-tutorial-web-app:latest

For a limited time, you can also view the changes on the UXD OpenShift 4 cluster: 
https://tutorial-web-app-redhat-rhmi-solution-explorer.apps.uxd.cloudservices.rhmw.io/

## Screencaps
**Masthead logged in as Dev:**
![dev_masthead](https://user-images.githubusercontent.com/39063664/80843697-f51e0600-8bd2-11ea-9373-c3220950d0e6.png)

**Masthead logged in as Admin:**
![admin_masthead](https://user-images.githubusercontent.com/39063664/80843692-f0f1e880-8bd2-11ea-9854-60f76ac71987.png)

**Settings page after click as Admin:**
![admin_after_click](https://user-images.githubusercontent.com/39063664/80843685-ed5e6180-8bd2-11ea-8038-a8b087f091c6.png)
