### PR TITLE
INTLY-7486: Point amq console links to the parent link instead of the address space link

### DIFF
--- a/src/common/serviceInstanceHelpers.js
+++ b/src/common/serviceInstanceHelpers.js
@@ -123,7 +123,13 @@ const getDashboardUrl = svc => {
   }
 
   const { status, metadata } = svc;
-  if (status.dashboardURL) {
+  // Ensure AMQ online console link points to the 'parent' amq console and not to an address space. This should only be applied for OS3
+  if (
+    window.OPENSHIFT_CONFIG.openshiftVersion === 3 &&
+    svc.spec.clusterServiceClassExternalName === DEFAULT_SERVICES.ENMASSE
+  ) {
+    return window.OPENSHIFT_CONFIG.provisionedServices[DEFAULT_SERVICES.ENMASSE].Host;
+  } else if (status.dashboardURL) {
     return status.dashboardURL;
   } else if (metadata.annotations && metadata.annotations['integreatly/dashboard-url']) {
     return metadata.annotations['integreatly/dashboard-url'];

--- a/src/components/installedAppsView/InstalledAppsView.js
+++ b/src/components/installedAppsView/InstalledAppsView.js
@@ -16,7 +16,7 @@ import {
 import { ChartPieIcon, ErrorCircleOIcon, HelpIcon, OnRunningIcon, OffIcon } from '@patternfly/react-icons';
 import { getProductDetails, getServiceSortOrder } from '../../services/middlewareServices';
 import { SERVICE_STATUSES, SERVICE_TYPES } from '../../redux/constants/middlewareConstants';
-import { DEFAULT_SERVICES } from '../../common/serviceInstanceHelpers';
+import { DEFAULT_SERVICES, getDashboardUrl } from '../../common/serviceInstanceHelpers';
 import { getWorkshopUrl, isWorkshopInstallation } from '../../common/docsHelpers';
 
 class InstalledAppsView extends React.Component {
@@ -120,6 +120,14 @@ class InstalledAppsView extends React.Component {
     }
     if (app.type === SERVICE_TYPES.PROVISIONED_SERVICE) {
       return app.url;
+    }
+    // Ensure AMQ online console link points to the 'parent' amq console and not to an address space. This should only be applied for OS3
+    if (
+      window.OPENSHIFT_CONFIG.openshiftVersion === 3 &&
+      app.spec &&
+      app.spec.clusterServiceClassExternalName === DEFAULT_SERVICES.ENMASSE
+    ) {
+      return getDashboardUrl(app);
     }
     if (app.status.dashboardURL) {
       return app.status.dashboardURL;


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-7486

This change ensures amq online url points to the parent console instead of address space on os3.

**Reason for change**
The AMQ console route has changed from `console-proxy` to `console` in the new AMQ version 1.4. It's path to the address space also has a new format.

After upgrade from rhmi 1.6 to 1.7, the dashboardUrl in the address space of the service instance still remained pointing to the `console-proxy` route which is being used by the webapp to populate the amq console links in the managed services menu and within the walkthroughs.

This dashboardurl field is managed by the AMQ service broker itself and cannot be modified once created.

Instead of pointing to the address space itself, we should point to the 'parent' amq console link. This will enable us to no longer rely on the dashboardUrl field in the service instance. It will also allow us to ensure that the url to the amq console will always be correct on future versions if it changes again. The AMQ url will now be made available to the webapp through the `INSTALLED_SERVICES` field.

Related Walkthrough changes: https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/137

## Verification steps
### Installation
1. Run the webapp locally and ensure you pass the following env var when running:
```
INSTALLED_SERVICES='{   "amq-online-standard":{       "Host":"<amq-online-console-route>"  }}'
```

Verified on OSD OS3:

Before amq was provisioned:
![image](https://user-images.githubusercontent.com/9078522/81425798-2a38d400-9150-11ea-8551-0bbb9922bb9b.png)

After amq was provisioned, each amq console link redirected you to the following url: https://console-openshift-enmasse.f2d1.rhmi-qe1.openshiftapps.com/#/address-spaces

This was also verified on OS4 by @pb82. 

Changes did not affect routes in OS4. This change only affected the AMQ route on OS3. 

WT1A was tested with the following PR: https://github.com/integr8ly/tutorial-web-app-walkthroughs/pull/137

## Upgrade
Steps to verify changes on upgrade from RHMI 1.6 to 1.7:
- Install RHMI 1.6
- Go through WT1A
- Upgrade to RHMI 1.7
- Update the webapp CR to add the following param to `spec.parameters`
  ```
  INSTALLED_SERVICES: |-
        { 
          "amq-online-standard":{ 
              "Host":"<amq-online-console-route>"
          }
        }
  ```
- Scale down the webapp operator deployment.
- Update the webapp image to point to `quay.io/jameelb/tutorial-web-app:master`
- Verify WT1A still works for previously created address spaces.
- Verify previously sent messages are still there.

Verified changes on upgrade from RHMI 1.6 to 1.7. WT1A still works, previously sent messages can still be seen in the order app. New messages can still be sent.