### PR TITLE
APPDUX-379: Days of week should not be abbreviated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -738,7 +738,7 @@ class SettingsPage extends React.Component {
     }
 
     // local testing purposes only - uncomment to test config tab (simulate OS4)
-    isOSv4 = true;
+    // isOSv4 = true;
 
     // show settings alert on first render
     if (window.localStorage.getItem('showSettingsAlert') === null)

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -46,13 +46,13 @@ import { getUser } from '../../services/openshiftServices';
 const moment = require('moment');
 
 const daysOfWeek = new Array(7);
-daysOfWeek[0] = 'Sun';
-daysOfWeek[1] = 'Mon';
-daysOfWeek[2] = 'Tue';
-daysOfWeek[3] = 'Wed';
-daysOfWeek[4] = 'Thu';
-daysOfWeek[5] = 'Fri';
-daysOfWeek[6] = 'Sat';
+daysOfWeek[0] = 'Sunday';
+daysOfWeek[1] = 'Monday';
+daysOfWeek[2] = 'Tuesday';
+daysOfWeek[3] = 'Wednesday';
+daysOfWeek[4] = 'Thursday';
+daysOfWeek[5] = 'Friday';
+daysOfWeek[6] = 'Saturday';
 
 class SettingsPage extends React.Component {
   constructor(props) {
@@ -62,7 +62,7 @@ class SettingsPage extends React.Component {
 
     this.state = {
       value: userWalkthroughs || '',
-      selectedRadio: 'nextRadio',
+      selectedRadio: 'followingRadio',
       emailContacts: '',
       maintWait: true,
       maintWaitDays: 0,
@@ -649,10 +649,37 @@ class SettingsPage extends React.Component {
     const rhmiConfig = this.state.config;
     const maint = rhmiConfig.spec.maintenance.applyFrom;
     const maintDay = maint.split(' ')[0];
+    let maintDisplay = '';
+
+    switch (maintDay) {
+      case 'Sun':
+        maintDisplay = 'Sunday';
+        break;
+      case 'Mon':
+        maintDisplay = 'Monday';
+        break;
+      case 'Tue':
+        maintDisplay = 'Tuesday';
+        break;
+      case 'Wed':
+        maintDisplay = 'Wednesday';
+        break;
+      case 'Thu':
+        maintDisplay = 'Thursday';
+        break;
+      case 'Fri':
+        maintDisplay = 'Friday';
+        break;
+      case 'Sat':
+        maintDisplay = 'Saturday';
+        break;
+      default:
+        maintDisplay = '';
+    }
 
     if (this.state.maintDayDisplay === '') {
       this.setState({
-        maintDayDisplay: maintDay
+        maintDayDisplay: maintDisplay
       });
     }
 
@@ -974,7 +1001,7 @@ class SettingsPage extends React.Component {
                                 this.saveMockConfigSettings(
                                   e,
                                   this.state.buStartTimeDisplay,
-                                  this.state.maintDayDisplay,
+                                  this.state.maintDayDisplay.substr(0, 3),
                                   this.state.maintTimeDisplay,
                                   this.state.emailContacts,
                                   this.state.maintWait,
@@ -984,7 +1011,7 @@ class SettingsPage extends React.Component {
                                 this.saveConfigSettings(
                                   e,
                                   this.state.buStartTimeDisplay,
-                                  this.state.maintDayDisplay,
+                                  this.state.maintDayDisplay.substr(0, 3),
                                   this.state.maintTimeDisplay,
                                   this.state.emailContacts,
                                   this.state.maintWait,

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -146,7 +146,7 @@ class SettingsPage extends React.Component {
 
     this.onBackupSelect = event => {
       this.setState({
-        isOpen: !this.state.isOpen,
+        isBackupOpen: !this.state.isBackupOpen,
         buStartTimeDisplay: event.target.innerText,
         canSave: true
       });
@@ -159,7 +159,7 @@ class SettingsPage extends React.Component {
 
     this.onMaintDaySelect = event => {
       this.setState({
-        isOpen: !this.state.isMaintDayOpen,
+        isMaintDayOpen: !this.state.isMaintDayOpen,
         maintDayDisplay: event.target.innerText,
         canSave: true
       });
@@ -167,7 +167,7 @@ class SettingsPage extends React.Component {
 
     this.onMaintTimeSelect = event => {
       this.setState({
-        isOpen: !this.state.isMaintTimeOpen,
+        isMaintTimeOpen: !this.state.isMaintTimeOpen,
         maintTimeDisplay: event.target.innerText,
         canSave: true
       });
@@ -738,7 +738,7 @@ class SettingsPage extends React.Component {
     }
 
     // local testing purposes only - uncomment to test config tab (simulate OS4)
-    // isOSv4 = true;
+    isOSv4 = true;
 
     // show settings alert on first render
     if (window.localStorage.getItem('showSettingsAlert') === null)


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-379

## What
Design preferred long day names over abbreviations in the front end UI, despite the day names being in the short form on the back end and config files.
 
## Why
Better usability.

## Verification Steps
These steps can be performed on my cluster:
https://solution-explorer.apps.cluster-uxddev-9f0b.uxddev-9f0b.example.opentlc.com/

Or on your own cluster using the following docker image:
docker.io/mfrances17/tutorial-web-app:APPDUX-379

1. Go to Settings > Managed Integration schedule.
2. Verify that the days of the week dropdown displays days in the long form (Monday) vs short form (Mon).
3. Choose a new day and click Save.
3. Verify that the rhmi-config file is saved in the short from required by the backend. To do this, on OpenShift:
     a) Select redhat-rhmi-operator project.
     b) Click Home > Search.
     c) Click Resources > RHMIConfig.
     d) Click rhmi-config.
     e) Select the YAML tab. 

## Checklist:
- [x] Code has been tested locally by PR requester

## Progress
- [x] Finished task

## Additional Notes
**Screen cap of UI showing longer days of the week:**
![saturday_ui](https://user-images.githubusercontent.com/39063664/89211885-7ef1bc80-d590-11ea-9356-55dae66473fc.png)

**Screen cap of rhmi-config file after save:**
![saturday_rhmicfg](https://user-images.githubusercontent.com/39063664/89211902-87e28e00-d590-11ea-9ea2-9ad6fef2c791.png)

