### PR TITLE
add permission check for post endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'import/no-dynamic-require': 'off',
     'global-require': 'off',
     'react/jsx-curly-brace-presence': 'off',
-    'react/no-unused-prop-types': 'off'
+    'react/no-unused-prop-types': 'off',
+    'camelcase': ['error', { 'allow': ['access_token', 'auth_token'] }]
   }
 };

--- a/server_middleware.js
+++ b/server_middleware.js
@@ -7,36 +7,70 @@ const insecureAgent = new https.Agent({
   rejectUnauthorized: false
 });
 
-exports.fetchOpenshiftUser = (req, res, next) => {
-  // Not much we can do if the openshift host is not set. This probably
-  // means we are running in a mock environment
-  if (!OPENSHIFT_HOST) {
-    return next();
+
+function getApiHost() {
+  if (process.env.OPENSHIFT_VERSION === '4') {
+    return `https://${process.env.OPENSHIFT_API}/apis/user.openshift.io/v1/users/~`;
+  }
+  return `https://${OPENSHIFT_HOST}/oapi/v1/users/~`;
+}
+
+function checkRoles(memberGroups, requestedGroups) {
+  // If no groups were requested the request is always authorized
+  if (!requestedGroups) {
+    return true;
   }
 
-  const token = req.get('X-Forwarded-Access-Token');
-  if (!token) {
-    return res.sendStatus(403);
+  // If groups were requested but the user is not a member of any group the request is
+  // always unauthorized
+  if (!memberGroups) {
+    return false;
   }
 
-  return axios({
-    httpsAgent: insecureAgent,
-    url: `https://${OPENSHIFT_HOST}/oapi/v1/users/~`,
-    headers: {
-      authorization: `Bearer ${token}`,
-      Accept: 'application/json'
+  // Require that at least one of the requested groups are part of the members group array
+  return requestedGroups.map(group => {
+    console.log(`checking against ${group}`);
+    return memberGroups.indexOf(group) >= 0;
+  }).reduce((acc, current) => {
+    return acc || current;
+  }, false);
+}
+
+exports.requireRoles = config => {
+  return function(req, res, next) {
+    // Not much we can do if the openshift host is not set. This probably
+    // means we are running in a mock environment
+    if (!OPENSHIFT_HOST) {
+      return next();
     }
-  })
-    .then(response => {
-      const {
-        kind,
-        metadata: { name }
-      } = response.data;
-      if (kind === 'User') {
-        req.body.openshiftUser = name;
-        return next();
-      }
+
+    const token = req.get('X-Forwarded-Access-Token');
+    if (!token) {
       return res.sendStatus(403);
+    }
+
+    return axios({
+      httpsAgent: insecureAgent,
+      url: getApiHost(),
+      headers: {
+        authorization: `Bearer ${token}`
+      }
     })
-    .catch(err => next(err));
+      .then(response => {
+        const {
+          kind,
+          groups,
+          metadata: { name }
+        } = response.data;
+        if (kind === 'User') {
+          if (checkRoles(groups, config)) {
+            console.error(`Access granted to user ${name}`);
+            return next();
+          }
+          console.error(`Access denied to user ${name}`);
+        }
+        return res.sendStatus(403);
+      })
+      .catch(err => next(err));
+  };
 };

--- a/server_middleware.js
+++ b/server_middleware.js
@@ -46,7 +46,7 @@ exports.requireRoles = config => {
 
     const token = req.get('X-Forwarded-Access-Token');
     if (!token) {
-      return res.sendStatus(403);
+      return res.sendStatus(401);
     }
 
     return axios({
@@ -71,6 +71,9 @@ exports.requireRoles = config => {
         }
         return res.sendStatus(403);
       })
-      .catch(err => next(err));
+      .catch(err => {
+        console.error(err);
+        return res.sendStatus(401);
+      });
   };
 };

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -37,6 +37,7 @@ import { connect, reduxActions } from '../../redux';
 import Breadcrumb from '../../components/breadcrumb/breadcrumb';
 import { setUserWalkthroughs, getUserWalkthroughs } from '../../services/walkthroughServices';
 import { getCurrentRhmiConfig, updateRhmiConfig } from '../../services/rhmiConfigServices';
+import { getUser } from '../../services/openshiftServices';
 
 const moment = require('moment');
 
@@ -145,8 +146,13 @@ class SettingsPage extends React.Component {
   saveSolutionPatternSettings = (e, value) => {
     e.preventDefault();
     const { history } = this.props;
-    setUserWalkthroughs(value);
-    history.push(`/`);
+    /* stylelint-disable */
+    getUser().then(({ access_token }) => {
+      setUserWalkthroughs(value, access_token).then(() => {
+        history.push(`/`);
+      });
+    });
+    /* stylelint-enable */
   };
 
   saveMockBackupSettings = (e, value) => {

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -146,13 +146,11 @@ class SettingsPage extends React.Component {
   saveSolutionPatternSettings = (e, value) => {
     e.preventDefault();
     const { history } = this.props;
-    /* stylelint-disable */
     getUser().then(({ access_token }) => {
       setUserWalkthroughs(value, access_token).then(() => {
         history.push(`/`);
       });
     });
-    /* stylelint-enable */
   };
 
   saveMockBackupSettings = (e, value) => {

--- a/src/services/walkthroughServices.js
+++ b/src/services/walkthroughServices.js
@@ -373,13 +373,16 @@ const getUserWalkthroughs = () =>
 /**
  * Saves the user-defined GitHub repositories from the UI to the database.
  */
-const setUserWalkthroughs = (data = {}) =>
+const setUserWalkthroughs = (data = {}, token) =>
   axios(
     serviceConfig(
       {
         method: 'post',
         url: `/user_walkthroughs`,
-        data: { data }
+        data: { data },
+        headers: {
+          'X-Forwarded-Access-Token': token
+        }
       },
       false
     )


### PR DESCRIPTION
Only admins (cluster or dedicated) should be able to modify user walkthrough content. Retrieving the content is not restricted.

Verification steps:

1. Open the log tab of the solution explorer pod in one tab
2. Login to the solution explorer as customer-admin in a second tab
3. Open the settings window and submit a custom walkthrough
4. There should be a message in the logs: `Granting access to <user name>`
5. Copy the post request to `user_walkthroughs` as a fetch or curl from the browser console
6. Modify the access_token of the request and re-submit it
7. You should get a 401 response