### PR TITLE
INTLY-8149 - export fuse namespace attribute dependant on install type

### DIFF
--- a/src/common/docsHelpers.js
+++ b/src/common/docsHelpers.js
@@ -96,7 +96,8 @@ const getMiddlewareServiceAttrs = middlewareServices => {
     'amq-broker-amqp-url': middlewareServices.amqCredentials.url,
     'amq-credentials-username': middlewareServices.amqCredentials.username,
     'amq-credentials-password': middlewareServices.amqCredentials.password,
-    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO)
+    'apicurio-url': getUrlFromMiddlewareServices(middlewareServices, DEFAULT_SERVICES.APICURIO),
+    'fuse-namespace': getFuseNamespace(username)
   };
 
   if (window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFIG.optionalProvisionServices.length > 0) {
@@ -142,5 +143,13 @@ const isWorkshopInstallation = window.OPENSHIFT_CONFIG && window.OPENSHIFT_CONFI
 const getDefaultAdocAttrs = walkthroughId => ({
   imagesdir: `/walkthroughs/${walkthroughId}/files/`
 });
+
+const getFuseNamespace = userName => {
+  if (isWorkshopInstallation) {
+    return `${userName}-fuse`;
+  }
+
+  return 'redhat-rhmi-fuse';
+};
 
 export { getDocsForWalkthrough, getDefaultAdocAttrs, getWorkshopUrl, getOpenshiftHost, isWorkshopInstallation };


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->
Per user fuse is created for `workshop` installs. Fuse namespace of either `redhat-rhmi-fuse` for `managed` install and `${username}-fuse` for `workshop` install should be exported for use in the solution pattern walkthroughs

Jira:
* https://issues.redhat.com/browse/INTLY-8149

Solution pattern PR:
* https://github.com/integr8ly/solution-patterns/pull/31

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

