### PR TITLE
APPDUX-378: Add missing help string to settings page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -918,6 +918,10 @@ class SettingsPage extends React.Component {
                                   id="followingRadio"
                                   value="followingRadio"
                                 />
+                                <Text className="integr8ly__text-small--m-secondary">
+                                  Upgrading during the first available maintenance window is only recommended for
+                                  development environments.{' '}
+                                </Text>
                                 <FlexItem>
                                   <Title headingLevel="h6" size="sm" className="pf-u-mt-md">
                                     Upgrade notifications


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-378

## What
The design of the settings config page had the following 'help' string under the maintenance window first/second available radio buttons, but it was missing from the final implementation:

"Upgrading during the first available maintenance window is only recommended for development environments."

# Why
Design wanted to make it more clear that you should really only choose first available in a dev environment.

## Verification Steps
1. Uncomment ln 714 of settings.js to allow settings UI to display the config tab when running locally, and then run yarn start:dev.
2. Go to Settings > Managed Integration schedule tab.
3. Verify that the help string identified above exists.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
Screen cap:
![upgrade-string](https://user-images.githubusercontent.com/39063664/89191402-dd0ea780-d570-11ea-852d-8ecd37c21497.png)
