### PR TITLE
APPDUX-380: Prevent duplicate backup and maintenance schedule times

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integreatly-web-app",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "private": true,
   "proxy": "http://localhost:5001/",
   "dependencies": {

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -310,33 +310,39 @@ class SettingsPage extends React.Component {
     buTime = this.convertTimeTo24Hr(buTime);
     maintTime = this.convertTimeTo24Hr(maintTime);
 
-    this.setState({ canSave: false });
+    if (buTime === maintTime) {
+      window.localStorage.setItem('showSettingsConflictAlert', 'true');
+      this.setState({ showSettingsConflictAlert: true });
+      this.setState({ canSave: false });
+    } else {
+      this.setState({ canSave: false });
 
-    this.setState(
-      {
-        config: {
-          ...this.state.config,
-          spec: {
-            ...this.state.config.spec,
-            backup: {
-              ...this.state.config.spec.backup,
-              applyOn: buTime
-            },
-            maintenance: {
-              ...this.state.config.spec.maintenance,
-              applyFrom: `${maintDay} ${maintTime}`
-            },
-            upgrade: {
-              ...this.state.config.spec.upgrade,
-              contacts: emailContacts,
-              waitForMaintenance: maintWait,
-              notBeforeDays: maintWaitDays
+      this.setState(
+        {
+          config: {
+            ...this.state.config,
+            spec: {
+              ...this.state.config.spec,
+              backup: {
+                ...this.state.config.spec.backup,
+                applyOn: buTime
+              },
+              maintenance: {
+                ...this.state.config.spec.maintenance,
+                applyFrom: `${maintDay} ${maintTime}`
+              },
+              upgrade: {
+                ...this.state.config.spec.upgrade,
+                contacts: emailContacts,
+                waitForMaintenance: maintWait,
+                notBeforeDays: maintWaitDays
+              }
             }
           }
-        }
-      },
-      () => updateRhmiConfig(this.state.config).then(() => history.push('/'))
-    );
+        },
+        () => updateRhmiConfig(this.state.config).then(() => history.push('/'))
+      );
+    }
   };
 
   handleTextInputChange = value => {
@@ -750,7 +756,7 @@ class SettingsPage extends React.Component {
     }
 
     // local testing purposes only - uncomment to test config tab (simulate OS4)
-    isOSv4 = true;
+    // isOSv4 = true;
 
     // show settings alert on first render
     if (window.localStorage.getItem('showSettingsAlert') === null)

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -80,6 +80,7 @@ class SettingsPage extends React.Component {
       maintDropdownItems: [],
       maintDayDropdownItems: [],
       showSettingsAlert: true,
+      showSettingsConflictAlert: false,
       config: {
         apiVersion: 'integreatly.org/v1alpha1',
         kind: 'RHMIConfig',
@@ -155,6 +156,11 @@ class SettingsPage extends React.Component {
     this.onAlertClose = () => {
       window.localStorage.setItem('showSettingsAlert', 'false');
       this.setState({ showSettingsAlert: false });
+    };
+
+    this.onConflictAlertClose = () => {
+      window.localStorage.setItem('showSettingsConflictAlert', 'false');
+      this.setState({ showSettingsConflictAlert: false });
     };
 
     this.onMaintDaySelect = event => {
@@ -264,31 +270,43 @@ class SettingsPage extends React.Component {
     buTime = this.convertTimeTo24Hr(buTime);
     maintTime = this.convertTimeTo24Hr(maintTime);
 
-    this.setState({ canSave: false });
+    if (buTime === maintTime) {
+      console.log('Backup time cannot be the same as maintenance time.');
+      window.localStorage.setItem('showSettingsConflictAlert', 'false');
+      this.setState({ showSettingsAlert: false });
 
-    this.setState({
-      config: {
-        ...this.state.config,
-        spec: {
-          ...this.state.config.spec,
-          backup: {
-            ...this.state.config.spec.backup,
-            applyOn: buTime
-          },
-          maintenance: {
-            ...this.state.config.spec.maintenance,
-            applyFrom: `${maintDay} ${maintTime}`
-          },
-          upgrade: {
-            ...this.state.config.spec.upgrade,
-            contacts: emailContacts,
-            waitForMaintenance: maintWait,
-            notBeforeDays: maintWaitDays
+
+
+
+
+      this.setState({ canSave: false });
+    } else {
+      this.setState({ canSave: false });
+
+      this.setState({
+        config: {
+          ...this.state.config,
+          spec: {
+            ...this.state.config.spec,
+            backup: {
+              ...this.state.config.spec.backup,
+              applyOn: buTime
+            },
+            maintenance: {
+              ...this.state.config.spec.maintenance,
+              applyFrom: `${maintDay} ${maintTime}`
+            },
+            upgrade: {
+              ...this.state.config.spec.upgrade,
+              contacts: emailContacts,
+              waitForMaintenance: maintWait,
+              notBeforeDays: maintWaitDays
+            }
           }
         }
-      }
-    });
-    history.push(`/`);
+      });
+      history.push(`/`);
+    }
   };
 
   saveConfigSettings = (e, buTime, maintDay, maintTime, emailContacts, maintWait, maintWaitDays) => {
@@ -724,7 +742,7 @@ class SettingsPage extends React.Component {
   };
 
   render() {
-    const { value, isValid, isEmailValid, showSettingsAlert } = this.state;
+    const { value, isValid, isEmailValid, showSettingsAlert, showSettingsConflictAlert } = this.state;
     this.contentRef1 = React.createRef();
     this.contentRef2 = React.createRef();
 
@@ -738,13 +756,14 @@ class SettingsPage extends React.Component {
     }
 
     // local testing purposes only - uncomment to test config tab (simulate OS4)
-    // isOSv4 = true;
+    isOSv4 = true;
 
     // show settings alert on first render
     if (window.localStorage.getItem('showSettingsAlert') === null)
       window.localStorage.setItem('showSettingsAlert', true);
 
     const isAlertOpen = window.localStorage.getItem('showSettingsAlert') === 'true';
+    // const isConflictAlertOpen = window.localStorage.getItem('showSettingsConflictAlert') === 'true';
 
     return (
       <Page className="pf-u-h-100vh">
@@ -805,6 +824,20 @@ class SettingsPage extends React.Component {
                           </p>
                         </Alert>
                       )}
+                    {showSettingsConflictAlert && (
+                      <Alert
+                        className="settings-alert"
+                        variant="danger"
+                        isInline
+                        title="Backups and maintenance window conflict"
+                        actionClose={<AlertActionCloseButton onClose={this.onConflictAlertClose} />}
+                      >
+                        <p>
+                          Backups cannot be scheduled during the first hour of a weekly maintenance window. Review your
+                          backup and maintenance window schedules, then choose a new start time for the event.
+                        </p>
+                      </Alert>
+                    )}
                     <CardTitle>
                       <h2 className="pf-c-title pf-m-lg">Daily Backups</h2>
                     </CardTitle>

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -271,14 +271,8 @@ class SettingsPage extends React.Component {
     maintTime = this.convertTimeTo24Hr(maintTime);
 
     if (buTime === maintTime) {
-      console.log('Backup time cannot be the same as maintenance time.');
-      window.localStorage.setItem('showSettingsConflictAlert', 'false');
-      this.setState({ showSettingsAlert: false });
-
-
-
-
-
+      window.localStorage.setItem('showSettingsConflictAlert', 'true');
+      this.setState({ showSettingsConflictAlert: true });
       this.setState({ canSave: false });
     } else {
       this.setState({ canSave: false });
@@ -763,7 +757,6 @@ class SettingsPage extends React.Component {
       window.localStorage.setItem('showSettingsAlert', true);
 
     const isAlertOpen = window.localStorage.getItem('showSettingsAlert') === 'true';
-    // const isConflictAlertOpen = window.localStorage.getItem('showSettingsConflictAlert') === 'true';
 
     return (
       <Page className="pf-u-h-100vh">

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -266,6 +266,7 @@ class SettingsPage extends React.Component {
   saveMockConfigSettings = (e, buTime, maintDay, maintTime, emailContacts, maintWait, maintWaitDays) => {
     e.preventDefault();
     const { history } = this.props;
+    const alertId = document.getElementById('refTab1Section');
 
     buTime = this.convertTimeTo24Hr(buTime);
     maintTime = this.convertTimeTo24Hr(maintTime);
@@ -274,6 +275,7 @@ class SettingsPage extends React.Component {
       window.localStorage.setItem('showSettingsConflictAlert', 'true');
       this.setState({ showSettingsConflictAlert: true });
       this.setState({ canSave: false });
+      alertId.scrollIntoView();
     } else {
       this.setState({ canSave: false });
 
@@ -306,6 +308,7 @@ class SettingsPage extends React.Component {
   saveConfigSettings = (e, buTime, maintDay, maintTime, emailContacts, maintWait, maintWaitDays) => {
     e.preventDefault();
     const { history } = this.props;
+    const alertId = document.getElementById('refTab1Section');
 
     buTime = this.convertTimeTo24Hr(buTime);
     maintTime = this.convertTimeTo24Hr(maintTime);
@@ -314,6 +317,7 @@ class SettingsPage extends React.Component {
       window.localStorage.setItem('showSettingsConflictAlert', 'true');
       this.setState({ showSettingsConflictAlert: true });
       this.setState({ canSave: false });
+      alertId.scrollIntoView();
     } else {
       this.setState({ canSave: false });
 


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-380

## What
The backup and maintenance window times should not be the same time as they would conflict with each other. In the current UI, this is prevented if you try to select the time that is already set. However, if you change both the backup time and the maintenance window time, the UI will allow you to save new duplicate times. This fix checks for that and if they both new values are the same, prevents the save, disables the Save button, and pops up a notification message.

## Why
To be more consistent with the design, and to prevent users from saving duplicate backup and maintenance window times.

## Verification Steps
1. Go to Settings > Managed Integration schedule tab.
2. Select a time in the Start time for your backups dropdown.
3. Select the same time in the Day and start time for your maintenance dropdown.
4. Verify that you stay on the same page (don't navigate back to Home), the Save button is disabled, and a notification displays and explains that you cannot set the same time for both.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress
- [x] Finished task

## Additional Notes
You may use my cluster to verify:
https://solution-explorer.apps.cluster-uxddev-9f0b.uxddev-9f0b.example.opentlc.com/

Or add the following docker image of the solution explorer to your own cluster:
docker.io/mfrances17/tutorial-web-app:appdux-380

Screen cap:
![conflict](https://user-images.githubusercontent.com/39063664/89568285-15bcb400-d7f1-11ea-8b2e-681cc5399be9.png)

