### PR TITLE
Clean up npm install in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ Then change to the webapp directory, install its dependencies and run the develo
 ----
 $ cd tutorial-web-app
 $ rm -rf node_modules
-$ npm install -g yarn react-scripts nodemon npm-run-all
+$ npm install -g yarn
 $ yarn install
 $ yarn start:dev
 ----


### PR DESCRIPTION
## Motivation
Local setup suggests installing things that aren't necessary.

## What
Removed some items from the npm install command in the README

## Why
No need to install things globally that aren't being used

## How
N/A

## Verification Steps
Clone the repo and run the local setup steps. They'll work without those deps.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
N/A