### PR TITLE
INTLY-7972: Fix for default home issue

### DIFF
--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -13,14 +13,6 @@ class Breadcrumb extends React.Component {
     }
   };
 
-  solutionPatternsClicked = () => {
-    const { solutionPatternsClickedCallback } = this.props;
-    this.props.history.push('/home/solution-patterns');
-    if (solutionPatternsClickedCallback) {
-      solutionPatternsClickedCallback();
-    }
-  };
-
   render() {
     const { t, threadName, threadId, totalTasks, taskPosition, isAllSolutionPattern } = this.props;
     return (

--- a/src/pages/landing/landingPage.js
+++ b/src/pages/landing/landingPage.js
@@ -75,7 +75,7 @@ class LandingPage extends React.Component {
   }
 
   handleLoad(event) {
-    if (window.location.href.indexOf('solution') > -1) {
+    if (window.location.href.indexOf('/solution-patterns') > -1) {
       this.setState({ activeTabKey: 1 });
       document.getElementById('pf-tab-1-solutionPatternsTab').click();
     }


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/INTLY-7972

## What
Home page was directing to wrong tab instead of defaulting to All services tab.

## Why
Breadcrumb changes were added and inadvertently changed the tab for certain systems. 

## Verification Steps
1. Open Solution Explorer. Default should now be the services tab.
2. Navigate through a solution pattern or other area of the UI, verify that when you click Home, you go to the services tab.
3. Navigate through a solution pattern and verify that when you click the solution patterns breadcrumb, you go to the solution patterns tab and not the services tab.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
For testing, you can point your OpenShift cluster to my Solution Explorer docker image at: docker.io/mfrances17/dev-tutorial-web-app:home-issue

For a limited time, you can also view the changes on my OpenShift 4 cluster: 
https://solution-explorer.apps.cluster-uxddev-a3e2.uxddev-a3e2.example.opentlc.com/
