### PR TITLE
APPDUX-259: Update react libraries to 16.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.26.3",
+  "version": "2.26.4",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {
@@ -24,8 +24,8 @@
     "lodash.get": "4.4.2",
     "mustache": "^3.0.0",
     "prop-types": "15.6.2",
-    "react": "16.6.3",
-    "react-dom": "16.6.3",
+    "react": "16.8.0",
+    "react-dom": "16.8.0",
     "react-i18next": "8.3.8",
     "react-redux": "5.0.6",
     "react-router": "4.3.1",


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-259

## What
When updating to the latest Patternfly 4 breaking change release, the required minimum version for react and react-dom libraries is 16.8.0.

## Why
We weren't using any PF4 components that were taking advantage of the latest react features (such as hooks), so when we upgraded to the the latest PF4 breaking change release, it didn't impact us. However, going forward, we will be affected as more and more PF4 components are using these features.

## Verification Steps
Simple change, just a react library update. To verify, just traverse the entire solution explorer UI and verify that there are no regressions e.g. visual or behavioral differences.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
Can be tested locally, but if you want to test on a live server, you can test on my cluster here:
https://solution-explorer.apps.cluster-uxddev-916c.uxddev-916c.example.opentlc.com/

**Sample screen cap:**
![sample-16 8 0](https://user-images.githubusercontent.com/39063664/87470944-89511400-c5eb-11ea-8ac1-9d1296ea0ea9.png)


