### PR TITLE
APPDUX-251: Incorrect backup time written for midnight

### DIFF
--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -190,7 +190,7 @@ class SettingsPage extends React.Component {
       hours = parseInt(hours, 10) + 12;
     }
 
-    if (parseInt(hours, 10) < 10 && (modifier === 'AM' || 'am')) {
+    if (parseInt(hours, 10) < 10 && parseInt(hours, 10) > 0 && (modifier === 'AM' || 'am')) {
       pad = '0';
     }
 


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-251

## What
Leading 0 was being added to 24hr time for midnight when writing daily backup times from the UI to the YAML (000:00 instead of 00:00).

## Why
Bad algorithm needed to be fixed.

## Verification Steps
1. On the **Settings** > **Managed Integration schedule** tab, select 12:00 am from the **Start time for your backups** dropdown and click **Save**.

2. View the rhmi-config YAML file and verify that the time is now saved as:
       applyOn: '00:00'

And is not saved as:
       applyOn: '000:00'

To view the YAML file:
1. Select Project: redhat-rhmi-operator
2. Click Home > Search
3. Select Resources > RHMIConfig 
4. Click rhmi-config
5. Select YAML tab. Scroll down to see the applyOn time.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
Can be tested live on my openshift cluster:
https://console-openshift-console.apps.cluster-uxddev-916c.uxddev-916c.example.opentlc.com/

Or on any OS4 cluster using this solution explorer docker image:
docker.io/mfrances17/tutorial-web-app:appdux-251

![12am-settings](https://user-images.githubusercontent.com/39063664/87085893-a60dd600-c1fe-11ea-9f86-858e069af982.png)

![12am-rhmi-config](https://user-images.githubusercontent.com/39063664/87085901-a9a15d00-c1fe-11ea-8bb0-15ce99b74079.png)

