### PR TITLE
INTLY-9766 Enable HSTS header

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express": "4.16.3",
     "express-http-proxy": "^1.5.1",
     "express-prometheus-middleware": "^0.6.1",
+    "helmet": "^4.2.0",
     "i": "0.3.6",
     "i18next": "11.6.0",
     "i18next-xhr-backend": "1.5.1",

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const querystring = require('querystring');
 const flattenDeep = require('lodash.flattendeep');
 const proxy = require('express-http-proxy');
 const { sync, closeConnection, getUserWalkthroughs, setUserWalkthroughs, validUrl } = require('./model');
+const helmet = require('helmet');
 
 const OPENSHIFT_PROXY_PATH = '/proxy/openshift';
 
@@ -55,6 +56,8 @@ const LOCAL_DEV_INSTALLED_SERVICES = {
 const CROSS_CONSOLE_ENABLED = false;
 
 app.use(bodyParser.json());
+app.use(helmet());
+
 app.use(
   OPENSHIFT_PROXY_PATH,
   proxy(`https://${process.env.OPENSHIFT_API}`, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6083,6 +6083,11 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+helmet@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-4.2.0.tgz#e81f5613cc1c90402af581794dc9878ad078b237"
+  integrity sha512-aoiSxXMd0ks1ojYpSCFoCRzgv4rY/uB9jKStaw8PkXwsdLYa/Gq+Nc5l0soH0cwBIsLAlujPnx4HLQs+LaXCrQ==
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"


### PR DESCRIPTION
## Motivation
Pen testing requires HSTS header to be set.

## What
Added helmet which enables hsts header
## Why
Security risk without HSTS header
## How
Added Helmet to set HSTS header 

## Verification Steps
Deploy operator from https://quay.io/repository/cathaloconnor/tutorial-web-app-operator?tab=tags and confirm solution explorer has HSTS strict header set. 

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
