### PR TITLE
Adds fully-functioning breadcrumb

### DIFF
--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -12,6 +12,15 @@ class Breadcrumb extends React.Component {
       homeClickedCallback();
     }
   };
+
+  solutionPatternsClicked = () => {
+    const { solutionPatternsClickedCallback } = this.props;
+    this.props.history.push('/home/solution-patterns');
+    if (solutionPatternsClickedCallback) {
+      solutionPatternsClickedCallback();
+    }
+  };
+
   render() {
     const { t, threadName, threadId, totalTasks, taskPosition, isAllSolutionPattern } = this.props;
     return (
@@ -19,7 +28,7 @@ class Breadcrumb extends React.Component {
         <BreadcrumbItem to="#" onClick={this.homeClicked} id="breadcrumb-home">
           Home
         </BreadcrumbItem>
-        {isAllSolutionPattern && <BreadcrumbItem>Solution Patterns</BreadcrumbItem>}
+        {isAllSolutionPattern && <BreadcrumbItem to="/solution-patterns">Solution Patterns</BreadcrumbItem>}
         {threadName && !taskPosition && <BreadcrumbItem isActive>{threadName}</BreadcrumbItem>}
         {threadName &&
           taskPosition && (
@@ -48,8 +57,10 @@ Breadcrumb.propTypes = {
   taskPosition: PropTypes.number,
   /** The total number of tasks for this walkthrough */
   totalTasks: PropTypes.number,
-  /** Called when the home button is clicked */
+  /** Called when the 'home' button is clicked */
   homeClickedCallback: PropTypes.func,
+  /** Called when the 'solution patterns' button is clicked */
+  solutionPatternsClickedCallback: PropTypes.func,
   /** Checks to see if all solutions pattern is in path */
   isAllSolutionPattern: PropTypes.bool
 };
@@ -61,6 +72,7 @@ Breadcrumb.defaultProps = {
   taskPosition: null,
   totalTasks: null,
   homeClickedCallback: undefined,
+  solutionPatternsClickedCallback: undefined,
   isAllSolutionPattern: false
 };
 

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -28,8 +28,6 @@ class LandingPage extends React.Component {
 
     // Toggle currently active tab
     this.handleTabClick = (event, tabIndex) => {
-      console.log("dsfsdfsf");
-      // window.location.reload();
       event.preventDefault();
       this.setState({
         activeTabKey: tabIndex

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, GridItem, Page, PageSection, PageSectionVariants, Tabs, Tab, TabContent } from '@patternfly/react-core';
+import { Grid, GridItem, Page, PageSection, PageSectionVariants, Tabs, Tab } from '@patternfly/react-core';
 import { noop } from '../../common/helpers';
 import TutorialDashboard from '../../components/tutorialDashboard/tutorialDashboard';
 import InstalledAppsView from '../../components/installedAppsView/InstalledAppsView';

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -28,6 +28,8 @@ class LandingPage extends React.Component {
 
     // Toggle currently active tab
     this.handleTabClick = (event, tabIndex) => {
+      console.log("dsfsdfsf");
+      // window.location.reload();
       event.preventDefault();
       this.setState({
         activeTabKey: tabIndex
@@ -75,9 +77,9 @@ class LandingPage extends React.Component {
   }
 
   handleLoad(event) {
-    if (window.location.href.indexOf('solution-patterns') > -1) {
-      this.handleTabClick(event, 1);
+    if (window.location.href.indexOf('solution') > -1) {
       this.setState({ activeTabKey: 1 });
+      document.getElementById('pf-tab-1-solutionPatternsTab').click();
     }
   }
 
@@ -88,7 +90,7 @@ class LandingPage extends React.Component {
 
     return (
       <React.Fragment>
-        <Page className="pf-u-h-100vh">
+        <Page className="pf-u-h-100vh" onLoad={this.handleLoad}>
           <RoutedConnectedMasthead currentUserName={this.state.currentUserName} />
           <PageSection variant={PageSectionVariants.light} className="pf-u-py-0 pf-u-pl-lg pf-u-pr-0">
             <h1 className="pf-c-title pf-m-4xl pf-c-landing__heading">Welcome to the Solution Explorer</h1>

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -20,16 +20,15 @@ import {
 class LandingPage extends React.Component {
   constructor(props) {
     super(props);
+    this.handleLoad = this.handleLoad.bind(this);
     this.state = {
       activeTabKey: 0,
       currentUserName: null
     };
 
-    this.contentRef1 = React.createRef();
-    this.contentRef2 = React.createRef();
-
     // Toggle currently active tab
     this.handleTabClick = (event, tabIndex) => {
+      event.preventDefault();
       this.setState({
         activeTabKey: tabIndex
       });
@@ -38,6 +37,7 @@ class LandingPage extends React.Component {
 
   componentDidMount() {
     const { getProgress, getCustomWalkthroughs, resetCurrentWalkthrough } = this.props;
+    window.addEventListener('load', this.handleLoad);
     getCustomWalkthroughs();
     resetCurrentWalkthrough();
     getProgress();
@@ -74,6 +74,13 @@ class LandingPage extends React.Component {
     });
   }
 
+  handleLoad(event) {
+    if (window.location.href.indexOf('solution-patterns') > -1) {
+      this.handleTabClick(event, 1);
+      this.setState({ activeTabKey: 1 });
+    }
+  }
+
   render() {
     const { walkthroughServices, middlewareServices, user } = this.props;
     const launchFn = isOpenShift4() ? this.handleServiceLaunchV4.bind(this) : this.handleServiceLaunch.bind(this);
@@ -89,55 +96,42 @@ class LandingPage extends React.Component {
               Quickly access consoles for all your Red Hat managed services, and learn how to easily implement
               integrations with Solution Pattern examples.
             </p>
-            <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
-              <Tab
-                id="servicesTab"
-                eventKey={0}
-                title="All services"
-                tabContentId="servicesTabSection"
-                tabContentRef={this.contentRef1}
-              />
-              <Tab
-                id="solutionPatternsTab"
-                eventKey={1}
-                title="All Solution Patterns"
-                tabContentId="solutionPatternsTabSection"
-                tabContentRef={this.contentRef2}
-              />
-            </Tabs>
           </PageSection>
-          <PageSection className="pf-u-py-0 pf-u-pl-lg pf-u-pr-lg">
-            <div>
-              <TabContent eventKey={0} id="servicesTabSection" ref={this.contentRef1} aria-label="Services tab content">
-                <Grid>
-                  <GridItem sm={12} md={12}>
-                    <InstalledAppsView
-                      apps={Object.values(middlewareServices.data)}
-                      username={this.state.currentUserName}
-                      openshiftHost={openshiftHost}
-                      enableLaunch={!window.OPENSHIFT_CONFIG.mockData}
-                      showUnready={middlewareServices.customServices.showUnreadyServices || DISPLAY_SERVICES}
-                      customApps={middlewareServices.customServices.services}
-                      handleLaunch={svcName => launchFn(svcName)}
-                    />
-                  </GridItem>
-                </Grid>
-              </TabContent>
-              <TabContent
-                eventKey={1}
-                id="solutionPatternsTabSection"
-                ref={this.contentRef2}
-                aria-label="Solution Patterns tab content"
-                hidden
-              >
+          <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+            <Tab id="servicesTab" eventKey={0} title="All services" tabContentId="servicesTabSection">
+              <PageSection className="pf-u-py-0 pf-u-pl-lg pf-u-pr-0">
+                <div>
+                  <Grid>
+                    <GridItem sm={12} md={12}>
+                      <InstalledAppsView
+                        apps={Object.values(middlewareServices.data)}
+                        username={this.state.currentUserName}
+                        openshiftHost={openshiftHost}
+                        enableLaunch={!window.OPENSHIFT_CONFIG.mockData}
+                        showUnready={middlewareServices.customServices.showUnreadyServices || DISPLAY_SERVICES}
+                        customApps={middlewareServices.customServices.services}
+                        handleLaunch={svcName => launchFn(svcName)}
+                      />
+                    </GridItem>
+                  </Grid>
+                </div>
+              </PageSection>
+            </Tab>
+            <Tab
+              id="solutionPatternsTab"
+              eventKey={1}
+              title="All Solution Patterns"
+              tabContentId="solutionPatternsTabSection"
+            >
+              <PageSection className="pf-u-py-0 pf-u-pl-lg pf-u-pr-0">
                 <Grid gutter="md">
                   <GridItem sm={12} md={12}>
                     <TutorialDashboard userProgress={user.userProgress} walkthroughs={walkthroughServices.data} />
                   </GridItem>
                 </Grid>
-              </TabContent>
-            </div>
-          </PageSection>
+              </PageSection>
+            </Tab>
+          </Tabs>
         </Page>
       </React.Fragment>
     );

--- a/src/router/__tests__/__snapshots__/router.test.js.snap
+++ b/src/router/__tests__/__snapshots__/router.test.js.snap
@@ -18,6 +18,12 @@ exports[`Router Component should render a basic component 1`] = `
     <Route
       component={[Function]}
       exact={true}
+      key="/solution-patterns"
+      path="/solution-patterns"
+    />
+    <Route
+      component={[Function]}
+      exact={true}
       key="/settings"
       path="/settings"
     />
@@ -60,7 +66,7 @@ exports[`Router Component should render a basic component 1`] = `
     <Redirect
       from="/"
       push={false}
-      to="/home"
+      to="/solution-patterns"
     />
   </Switch>
 </div>

--- a/src/routes.js
+++ b/src/routes.js
@@ -36,6 +36,14 @@ const routes = () => [
   },
   {
     iconClass: 'pficon pficon-orders',
+    title: 'Solution Patterns',
+    to: '/solution-patterns',
+    redirect: true,
+    component: LandingPage,
+    exact: true
+  },
+  {
+    iconClass: 'pficon pficon-orders',
     title: 'Settings',
     to: '/settings',
     component: SettingsPage,

--- a/src/styles/application/pages/_landing.scss
+++ b/src/styles/application/pages/_landing.scss
@@ -20,14 +20,15 @@
 }
 
 .pf-c-tab-content {
-  padding-right: var(--pf-c-page__main-breadcrumb--md--PaddingRight)
+  padding-right: var(--pf-c-page__main-breadcrumb--md--PaddingRight);
 }
-/* stylelint-enable */
 
 .pf-c-page__header {
-    background: var(--pf-global--BackgroundColor--dark-100);
+  background: var(--pf-global--BackgroundColor--dark-100);
 }
 
 .pf-c-page__main {
   background: var(--pf-global--BackgroundColor--300);
 }
+
+/* stylelint-enable */

--- a/src/styles/application/pages/_landing.scss
+++ b/src/styles/application/pages/_landing.scss
@@ -9,4 +9,25 @@
   margin: 0;
   padding: 0 0 20px;
 }
+
+.pf-c-tabs {
+  background: var(--pf-global--BackgroundColor--100);
+  padding-left: var(--pf-global--spacer--lg);
+}
+
+.pf-c-tabs-list {
+  background: var(--pf-global--BackgroundColor--100);
+}
+
+.pf-c-tab-content {
+  padding-right: var(--pf-c-page__main-breadcrumb--md--PaddingRight)
+}
 /* stylelint-enable */
+
+.pf-c-page__header {
+    background: var(--pf-global--BackgroundColor--dark-100);
+}
+
+.pf-c-page__main {
+  background: var(--pf-global--BackgroundColor--300);
+}


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->
[APPDUX-185](https://issues.redhat.com/browse/APPDUX-185)

## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) --> As stated in the linked Jira ticked above, this PR adds " an additional leaf in the breadcrumbs for 'Solution Patterns' ... a hyperlink to the home page with the Solution Patterns tab selected."

## Why
<!-- Add a short answer for: Why it was done? (E.g The feature X was deprecated.) -->
This link did not exist previously.

## How
<!-- Add a short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) --> Tried several methods for using an`href` together with an `onClick` method on the `Tab` component. After doing a lot of research, I removed the `TabContent` refs which were the source of the problem, since the correct content for the active tab was not rendering.
 
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

Check out locally, or view screenshots under "Additional Notes" below.

-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->

Note the new "Solution Patterns" link in the breadcrumb.

<img width="1680" alt="Screen Shot 2020-05-15 at 5 03 15 PM" src="https://user-images.githubusercontent.com/32821331/82095935-118b6980-96ce-11ea-8b18-b037b841745b.png">

That link takes you here:

<img width="1680" alt="Screen Shot 2020-05-15 at 5 03 25 PM" src="https://user-images.githubusercontent.com/32821331/82095985-28ca5700-96ce-11ea-8c63-094b3a352c4c.png">

